### PR TITLE
luci-app-banip: improve translation

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -574,7 +574,7 @@ return view.extend({
 		o.rmempty = true;
 
 		o = s.taboption('adv_log', form.ListValue, 'ban_loglimit', _('Log Limit'), _('Parse only the last stated number of log entries for suspicious events. To disable the log monitor at all set it to \'0\'.'));
-		o.value('0', _('0 (disable)'));
+		o.value('0', _('Disable'));
 		o.value('50', '50');
 		o.value('100', '100');
 		o.value('250', '250');

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -319,11 +319,12 @@ return view.extend({
 		o.rmempty = true;
 
 		o = s.taboption('general', form.ListValue, 'ban_fetchretry', _('Download Retries'), _('Number of download attempts in case of an error (not supported by uclient-fetch).'));
-		o.value('1', _('1'));
-		o.value('3', _('3'));
-		o.value('5', _('5 (default)'));
-		o.value('10', _('10'));
-		o.value('20', _('20'));
+		o.value('1', '1');
+		o.value('3', '3');
+		o.value('5', '5');
+		o.value('10', '10');
+		o.value('20', '20');
+		o.default = '5';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -340,17 +341,19 @@ return view.extend({
 		o = s.taboption('advanced', form.ListValue, 'ban_nicelimit', _('Nice Level'), _('The selected priority will be used for banIP background processing.'));
 		o.value('-20', _('Highest Priority'));
 		o.value('-10', _('High Priority'));
-		o.value('0', _('Normal Priority (default)'));
+		o.value('0', _('Normal Priority'));
 		o.value('10', _('Less Priority'));
 		o.value('19', _('Least Priority'));
+		o.default = '0';
 		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('advanced', form.ListValue, 'ban_filelimit', _('Max Open Files'), _('Increase the maximal number of open files, e.g. to handle the amount of temporary split files while loading the Sets.'));
-		o.value('512', _('512'));
-		o.value('1024', _('1024 (default)'));
-		o.value('2048', _('2048'));
-		o.value('4096', _('4096'));
+		o.value('512', '512');
+		o.value('1024', '1024');
+		o.value('2048', '2048');
+		o.value('4096', '4096');
+		o.default = '1024';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -401,10 +404,11 @@ return view.extend({
 		o.default = '<em style="color:#37c;font-weight:bold;">' + _('Changes on this tab needs a banIP service restart to take effect.') + '</em>';
 
 		o = s.taboption('adv_chain', form.ListValue, 'ban_nftpriority', _('Chain Priority'), _('Set the nft chain priority within the banIP table, lower values means higher priority.'));
-		o.value('0', _('0'));
-		o.value('-100', _('-100 (default)'));
-		o.value('-150', _('-150'));
-		o.value('-200', _('-200'));
+		o.value('0', '0');
+		o.value('-100', '-100');
+		o.value('-150', '-150');
+		o.value('-200', '-200');
+		o.default = '100';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -425,32 +429,35 @@ return view.extend({
 		o.rmempty = true;
 
 		o = s.taboption('adv_chain', form.ListValue, 'ban_icmplimit', _('ICMP-Treshold'), _('ICMP-Treshold in packets per second to prevent WAN-DDoS attacks.'));
-		o.value('1', _('1'));
-		o.value('10', _('10 (default)'));
-		o.value('50', _('50'));
-		o.value('100', _('100'));
-		o.value('250', _('250'));
-		o.value('500', _('500'));
+		o.value('1', '1');
+		o.value('10', '10');
+		o.value('50', '50');
+		o.value('100', '100');
+		o.value('250', '250');
+		o.value('500', '500');
+		o.default = '10';
 		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('adv_chain', form.ListValue, 'ban_synlimit', _('SYN-Treshold'), _('SYN-Treshold in packets per second to prevent WAN-DDoS attacks.'));
-		o.value('1', _('1'));
-		o.value('10', _('10 (default)'));
-		o.value('50', _('50'));
-		o.value('100', _('100'));
-		o.value('250', _('250'));
-		o.value('500', _('500'));
+		o.value('1', '1');
+		o.value('10', '10');
+		o.value('50', '50');
+		o.value('100', '100');
+		o.value('250', '250');
+		o.value('500', '500');
+		o.default = '10';
 		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('adv_chain', form.ListValue, 'ban_udplimit', _('UDP-Treshold'), _('UDP-Treshold in packets per second to prevent WAN-DDoS attacks.'));
-		o.value('1', _('1'));
-		o.value('10', _('10'));
-		o.value('50', _('50'));
-		o.value('100', _('100 (default)'));
-		o.value('250', _('250'));
-		o.value('500', _('500'));
+		o.value('1', '1');
+		o.value('10', '10');
+		o.value('50', '50');
+		o.value('100', '100');
+		o.value('250', '250');
+		o.value('500', '500');
+		o.default = '100';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -462,14 +469,16 @@ return view.extend({
 		o.default = '<em style="color:#37c;font-weight:bold;">' + _('Changes on this tab needs a banIP service restart to take effect.') + '</em>';
 
 		o = s.taboption('adv_set', form.ListValue, 'ban_nftpolicy', _('Set Policy'), _('Set the nft policy for banIP-related Sets.'));
-		o.value('memory', _('memory (default)'));
+		o.value('memory', _('memory'));
 		o.value('performance', _('performance'));
+		o.default = 'memory';
 		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('adv_set', form.ListValue, 'ban_blocktype', _('Block Type'), _('Drop packets silently or actively reject the traffic on WAN-Input and WAN-Forward chains.'));
-		o.value('drop', _('drop (default)'));
+		o.value('drop', _('drop'));
 		o.value('reject', _('reject'));
+		o.default = 'drop';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -540,10 +549,11 @@ return view.extend({
 		o.value('alert', _('alert'));
 		o.value('crit', _('crit'));
 		o.value('err', _('err'));
-		o.value('warn', _('warn (default)'));
+		o.value('warn', _('warn'));
 		o.value('notice', _('notice'));
 		o.value('info', _('info'));
 		o.value('debug', _('debug'));
+		o.default = 'warn';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -565,11 +575,12 @@ return view.extend({
 
 		o = s.taboption('adv_log', form.ListValue, 'ban_loglimit', _('Log Limit'), _('Parse only the last stated number of log entries for suspicious events. To disable the log monitor at all set it to \'0\'.'));
 		o.value('0', _('0 (disable)'));
-		o.value('50', _('50'));
-		o.value('100', _('100 (default)'));
-		o.value('250', _('250'));
-		o.value('500', _('500'));
-		o.value('1000', _('1000'));
+		o.value('50', '50');
+		o.value('100', '100');
+		o.value('250', '250');
+		o.value('500', '500');
+		o.value('1000', '1000');
+		o.default = '100';
 		o.optional = true;
 		o.rmempty = true;
 
@@ -722,8 +733,9 @@ return view.extend({
 		o = s.taboption('feeds', form.ListValue, 'ban_autoallowuplink', _('Auto Allow Uplink'), _('Limit the uplink autoallow function.'));
 		o.depends('ban_autoallowlist', '1');
 		o.value('disable', _('Disable'));
-		o.value('subnet', _('Subnet (default)'));
+		o.value('subnet', _('Subnet'));
 		o.value('ip', _('IP'));
+		o.default = 'subnet';
 		o.optional = true;
 		o.rmempty = true;
 

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -662,7 +662,7 @@ return view.extend({
 		if (result[2]) {
 			countries = result[2].trim().split('\n');
 
-			o = s.taboption('feeds', form.MultiValue, 'ban_country', _('Countries (RIR)'));
+			o = s.taboption('feeds', form.MultiValue, 'ban_country', _('Countries') + ' (<abbr title="Regional Internet Registries">RIR</abbr>)');
 			for (let i = 0; i < countries.length; i++) {
 				try {
 					ccode = countries[i].match(/^(\w+)\t/)[1].trim();

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -428,7 +428,7 @@ return view.extend({
 		o.optional = true;
 		o.rmempty = true;
 
-		o = s.taboption('adv_chain', form.ListValue, 'ban_icmplimit', _('ICMP-Treshold'), _('ICMP-Treshold in packets per second to prevent WAN-DDoS attacks.'));
+		o = s.taboption('adv_chain', form.ListValue, 'ban_icmplimit', _('ICMP-Threshold'), _('ICMP-Threshold in packets per second to prevent WAN-DDoS attacks.'));
 		o.value('1', '1');
 		o.value('10', '10');
 		o.value('50', '50');
@@ -439,7 +439,7 @@ return view.extend({
 		o.optional = true;
 		o.rmempty = true;
 
-		o = s.taboption('adv_chain', form.ListValue, 'ban_synlimit', _('SYN-Treshold'), _('SYN-Treshold in packets per second to prevent WAN-DDoS attacks.'));
+		o = s.taboption('adv_chain', form.ListValue, 'ban_synlimit', _('SYN-Threshold'), _('SYN-Threshold in packets per second to prevent WAN-DDoS attacks.'));
 		o.value('1', '1');
 		o.value('10', '10');
 		o.value('50', '50');
@@ -450,7 +450,7 @@ return view.extend({
 		o.optional = true;
 		o.rmempty = true;
 
-		o = s.taboption('adv_chain', form.ListValue, 'ban_udplimit', _('UDP-Treshold'), _('UDP-Treshold in packets per second to prevent WAN-DDoS attacks.'));
+		o = s.taboption('adv_chain', form.ListValue, 'ban_udplimit', _('UDP-Threshold'), _('UDP-Threshold in packets per second to prevent WAN-DDoS attacks.'));
 		o.value('1', '1');
 		o.value('10', '10');
 		o.value('50', '50');

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -93,7 +93,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "إعادة تشغيل"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -238,6 +234,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -15,155 +15,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -173,83 +77,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "مجلد النسخ الاحتياطي"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -259,13 +167,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -274,14 +182,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -289,7 +197,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -298,7 +206,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -306,17 +214,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -324,21 +232,21 @@ msgstr ""
 msgid "Description"
 msgstr "الوصف"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -346,49 +254,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "تنزيل المعلمات"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "تحميل الأداة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "إعلام البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "ملف تعريف البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "عنوان مستقبل البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "عنوان مرسل البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "موضوع البريد الإلكتروني"
 
@@ -404,7 +312,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -414,47 +322,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "مفعل"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -462,11 +370,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -486,7 +394,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "الاعدادات العامة"
 
@@ -494,23 +402,23 @@ msgstr "الاعدادات العامة"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -522,34 +430,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "معلومة"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -557,7 +465,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -565,50 +473,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "آخر تشغيل"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -616,85 +524,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -707,22 +615,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -732,7 +640,7 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -746,25 +654,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -774,35 +682,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "نعش الذاكرة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "دليل التقارير"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "إعادة تشغيل"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -819,19 +723,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "تشغيل الإشارات"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -847,23 +751,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -872,7 +776,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -880,7 +784,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -896,57 +800,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "إعدادات"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -958,13 +862,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -999,29 +903,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "تأخير الزناد"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1033,11 +937,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1064,11 +972,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "تسجيل مطول للتصحيح"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1076,8 +984,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1085,8 +993,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1100,7 +1008,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1136,60 +1044,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Startup Trigger Interface"

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -408,11 +408,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -729,11 +729,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -919,11 +919,11 @@ msgid "Trigger Delay"
 msgstr "تأخير الزناد"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -203,7 +203,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN-и"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Активни устройства"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Активни потоци"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Разширени настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Автоматичен блоклист"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Автоматично засичане"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Директоря за резервни копия"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмени"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Не проверявай SSL сертификати по време на сваляне."
 
@@ -345,49 +253,49 @@ msgstr "Не проверявай SSL сертификати по време н�
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Сваляй несигурно"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Параметри за теглене"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-Mail Известяване"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Mail Профил"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Изпращач"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-Mail Тема"
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Включи banIP сервиз."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Разрешен"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Общи настройки"
 
@@ -493,23 +401,23 @@ msgstr "Общи настройки"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 поддръжка"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Информация"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Състояние"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Спиране"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Версия"
 
@@ -1075,8 +983,8 @@ msgstr "Версия"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Countries"

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -202,8 +202,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Държави"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1095,9 +1095,6 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
 msgid "warn"
 msgstr ""
-
-#~ msgid "Countries"
-#~ msgstr "Държави"
 
 #~ msgid "Active Subnets"
 #~ msgstr "Активни събнети"

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "চালু ডিভাইসগুলো"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "বাতিল করুন"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "সক্রিয়"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "সাধারণ সেটিংস"
 
@@ -493,23 +401,23 @@ msgstr "সাধারণ সেটিংস"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "সেটিংস"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Active Subnets"

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Reiniciar"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel•lar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Descripció"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Paràmetres de descàrrega"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notificació de correu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Adreça del destinatari de correu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Paràmetres generals"
 
@@ -493,23 +401,23 @@ msgstr "Paràmetres generals"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informació"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Darrera execució"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Actualitza"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Torna a carregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Paràmetres"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Pokročilá nastavení"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Zakázat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -493,23 +401,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Podpora IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informace"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Poslední spuštění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Aktualizovat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Znovu načíst"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Restart"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Nastavení"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Stav"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Verze"
 
@@ -1075,8 +983,8 @@ msgstr "Verze"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "-m limit --limit 2/sec (default)"

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Restart"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Zakázat"

--- a/applications/luci-app-banip/po/da/banip.po
+++ b/applications/luci-app-banip/po/da/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr "Højeste prioritet"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr "Kør oplysninger"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr "Udløserforsinkelse"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/da/banip.po
+++ b/applications/luci-app-banip/po/da/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Genstart"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/da/banip.po
+++ b/applications/luci-app-banip/po/da/banip.po
@@ -202,8 +202,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Lande"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1095,9 +1095,6 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
 msgid "warn"
 msgstr ""
-
-#~ msgid "Countries"
-#~ msgstr "Lande"
 
 #~ msgid "Network Interfaces"
 #~ msgstr "Netværks Interfaces"

--- a/applications/luci-app-banip/po/da/banip.po
+++ b/applications/luci-app-banip/po/da/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/da/banip.po
+++ b/applications/luci-app-banip/po/da/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN'er"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktive enheder"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Avancerede indstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automatisk detektering"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Backup Mappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuller"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Kontroller ikke SSL-servercertifikater under download."
 
@@ -345,49 +253,49 @@ msgstr "Kontroller ikke SSL-servercertifikater under download."
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Download usikker"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Download parametre"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Download hjælpeprogram"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Meddelelse pr. e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-mail profil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Modtagerens e-mailadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-mail afsenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-mail emne"
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Aktiver banIP-tjenesten."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Generelle indstillinger"
 
@@ -493,23 +401,23 @@ msgstr "Generelle indstillinger"
 msgid "Grant access to LuCI app banIP"
 msgstr "Giv adgang til LuCI-app banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Høj prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Højeste prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4-understøttelse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6-understøttelse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Information"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Sidste kørsel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Mindste prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Mindre prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Loggrænse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Log Vilkår"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Normal prioritet (standard)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversigt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "Profil, der anvendes af \"msmtp\" til banIP-meddelelses-e-mails."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Opdater"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Genstart"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Kør flag"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Kør oplysninger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Afsenderadresse for banIP-meddelelses-e-mails."
 
@@ -871,7 +775,7 @@ msgstr "Afsenderadresse for banIP-meddelelses-e-mails."
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Indstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Status"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Tidsstempel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Emne for banIP-meddelelses-e-mails."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Udløserforsinkelse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Verbose Debug Logning"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Version"
 
@@ -1075,8 +983,8 @@ msgstr "Version"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Countries"

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -206,8 +206,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Länder"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1125,9 +1125,6 @@ msgstr "warn"
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "Ketten-/Set-Einstellungen"
-
-#~ msgid "Countries"
-#~ msgstr "Länder"
 
 #~ msgid "Log suspicious forwarded LAN packets (rejected)."
 #~ msgstr "Verdächtige weitergeleitete LAN-Pakete protokollieren (abgelehnt)."

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -96,7 +96,7 @@ msgstr "Immer bestimmte VLAN-Forwards blockieren."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Neustart"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Auswahl einstellen --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (deaktiviert)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -243,6 +239,7 @@ msgstr ""
 "Automatische Erkennung relevanter Netzwerkgeräte, Schnittstellen, Subnetze, "
 "Protokolle und Dienstprogramme."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Deaktivieren"

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -414,11 +414,11 @@ msgid "Highest Priority"
 msgstr "Höchste Priorität"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -744,11 +744,11 @@ msgid "Run Information"
 msgstr "Informationen zur Ausführung"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -945,11 +945,11 @@ msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -14,157 +14,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Auswahl einstellen --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (deaktiviert)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (Standard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (Standard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (Standard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "Autonome Systemnummern"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktive Geräte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Aktive Feeds"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Aktiver Uplink"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Zusätzliche Auslöseverzögerung in Sekunden während des Interface-Neustarts "
 "und Bootens."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "VLAN Forwards erlauben"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Nur Zulassungsliste"
 
@@ -176,83 +80,87 @@ msgstr ""
 "Änderungen an der Zulassungsliste wurden gespeichert, starten Sie den Domain "
 "Lookup oder starten Sie banIP neu, damit die Änderungen wirksam werden."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Immer bestimmte VLAN-Forwards erlauben."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Immer bestimmte VLAN-Forwards blockieren."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Automatische Zulassungsliste"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Automatische Sperrliste"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automatische Erkennung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Basisverzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Basisarbeitsverzeichnis während der BanIP-Verarbeitung."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -262,13 +170,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "CPU-Kerne"
 
@@ -277,14 +185,14 @@ msgstr "CPU-Kerne"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Kettenpriorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -292,7 +200,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -301,7 +209,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -309,17 +217,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "IPs deduplizieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -327,7 +235,7 @@ msgstr ""
 msgid "Description"
 msgstr "Beschreibung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -335,15 +243,15 @@ msgstr ""
 "Automatische Erkennung relevanter Netzwerkgeräte, Schnittstellen, Subnetze, "
 "Protokolle und Dienstprogramme."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Deaktivieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Während des Downloads keine SSL-Serverzertifikate überprüfen."
 
@@ -351,49 +259,49 @@ msgstr "Während des Downloads keine SSL-Serverzertifikate überprüfen."
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Unsicher herunterladen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Download Parameter"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "E-Mail-Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
@@ -409,7 +317,7 @@ msgstr "Sperrliste bearbeiten"
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Anzahl der Elemente"
 
@@ -419,48 +327,48 @@ msgstr "Elemente"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 #, fuzzy
 msgid "Empty field not allowed"
 msgstr "Das Feld darf nicht leer sein"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Remote-Logging Aktivieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Aktiviere den banIP-Service."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "Aktivieren ausführlicher Debug-Logs im Fehlerfall."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Aktiviert die IPv4-Unterstützung."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Aktiviert die IPv6-Unterstützung."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -468,11 +376,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Feed-Auswahl"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -492,7 +400,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -500,23 +408,23 @@ msgstr "Allgemeine Einstellungen"
 msgid "Grant access to LuCI app banIP"
 msgstr "Zugriff auf LuCI-App banIP gewähren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Hohe Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Höchste Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -528,34 +436,34 @@ msgstr "IP-Suche"
 msgid "IP Search..."
 msgstr "IP-Suche..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 Unterstützung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 Unterstützung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informationen"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Ungültige Zeichen"
 
@@ -563,7 +471,7 @@ msgstr "Ungültige Zeichen"
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -571,44 +479,44 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (Pakete)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "LAN-Forward-Kette"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Letzter Durchgang"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Niedrigste Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Niedrige Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Beschränken bestimmter Feeds auf die LAN-Forward-Kette."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Beschränken bestimmter Feeds auf die WAN-Forward-Kette."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Beschränken bestimmter Feeds auf die WAN-Eingang-Kette."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "Begrenzen von banIP verwendeter Rechenkerne, um RAM zu sparen."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -616,7 +524,7 @@ msgstr ""
 "Set-Elemente im Status und Bericht auflisten. Deaktivieren, um die CPU-Last "
 "zu reduzieren."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -624,85 +532,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Auflistung der Elemente eines bestimmten banIP-bezogenen Sets."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Anzahl der Protokolle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "LAN-Weiterleitung protokollieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Protokollbegrenzung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Protokolleinstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Protokollbedingungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "WAN-Weiterleitung protokollieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "WAN-Eingang protokollieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Max. geöffnete Dateien"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "NFT-Informationen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Netzwerkadapter"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Nice-Level"
 
@@ -715,24 +623,24 @@ msgstr "Keine Suchergebnisse!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Noch keine banIP-bezogenen Firewall-Protokolle!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Normale Priorität (Voreinstellung)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Anzahl der fehlgeschlagenen Anmeldeversuche von der gleichen IP im Protokoll "
 "vor der Sperrung."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -744,7 +652,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -758,25 +666,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr "Verarbeitungsprotokoll"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "Von 'msmtp' verwendetes Profil für banIP-Benachrichtigungs-E-Mails."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -788,35 +696,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Neu laden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Report-Verzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Berichtselemente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Neustart"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Beschränken des Internetzugangs von/zu einer kleinen Anzahl von sicheren IPs."
@@ -834,19 +738,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Laufzeit-Flags"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informationen zur Ausführung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -862,23 +766,23 @@ msgstr "Suche"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Suche in den banIP-bezogenen Sets nach einer bestimmten IP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Wählen Sie eines der vorkonfigurierten Download-Dienstprogramme."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Wählen Sie das/die WAN-Netzwerkgerät(e)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Wählen Sie die logische(n) WAN-IPv4-Netzwerkschnittstelle(n) aus."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Wählen Sie die logische(n) WAN-IPv6-Netzwerkschnittstelle(n) aus."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Absenderadresse für banIP-Benachrichtigungs-E-Mails."
 
@@ -887,7 +791,7 @@ msgstr "Absenderadresse für banIP-Benachrichtigungs-E-Mails."
 msgid "Set"
 msgstr "Set"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 #, fuzzy
 msgid "Set Policy"
 msgstr "Set-Richtlinie"
@@ -896,7 +800,7 @@ msgstr "Set-Richtlinie"
 msgid "Set Reporting"
 msgstr "Set-Berichte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 #, fuzzy
 msgid "Set Split Size"
 msgstr "Teilungsgröße festlegen"
@@ -915,57 +819,57 @@ msgstr "Umfrage einstellen..."
 msgid "Set details"
 msgstr "Details zum Set"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Legen Sie den Syslog-Level für die NFT-Protokollierung fest."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Status"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Stopp"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Subnetz (Standard)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Subnetz"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Umfrage"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Systeminformationen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Zielverzeichnis für banIP-bezogene Berichtsdateien."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Zielverzeichnis für komprimierte Feed-Sicherungen."
 
@@ -979,13 +883,13 @@ msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 "Die Sperrliste ist zu groß, Änderungen können nicht gespeichert werden."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "Die gewählte Priorität wird für die BanIP-Hintergrundverarbeitung verwendet."
@@ -1025,29 +929,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Zeitstempel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Betreff für banIP-Benachrichtigungs-E-Mails."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1059,11 +963,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1090,11 +998,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Version"
 
@@ -1102,8 +1010,8 @@ msgstr "Version"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (Pakete)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "WAN-Forward-Kette"
 
@@ -1111,8 +1019,8 @@ msgstr "WAN-Forward-Kette"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Input (Pakete)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "WAN-Input-Kette"
 
@@ -1126,7 +1034,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "Alarm"
 
@@ -1162,73 +1070,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "crit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "debug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "emerg"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "err"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "Speicher (Standard)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "Speicher"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "notice"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "Leistung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "warn (Standard)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (Standard)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "warn"
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "Ketten-/Set-Einstellungen"

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -493,23 +401,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "General Settings"
 
@@ -493,23 +401,23 @@ msgstr "General Settings"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Overview"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Version"
 
@@ -1075,8 +983,8 @@ msgstr "Version"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,58 +1043,58 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -432,11 +432,11 @@ msgid "Highest Priority"
 msgstr "Prioridad más alta"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -757,11 +757,11 @@ msgid "Run Information"
 msgstr "Ejecutar información"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -948,11 +948,11 @@ msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -17,157 +17,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Selección de conjuntos --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (desactivar)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (predeterminado)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (predeterminado)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (predeterminado)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASNs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Dispositivos activos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Fuentes activas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Enlace ascendente activo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Retraso de activación adicional en segundos durante la recarga y el inicio "
 "de la interfaz."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Ajustes avanzados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Permitir reenvíos de VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Solo lista de permitidos"
 
@@ -179,41 +83,45 @@ msgstr ""
 "Las modificaciones de la lista de permitidos se han guardado, inicie la "
 "búsqueda de dominios o reinicie banIP para que los cambios surtan efecto."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Permite siempre ciertos reenvíos VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Siempre bloquea ciertos reenvíos VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Permitir Enlace Ascendente automáticamente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Lista de Permitidos automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Subred de Autobloqueo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Lista de Bloqueos automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Detección automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -221,7 +129,7 @@ msgstr ""
 "Automáticamente agrega subredes completas al conjunto de lista de bloqueo "
 "con base en una petición adicional RDAP con la IP sospechosa."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -229,7 +137,7 @@ msgstr ""
 "Agregue automáticamente dominios resueltos e IP sospechosas a la lista de "
 "bloqueo de banIP local."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -237,31 +145,31 @@ msgstr ""
 "Agregue automáticamente dominios resueltos e IP de enlace ascendente a la "
 "lista de permitidos de banIP local."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Directorio base"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Directorio de trabajo base durante el procesamiento de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Tipo de Bloqueo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Bloquear Reenvíos VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Expiración del Conjunto de Lista de bloqueos"
 
@@ -273,13 +181,13 @@ msgstr ""
 "Las modificaciones a la lista de bloqueo han sido guardadas, inicia la "
 "Búsqueda de Dominios o reinicia banIP para que los cambios surtan efecto."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Núcleos de CPU"
 
@@ -288,14 +196,14 @@ msgstr "Núcleos de CPU"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Los cambios en esta pestaña necesitan un reinicio del servicio banIP para "
@@ -305,7 +213,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Limpiar Fuentes Personalizadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -314,7 +222,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -322,17 +230,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Editor de Fuentes Personalizadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -340,7 +248,7 @@ msgstr ""
 msgid "Description"
 msgstr "Descripción"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -348,15 +256,15 @@ msgstr ""
 "Detectar automáticamente dispositivos de red relevantes, interfases, "
 "subredes, protocolos y utilerías."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Deshabilitar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Búsqueda de Dominios"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "No verificar los certificados SSL del servidor durante la descarga."
 
@@ -364,23 +272,23 @@ msgstr "No verificar los certificados SSL del servidor durante la descarga."
 msgid "Download Custom Feeds"
 msgstr "Descargar Fuentes Personalizadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Descarga insegura"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Descargar Reintentos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -388,27 +296,27 @@ msgstr ""
 "Tirar paquetes silenciosamente o rechazar activamente el tráfico en cadenas "
 "de entrada WAN y reenvío WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notificación por correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Ajustes de Correo Electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
@@ -424,7 +332,7 @@ msgstr "Editar Lista de Bloqueos"
 msgid "Edit Custom Feeds"
 msgstr "Editar Fuentes Personalizadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Conteo de Elementos"
 
@@ -434,51 +342,51 @@ msgstr "Elementos"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Campo vacío no permitido"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Habilitar Bitácora Remota"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Activar el servicio banIP.."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "Habilitar la interfaz cgi para recibir eventos de bitácora remota."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "Habilitar registro en bitácora de depuración verbosa en caso de procesar "
 "errores."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Activado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Habilita soporte a IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Habilita soporte a IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Tiempo de expiración para miembros del conjunto de lista de bloqueo auto "
 "añadidos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -486,11 +394,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Nombre de Fuente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Selección de Fuente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -510,7 +418,7 @@ msgstr "Bandera"
 msgid "Flag not supported"
 msgstr "Bandera no soportada"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Ajustes generales"
 
@@ -518,23 +426,23 @@ msgstr "Ajustes generales"
 msgid "Grant access to LuCI app banIP"
 msgstr "Otorgar acceso a la aplicación banIP de LuCI"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Alta prioridad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Prioridad más alta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -546,23 +454,23 @@ msgstr "Búsqueda de IP"
 msgid "IP Search..."
 msgstr "Buscar IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "Interfases de Red IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Soporte IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "Interfases de Red IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Soporte IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -570,12 +478,12 @@ msgstr ""
 "Incrementar el número máximo de ficheros abiertos, ej. para manejar la "
 "cantidad ficheros divididos temporales al cargar los conjuntos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Información"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Caracteres inválidos"
 
@@ -583,7 +491,7 @@ msgstr "Caracteres inválidos"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Valores de entrada inválidos, no se guardaron las modificaciones."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -591,50 +499,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "Reenvío LAN (paquetes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Cadena de Reenvío LAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Último inicio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Prioridad mínima"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Menos prioridad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Limitar ciertas fuentes a la cadena de Reenvío LAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Limitar ciertas fuentes a la cadena de Reenvío WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Limitar ciertas fuentes a la cadena de Entrada WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "Limitar núcleos de CPU usados por banIP para ahorrar memoria RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -642,85 +550,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Límite de registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Términos de registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -733,22 +641,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Prioridad normal (predeterminado)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -758,7 +666,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -772,7 +680,7 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Perfil utilizado por 'msmtp' para correos electrónicos de notificación de "
@@ -780,19 +688,19 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -802,35 +710,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Refrescar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Recargar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Informar directorio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -847,19 +751,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Ejecutar banderas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Ejecutar información"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -875,23 +779,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 "Dirección del remitente para correos electrónicos de notificación de banIP."
@@ -901,7 +805,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -909,7 +813,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -925,57 +829,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Ajustes"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Estado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -987,13 +891,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -1028,29 +932,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Marca de tiempo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Tema para correos electrónicos de notificación de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1062,11 +966,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1093,11 +1001,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versión"
 
@@ -1105,8 +1013,8 @@ msgstr "Versión"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1114,8 +1022,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1129,7 +1037,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1165,73 +1073,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (predeterminado)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Selección de feeds de la lista de permitidos"

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -17,10 +17,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Selección de conjuntos --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (desactivar)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -256,6 +252,7 @@ msgstr ""
 "Detectar automáticamente dispositivos de red relevantes, interfases, "
 "subredes, protocolos y utilerías."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Deshabilitar"

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -99,7 +99,7 @@ msgstr "Siempre bloquea ciertos reenvíos VLAN."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Reiniciar"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -219,8 +219,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Países"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1134,9 +1134,6 @@ msgstr ""
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "Ajustes de Cadena/Conjunto"
-
-#~ msgid "Countries"
-#~ msgstr "Países"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Fuentes externas de lista de permitidos"

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -202,8 +202,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Maat"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1095,9 +1095,6 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
 msgid "warn"
 msgstr ""
-
-#~ msgid "Countries"
-#~ msgstr "Maat"
 
 #~ msgid "Network Interfaces"
 #~ msgstr "Verkkoliitynnät"

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN:t"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktiiviset laitteet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automaattinen tunnistus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Kuvaus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Älä tarkista SSL-palvelinvarmenteita latauksen aikana."
 
@@ -345,49 +253,49 @@ msgstr "Älä tarkista SSL-palvelinvarmenteita latauksen aikana."
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Sähköpostin saajan osoite"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Sähköpostin lähettäjän osoite"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Sähköpostin aihe"
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Ota banIP-palvelun käyttöön."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Yleiset asetukset"
 
@@ -493,23 +401,23 @@ msgstr "Yleiset asetukset"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4-tuki"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6-tuki"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Päivitä"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Käynnistä uudelleen"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Asetukset"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Countries"

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Käynnistä uudelleen"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Définir la sélection --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (désactivé)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -255,9 +251,10 @@ msgstr ""
 "Détecter automatiquement les périphériques, interfaces, sous-réseaux, "
 "protocoles et utilitaires du réseau."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
-msgstr ""
+msgstr "Désactivé"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -95,7 +95,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Redémarrer"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -426,11 +426,11 @@ msgid "Highest Priority"
 msgstr "Priorité la plus élevée"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -767,11 +767,11 @@ msgid "Run Information"
 msgstr "Informations sur l’exécution"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -968,11 +968,11 @@ msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -218,8 +218,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Pays"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1165,9 +1165,6 @@ msgstr ""
 #~ "href=\"https://github.com/openwrt/packages/blob/master/net/banip/files/"
 #~ "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >consultez la "
 #~ "documentation en ligne</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Pays"
 
 #~ msgid ""
 #~ "Set the nft chain priority within the banIP table. Please note: lower "

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Définir la sélection --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (désactivé)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (par défaut)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (par défaut)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "Les ASN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Appareils actifs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -175,41 +79,45 @@ msgstr ""
 "la recherche de domaine ou redémarrez banIP dont les modifications prennent "
 "effet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Détection automatique"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -218,7 +126,7 @@ msgstr ""
 "blocage en fonction d’une requête RDAP supplémentaire avec l’adresse IP "
 "suspecte."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -226,7 +134,7 @@ msgstr ""
 "Ajoutez automatiquement les domaines résolus et les adresses IP suspectes à "
 "la liste de blocage banIP locale."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -234,31 +142,31 @@ msgstr ""
 "Ajoutez automatiquement des domaines résolus et des adresses IP de liaison "
 "montante à la liste d'autorisation banIP locale."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -270,7 +178,7 @@ msgstr ""
 "Les modifications Blocklist ont été sauvegardées, démarrent le Domain Lookup "
 "ou le redémarrage banIP que les changements prennent effet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -278,7 +186,7 @@ msgstr ""
 "Par défaut, chaque flux est actif dans toutes les chaînes prises en charge. "
 "Limiter la politique de blocage par défaut à une certaine chaîne."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -287,14 +195,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuler"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Les modifications apportées à cet onglet nécessitent un redémarrage du "
@@ -304,7 +212,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -313,7 +221,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -321,17 +229,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -339,7 +247,7 @@ msgstr ""
 msgid "Description"
 msgstr "Description"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -347,15 +255,15 @@ msgstr ""
 "Détecter automatiquement les périphériques, interfaces, sous-réseaux, "
 "protocoles et utilitaires du réseau."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 "Ignorer la vérification des certificats serveur pendant le téléchargement."
@@ -364,49 +272,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Téléchargement non sécurisé"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Paramètres de téléchargement"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notification par courriel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Courriel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Adresse courriel du destinataire"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Adresse courriel de l'expéditeur"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Réglages e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Objet du courriel"
 
@@ -422,7 +330,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -432,47 +340,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Activer le service banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Activé"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -480,11 +388,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -504,7 +412,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Réglages généraux"
 
@@ -512,23 +420,23 @@ msgstr "Réglages généraux"
 msgid "Grant access to LuCI app banIP"
 msgstr "Accorder l'accès à l'application LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Priorité élevée"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Priorité la plus élevée"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -540,23 +448,23 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Prise en charge d’IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Prise en charge d’IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -564,12 +472,12 @@ msgstr ""
 "Augmenter le nombre maximal de fichiers ouverts, par exemple pour gérer le "
 "nombre de fichiers temporaires divisés pendant le chargement des Sets."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Information"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -577,7 +485,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -585,45 +493,45 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Dernière exécution"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Priorité minimale"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Moins prioritaire"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 "Limitez les cœurs de processeur utilisés par banIP pour économiser de la RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -631,7 +539,7 @@ msgstr ""
 "Liste Définir les éléments dans l'état et le rapport, désactiver cela pour "
 "réduire la charge CPU."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -639,85 +547,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Limite de journalisation"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Conditions de journalisation"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -730,11 +638,11 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Priorité normale (par défaut)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -742,14 +650,14 @@ msgstr ""
 "Nombre de tentatives de téléchargement en cas d’erreur (non pris en charge "
 "par uclient-fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Nombre de tentatives de connexion infructueuses de la même IP dans le "
 "journal avant le blocage."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -761,7 +669,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -778,7 +686,7 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Profil utilisé par 'msmtp' pour les courriel de notification de bannissement "
@@ -786,19 +694,19 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -810,35 +718,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Actualiser"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Recharger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Répertoire des rapports"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Redémarrer"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Limitez l’accès à Internet depuis/vers un petit nombre d’adresses IP "
@@ -857,19 +761,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Drapeaux d'exécution"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informations sur l’exécution"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -885,23 +789,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriels de notification de bannissement IP."
@@ -911,7 +815,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -919,7 +823,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -935,59 +839,59 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Séparez le chargement externe de l'ensemble tous les n membres pour "
 "économiser de la RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "État"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -999,13 +903,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "La priorité sélectionnée sera utilisée pour le traitement en arrière-plan "
@@ -1046,7 +950,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Horodatage"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1054,23 +958,23 @@ msgstr ""
 "Pour activer les notifications par e-mail, configurez le package 'msmtp' et "
 "spécifiez une adresse de destinataire E-Mail valide."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Rubrique pour les courriels de notification banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1082,11 +986,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1113,11 +1021,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Journalisation détaillée du débogage"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1125,8 +1033,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1134,8 +1042,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1156,7 +1064,7 @@ msgstr ""
 "des mainteneurs, il suffit de vider à nouveau le fichier de flux "
 "personnalisé (ne le supprimez pas!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1192,73 +1100,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (par défaut)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
 
 #~ msgid ""
 #~ "Configuration of the banIP package to ban incoming and outgoing IPs via "

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -408,11 +408,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -729,11 +729,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -919,11 +919,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -238,6 +234,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -15,155 +15,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -173,83 +77,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -259,13 +167,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -274,14 +182,14 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -289,7 +197,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -298,7 +206,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -306,17 +214,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -324,21 +232,21 @@ msgstr ""
 msgid "Description"
 msgstr "תיאור"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -346,49 +254,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -404,7 +312,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -414,47 +322,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -462,11 +370,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -486,7 +394,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "הגדרות כלליות"
 
@@ -494,23 +402,23 @@ msgstr "הגדרות כלליות"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -522,34 +430,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -557,7 +465,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -565,50 +473,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -616,85 +524,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -707,22 +615,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -732,7 +640,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -746,25 +654,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -774,35 +682,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -819,19 +723,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -847,23 +751,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -872,7 +776,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -880,7 +784,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -896,57 +800,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "מצב"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -958,13 +862,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -999,29 +903,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1033,11 +937,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1064,11 +972,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1076,8 +984,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1085,8 +993,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1100,7 +1008,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1136,58 +1044,58 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -203,7 +203,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -196,7 +196,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -8,155 +8,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -166,83 +70,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -252,13 +160,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -267,14 +175,14 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -282,7 +190,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -291,7 +199,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -299,17 +207,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -317,21 +225,21 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -339,49 +247,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -397,7 +305,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -407,47 +315,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -455,11 +363,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -479,7 +387,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -487,23 +395,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -515,34 +423,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -550,7 +458,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -558,50 +466,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -609,85 +517,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -700,22 +608,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -725,7 +633,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -739,25 +647,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -767,35 +675,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -812,19 +716,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -840,23 +744,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -865,7 +769,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -873,7 +777,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -889,57 +793,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -951,13 +855,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -992,29 +896,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1026,11 +930,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1057,11 +965,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1069,8 +977,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1078,8 +986,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1093,7 +1001,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1129,58 +1037,58 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -8,10 +8,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -231,6 +227,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -401,11 +401,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -722,11 +722,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -912,11 +912,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -203,8 +203,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Országok"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1097,9 +1097,6 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
 msgid "warn"
 msgstr ""
-
-#~ msgid "Countries"
-#~ msgstr "Országok"
 
 #~ msgid "Network Interfaces"
 #~ msgstr "Hálózati csatolók"

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -409,11 +409,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -730,11 +730,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -920,11 +920,11 @@ msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -93,7 +93,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Újraindítás"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -14,156 +14,60 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "AS számok"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktív eszközök"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 #, fuzzy
 msgid "Advanced Settings"
 msgstr "Haladó Beállítások"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -173,83 +77,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automatikus észlelés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -259,13 +167,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -274,14 +182,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Mégse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -289,7 +197,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -298,7 +206,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -306,17 +214,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -324,21 +232,21 @@ msgstr ""
 msgid "Description"
 msgstr "Leírás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -346,49 +254,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Mail profil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-Mail küldő cím"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 #, fuzzy
 msgid "E-Mail Topic"
 msgstr "E-Mail téma"
@@ -405,7 +313,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -415,47 +323,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -463,11 +371,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -487,7 +395,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Általános Beállítások"
 
@@ -495,23 +403,23 @@ msgstr "Általános Beállítások"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -523,34 +431,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 támogatás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 támogatás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Információ"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -558,7 +466,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -566,50 +474,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Utolsó futás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Legkisebb prioritás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Kisebb prioritás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -617,85 +525,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -708,22 +616,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Közepes prioritás (alapértelmezett)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -733,7 +641,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -747,25 +655,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -775,35 +683,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Újratöltés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Újraindítás"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -820,19 +724,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -848,23 +752,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -873,7 +777,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -881,7 +785,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -897,57 +801,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Beállítások"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -959,13 +863,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -1000,29 +904,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1034,11 +938,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1065,11 +973,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1077,8 +985,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1086,8 +994,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1101,7 +1009,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1137,60 +1045,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Countries"

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -238,6 +234,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -219,8 +219,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Paesi"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1183,9 +1183,6 @@ msgstr "avviso"
 #~ "href=\"https://github.com/openwrt/packages/blob/master/net/banip/files/"
 #~ "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >consulta la "
 #~ "documentazione online</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Paesi"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Feed di Lista consentiti esterna"

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -96,7 +96,7 @@ msgstr "Blocca sempre alcuni inoltri VLAN."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Riavvia"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -432,11 +432,11 @@ msgid "Highest Priority"
 msgstr "Priorità massima"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -769,11 +769,11 @@ msgid "Run Information"
 msgstr "Avvia informazioni"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -978,11 +978,11 @@ msgid "Trigger Delay"
 msgstr "Ritardo innesco"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Imposta selezione --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (disattiva)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -258,6 +254,7 @@ msgstr ""
 "Rileva automaticamente i dispositivi di rete, le interfacce, le sottoreti, i "
 "protocolli e le utilità rilevanti."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Disattiva"

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -1271,12 +1271,6 @@ msgstr "avviso"
 #~ msgid "start (default)"
 #~ msgstr "avvio"
 
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "Consenti inoltri VLAN"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Blocca inoltri VLAN"
-
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
 #~ "blocklist."

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -14,157 +14,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Imposta selezione --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (disattiva)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (predefinito)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (predefinito)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (predefinito)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASNs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Dispositivi attivi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Feed attivi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Uplink attivi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Ritardo aggiuntivo del trigger in secondi durante il ricaricamento e l'avvio "
 "dell'interfaccia."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Impostazioni avanzate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Consenti l'inoltro delle VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Solo Lista consentiti"
 
@@ -176,41 +80,45 @@ msgstr ""
 "Le modifiche alla Lista consentiti sono state salvate, avvia la ricerca di "
 "domini o riavvia banIP per applicare le modifiche."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Permetti sempre alcuni inoltri VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Blocca sempre alcuni inoltri VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Consenti automaticamente Uplink"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Auto-Lista consentiti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Blocco automatico sottoreti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Auto-Lista bloccati"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Rilevamento automatico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -218,7 +126,7 @@ msgstr ""
 "Aggiungi automaticamente intere sottoreti alla lista bloccati in base a "
 "un'ulteriore richiesta RDAP con l'IP sospetto."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -226,7 +134,7 @@ msgstr ""
 "Aggiungi automaticamente i domini risolti e gli IP sospetti alla lista "
 "bloccati locale di banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -234,31 +142,31 @@ msgstr ""
 "Aggiungi automaticamente i domini risolti e gli IP di uplink alla lista "
 "consentiti locale di banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Cartella del backup"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Cartella di base"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Cartella di lavoro di base durante l'elaborazione di banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Tipo di blocco"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Blocco dell'inoltro delle VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Scadenza set Lista bloccati"
 
@@ -270,7 +178,7 @@ msgstr ""
 "Le modifiche alla lista bloccati sono state salvate, avvia la ricerca dei "
 "domini o riavvia banIP per applicare le modifiche."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -279,7 +187,7 @@ msgstr ""
 "supportate. Limita la politica di blocco predefinita a una determinata "
 "catena."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Core CPU"
 
@@ -288,14 +196,14 @@ msgstr "Core CPU"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Per applicare le modifiche in questa scheda serve riavviare il servizio "
@@ -305,7 +213,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Cancella i feed personalizzati"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -314,7 +222,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -322,7 +230,7 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Editor di feed personalizzati"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -330,11 +238,11 @@ msgstr ""
 "Deduplica gli indirizzi IP su tutti i set attivi e riordina la lista "
 "bloccati locale."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Deduplica gli IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Politica di blocco predefinita"
 
@@ -342,7 +250,7 @@ msgstr "Politica di blocco predefinita"
 msgid "Description"
 msgstr "Descrizione"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -350,15 +258,15 @@ msgstr ""
 "Rileva automaticamente i dispositivi di rete, le interfacce, le sottoreti, i "
 "protocolli e le utilità rilevanti."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Disattiva"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Ricerca del dominio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Non controllare i certificati SSL del server durante il download."
 
@@ -366,23 +274,23 @@ msgstr "Non controllare i certificati SSL del server durante il download."
 msgid "Download Custom Feeds"
 msgstr "Scarica i feed personalizzati"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Download non sicuro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Parametri di download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Tentativi di download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Utilità di download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -390,27 +298,27 @@ msgstr ""
 "Scarta i pacchetti in silenzio o rifiuta attivamente il traffico sulle "
 "catene WAN-Input e WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notifica e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Profilo e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Indirizzo e-mail destinatario"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Indirizzo e-mail mittente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Impostazioni e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Oggetto e-mail"
 
@@ -426,7 +334,7 @@ msgstr "Modifica Lista bloccati"
 msgid "Edit Custom Feeds"
 msgstr "Modifica feed personalizzati"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Numero elementi"
 
@@ -436,49 +344,49 @@ msgstr "Elementi"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Campo vuoto non consentito"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Abilita il log Remoto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Attiva il servizio banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "Abilita l'interfaccia cgi a ricevere eventi di log remoti."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "Attiva log di debug esteso in caso di errori di elaborazione."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Attiva il supporto IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Attiva il supporto IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Tempo di scadenza per i membri del set Lista bloccati aggiunti "
 "automaticamente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -486,11 +394,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Nome feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Selezione feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -510,7 +418,7 @@ msgstr "Flag"
 msgid "Flag not supported"
 msgstr "Flag non supportato"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Impostazioni Generali"
 
@@ -518,23 +426,23 @@ msgstr "Impostazioni Generali"
 msgid "Grant access to LuCI app banIP"
 msgstr "Consenti l'accesso all'app banIP di LuCI"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Priorità alta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Priorità massima"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -546,23 +454,23 @@ msgstr "Ricerca IP"
 msgid "IP Search..."
 msgstr "Ricerca IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "Interfacce di rete IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Supporto IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "Interfacce di rete IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Supporto IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -570,12 +478,12 @@ msgstr ""
 "Aumenta il numero massimo di file aperti, ad es. per gestire la quantità di "
 "file divisi temporanei durante il caricamento dei set."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informazioni"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Caratteri non validi"
 
@@ -583,7 +491,7 @@ msgstr "Caratteri non validi"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Valori di input non validi, impossibile salvare le modifiche."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -591,44 +499,44 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (pacchetti)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Catena LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Ultimo avvio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Priorità minima"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Priorità bassa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Limita determinati feed alla catena LAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Limita determinati feed alla catena WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Limita determinati feed alla catena WAN-Input."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "Limita i core della CPU usati da banIP per risparmiare RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Limita la funzione auto-consentiti di uplink."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -636,7 +544,7 @@ msgstr ""
 "Elenca gli elementi del set nello stato e nel rapporto, disattivalo per "
 "ridurre il carico della CPU."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr "Elenco delle interfacce di trigger di ricaricamento disponibili."
 
@@ -644,11 +552,11 @@ msgstr "Elenco delle interfacce di trigger di ricaricamento disponibili."
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Elenca gli elementi di un set specifico relativo a banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
@@ -656,75 +564,75 @@ msgstr ""
 "Posizione per l'analisi del file di log, ad esempio tramite syslog-ng, per "
 "disattivare l'analisi standard tramite logread."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Numero log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Registra LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Limite di log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Impostazioni log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Termini del log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Registra WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Registra WAN-Input"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "Posizione del file di log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Max file aperti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Informazioni NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "Livello log NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Dispositivi di rete"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Livello priorità (nice)"
 
@@ -737,11 +645,11 @@ msgstr "Nessun risultato di ricerca!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Non ci sono ancora log del firewall relativi a banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Priorità normale (predefinito)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Priorità normale"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -749,14 +657,14 @@ msgstr ""
 "Numero di tentativi di download in caso di errore (non supportato da uclient-"
 "fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Numero di tentativi di accesso falliti dello stesso IP nel log prima del "
 "blocco."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -768,7 +676,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riepilogo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -784,25 +692,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr "Log di elaborazione"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "Profilo usato da 'msmtp' per le notifiche e-mail di banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Protocollo/Formato URL non supportato"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Ricevi notifiche e-mail ad ogni esecuzione di banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -814,35 +722,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Ricarica"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr "Interfaccia di trigger di ricaricamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "Token Remoto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Cartella del report"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Elementi del report"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Riavvia"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr "Limita l'accesso a Internet da/a un numero limitato di IP sicuri."
 
@@ -859,19 +763,19 @@ msgstr "Rulev4"
 msgid "Rulev6"
 msgstr "Rulev6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Avvia flags"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Avvia informazioni"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -887,23 +791,23 @@ msgstr "Cerca"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Cerca i set relativi a banIP per un IP specifico."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Seleziona una delle utilità di download preconfigurate."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Seleziona il/i dispositivo/i di rete WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Seleziona l'/le interfaccia/e di rete WAN IPv4 logica/che."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Seleziona l'/le interfaccia/e di rete WAN IPv6 logica/che."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Indirizzo del mittente per le e-mail di notifica di banIP."
 
@@ -912,7 +816,7 @@ msgstr "Indirizzo del mittente per le e-mail di notifica di banIP."
 msgid "Set"
 msgstr "Imposta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -920,7 +824,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr "Imposta resoconti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Imposta dim. divisione"
 
@@ -936,58 +840,58 @@ msgstr "Imposta sondaggio..."
 msgid "Set details"
 msgstr "Imposta dettagli"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Imposta il criterio nft per iset relativi a banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Imposta il livello syslog per la registrazione NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Dividi il caricamento del set esterno dopo ogni n membri per risparmiare RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Stato"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Ferma"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Sottorete (predefinito)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Sottorete"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Sondaggio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Informazioni di sistema"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Cartella di destinazione per i file di report relativi a banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Cartella di destinazione per i backup dei feed compressi."
 
@@ -999,13 +903,13 @@ msgstr "La lista consentiti è troppo grande, impossibile salvare le modifiche."
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "La lista bloccati è troppo grande, impossibile salvare le modifiche."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "La priorità selezionata verrà usata per l'elaborazione in secondo piano di "
@@ -1056,7 +960,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Marca temporale"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1064,23 +968,23 @@ msgstr ""
 "Per attivare le notifiche e-mail, configura il pacchetto 'msmtp' e specifica "
 "un indirizzo di destinatario e-mail valido."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr "Token per comunicare con l'interfaccia cgi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Oggetto per le e-mail di notifica di banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Ritardo innesco"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1092,11 +996,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1123,11 +1031,11 @@ msgstr "Carica feed personalizzati"
 msgid "Upload of the custom feed file failed."
 msgstr "Caricamento del file dei feed personalizzati fallito."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Registro di debug dettagliato"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versione"
 
@@ -1135,8 +1043,8 @@ msgstr "Versione"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (pacchetti)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Catena WAN-Forward"
 
@@ -1144,8 +1052,8 @@ msgstr "Catena WAN-Forward"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Input (pacchetti)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Catena WAN-Input"
 
@@ -1165,7 +1073,7 @@ msgstr ""
 "backup locale. Per tornare alla versione dei manutentori, svuota di nuovo il "
 "file dei feed personalizzati (non eliminarlo!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "allarme"
 
@@ -1201,73 +1109,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "crit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "debug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
-msgstr "scarta (predefinito)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
+msgstr "scarta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "emerg"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "err"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "lista consentiti locale"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "lista bloccati locale"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "memoria (predefinito)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "memoria"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "notifica"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "prestazioni"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "rifiuta (reject)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "avviso (predefinito)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (predefinito)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "avviso"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Selezione Feed della Lista consentiti"
@@ -1378,11 +1274,8 @@ msgstr "avviso (predefinito)"
 #~ msgid "reload"
 #~ msgstr "ricarica"
 
-#~ msgid "restart"
-#~ msgstr "riavvio"
-
 #~ msgid "start (default)"
-#~ msgstr "avvio (predefinito)"
+#~ msgstr "avvio"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "Consenti inoltri VLAN"
@@ -1401,7 +1294,7 @@ msgstr "avviso (predefinito)"
 #~ msgstr "Impossibile salvare le modifiche: %s"
 
 #~ msgid "-m limit --limit 2/sec (default)"
-#~ msgstr "-m limit --limit 2/sec (predefinito)"
+#~ msgstr "-m limit --limit 2/sec"
 
 #~ msgid "1 hour"
 #~ msgstr "1 ora"

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "再起動"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -202,8 +202,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "国"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1095,9 +1095,6 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
 msgid "warn"
 msgstr ""
-
-#~ msgid "Countries"
-#~ msgstr "国"
 
 #~ msgid "Network Interfaces"
 #~ msgstr "ネットワークインターフェース"

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- 選択 --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (無効)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,9 +233,10 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
-msgstr ""
+msgstr "無効"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- 選択 --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (無効)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (デフォルト)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (デフォルト)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (デフォルト)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASNs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "アクティブなデバイス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "アクティブなフィード"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "アクティブなアップリンク"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "自動検出"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "説明"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "ダウンロードのパラメータ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "banIP サービスを有効にする。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -493,23 +401,23 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "高い優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "最高の優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 サポート"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 サポート"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "情報"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "最終実行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "最低の優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "低い優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "ログ制限"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "通常の優先度 (デフォルト)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "リフレッシュ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "リロード"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "再起動"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "実行フラグ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "実行情報"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr "タイムスタンプ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,73 +1043,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (デフォルト)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
 
 #~ msgid "Countries"
 #~ msgstr "国"

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr "最高の優先度"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr "実行情報"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -408,11 +408,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -729,11 +729,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -919,11 +919,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -203,7 +203,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "고급 설정"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,84 +76,88 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 #, fuzzy
 msgid "Backup Directory"
 msgstr "백업 경로"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -259,13 +167,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -274,14 +182,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "취소"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -289,7 +197,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -298,7 +206,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -306,17 +214,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -324,21 +232,21 @@ msgstr ""
 msgid "Description"
 msgstr "설명"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -346,49 +254,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -404,7 +312,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -414,47 +322,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "활성화"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -462,11 +370,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -486,7 +394,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "기본 설정"
 
@@ -494,23 +402,23 @@ msgstr "기본 설정"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -522,34 +430,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "정보"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -557,7 +465,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -565,50 +473,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -616,85 +524,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -707,22 +615,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -732,7 +640,7 @@ msgstr ""
 msgid "Overview"
 msgstr "개요"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -746,25 +654,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -774,35 +682,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -819,19 +723,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -847,23 +751,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -872,7 +776,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -880,7 +784,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -896,57 +800,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -958,13 +862,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -999,29 +903,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1033,11 +937,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1064,11 +972,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1076,8 +984,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1085,8 +993,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1100,7 +1008,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1136,60 +1044,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Name"

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -238,6 +234,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/lt/banip.po
+++ b/applications/luci-app-banip/po/lt/banip.po
@@ -207,8 +207,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Šalys"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1112,9 +1112,6 @@ msgstr "įspėti"
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "Grandinė/Nustatyti nustatymus"
-
-#~ msgid "Countries"
-#~ msgstr "Šalys"
 
 #~ msgid "NFT Chain Priority"
 #~ msgstr "„NFT“ grandinės prioritetas"

--- a/applications/luci-app-banip/po/lt/banip.po
+++ b/applications/luci-app-banip/po/lt/banip.po
@@ -414,11 +414,11 @@ msgid "Highest Priority"
 msgstr "Aukščiausio prioriteto"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -742,11 +742,11 @@ msgid "Run Information"
 msgstr "Vykdymo informacija"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -932,11 +932,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/lt/banip.po
+++ b/applications/luci-app-banip/po/lt/banip.po
@@ -17,10 +17,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Nustatyti pasirinkimą --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (išjungti)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -242,6 +238,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Išjungti"

--- a/applications/luci-app-banip/po/lt/banip.po
+++ b/applications/luci-app-banip/po/lt/banip.po
@@ -17,155 +17,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Nustatyti pasirinkimą --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (išjungti)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (numatytas)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (numatytas)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (numatytas)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "Autonominės sistemos („ASNs“)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktyvūs įrenginiai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Pažangūs nustatymai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Leisti „VLAN“ persiuntimus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Tik leidžiamas sąrašas"
 
@@ -175,83 +79,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Visada leisti kai kuriuos „VLAN“ persiuntimus."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Visada blokuoti kai kuriuos „VLAN“ persiuntimus."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Automatiškas leidžiamas sąrašas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Automatiškai blokuoti potinklį/-ius"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Automatiškas blokavimo sąrašas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automatinis patikrinimas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Atsarginės kopijos katalogas/vietovė"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Bazinis katalogas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Blokavimo tipas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Blokuoti „VLAN“ persiuntimus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Nustatyti blokavimo sąrašo galiojimo laiką"
 
@@ -261,13 +169,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Procesoriaus branduoliai"
 
@@ -276,14 +184,14 @@ msgstr "Procesoriaus branduoliai"
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Pakeitimai, kuriuos šiame skirtuke atlikote, reikalauja tarnybos paleidimo "
@@ -293,7 +201,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -302,7 +210,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -310,17 +218,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Numatyta blokavimo politika"
 
@@ -328,21 +236,21 @@ msgstr "Numatyta blokavimo politika"
 msgid "Description"
 msgstr "Aprašas/-ymas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Išjungti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Domeno-Srities paieška"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Netikrinti „SSL“ serverio sertifikatus, kol siunčiasi."
 
@@ -350,23 +258,23 @@ msgstr "Netikrinti „SSL“ serverio sertifikatus, kol siunčiasi."
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Atsisiuntimas nesaugus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Atsisiuntimo parametrai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Atsisiuntimo atkartojimai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Atsisiuntimo įrankis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -374,27 +282,27 @@ msgstr ""
 "Išmesti paketus tyliai arba aktyviai neleisti srautą ant grandinių – „WAN-"
 "įvestis“ ir „WAN-persiuntimas“."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "El. pašto pranešimas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "El. pašto profilis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "El. pašto gavėjo adresas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "El. pašto siuntėjo adresas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "El. pašto nustatymai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "El. pašto tema"
 
@@ -410,7 +318,7 @@ msgstr "Redaguoti blokavimo sąrašą"
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Elementų kiekis"
 
@@ -420,47 +328,47 @@ msgstr "Elementai"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Tuščia įvestis yra neleidžiama"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Įjungti „banIP“ tarnybą."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Įjungta/-as"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Įgalina IPv4 palaikymą."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Įgalina IPv6 palaikymą."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -468,11 +376,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -492,7 +400,7 @@ msgstr "Vėliava"
 msgid "Flag not supported"
 msgstr "Vėliava nepalaikoma"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Bendri nustatymai"
 
@@ -500,23 +408,23 @@ msgstr "Bendri nustatymai"
 msgid "Grant access to LuCI app banIP"
 msgstr "Duoti prieigą prie „LuCI-app-banIP“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Aukšto prioriteto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Aukščiausio prioriteto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -528,34 +436,34 @@ msgstr "IP paieška"
 msgid "IP Search..."
 msgstr "IP paieška..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "IPv4 tinklo sąsajos ir sietuvai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 palaikymas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "IPv6 tinklo sąsajos ir sietuvai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 palaikymas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informacija"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Negalimi simboliai"
 
@@ -563,7 +471,7 @@ msgstr "Negalimi simboliai"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Negalimos įvesties reikšmės, nepavyko išsaugoti pakeitimų."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -571,50 +479,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "„LAN-Persiuntimas“ (paketai)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "„LAN-Persiuntimo grandinė“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Paskutinį kartą vykdytą"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Mažiausias prioritetas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Mažiau prioriteto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -622,85 +530,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Žurnalo kiekis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Žurnalas/-inti – „LAN-Persiuntimas“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Žurnalo limitas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Žurnalo nustatymai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Žurnalas/-inti – „WAN-Persiuntimas“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Žurnalas/-inti – „WAN-Įvestis“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "Žurnalo failo vietovė"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Maksimalus atidarytų failų kiekis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "„NFT“ informacija"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "„NFT“ žurnalo lygis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Tinklo įrenginiai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -713,11 +621,11 @@ msgstr "Nėra paieškos rezultatų!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Nėra „banIP“ susijusių užkardos žurnalų (kol kas)!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Normalus prioritetas (numatytas)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Normalus prioritetas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -725,14 +633,14 @@ msgstr ""
 "Atsisiuntimų bandymų skaičius atsiradus klaidai (nepalaikomas „uclient-"
 "fetch“)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Nepavykusių prisijungimų skaičius to pačio IP, kuris randamas žurnale prieš "
 "blokavimą."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -744,7 +652,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Apžiūra"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -758,26 +666,26 @@ msgstr "Prievado/Protokolo limitas"
 msgid "Processing Log"
 msgstr "Apdorojamas žurnalas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Profilis kurį naudoja „msmtp“, skirta „banIP“ pranešimams per el. paštą."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Protokolo/„URL – Saito“ formatas yra nepalaikomas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Gauti el. pašto pranešimus su kiekvienu „banIP“ paleidimu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -787,35 +695,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "Nuotolinis žetonas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Paleisti iš naujo"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -832,19 +736,19 @@ msgstr "„Rulev4“"
 msgid "Rulev6"
 msgstr "„Rulev6“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Vykdymo vėliavos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Vykdymo informacija"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -860,23 +764,23 @@ msgstr "Paieška"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Pasirinkite „WAN“ tinklo įrenginį/-ius."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -885,7 +789,7 @@ msgstr ""
 msgid "Set"
 msgstr "Nustatyti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -893,7 +797,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -909,57 +813,57 @@ msgstr "Nustatyti apklausą..."
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Nustatyti „syslog“ lygį „NFT“ žurnalinimui."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Nustatymai"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Būklė/Būsena"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Stop"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr "Potinklis (numatytas/-a)"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Apklausa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Sistemos informacija"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -971,13 +875,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -1012,29 +916,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1046,11 +950,15 @@ msgstr "„URLv4“"
 msgid "URLv6"
 msgstr "„URLv6“"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1077,11 +985,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versija"
 
@@ -1089,8 +997,8 @@ msgstr "Versija"
 msgid "WAN-Forward (packets)"
 msgstr "„WAN-Persiuntimas“ (paketai)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "„WAN-Persiuntimo“ grandinė"
 
@@ -1098,8 +1006,8 @@ msgstr "„WAN-Persiuntimo“ grandinė"
 msgid "WAN-Input (packets)"
 msgstr "„WAN-Įvestis“ (paketai)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "„WAN-Įvesties“ grandinė"
 
@@ -1113,7 +1021,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "įspėjimas"
 
@@ -1149,73 +1057,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "kritinė"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "derinimas/trukdžių šalinimas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
-msgstr "mesti (numatytas)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
+msgstr "mesti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "kritinė būklė/avarinis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "klaida"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "informacija"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "vietinis leidžiamasis sąrašas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "vietinis blokavimo sąrašas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "atmintis (numatytas)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "atmintis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "pranešimas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "našumas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "atmesti"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "įspėti (numatytas)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (numatytas)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "įspėti"
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "Grandinė/Nustatyti nustatymus"

--- a/applications/luci-app-banip/po/lt/banip.po
+++ b/applications/luci-app-banip/po/lt/banip.po
@@ -95,7 +95,7 @@ msgstr "Visada blokuoti kai kuriuos „VLAN“ persiuntimus."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Paleisti iš naujo"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "वर्णन"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -493,23 +401,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "रीलोड करा"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Loading"

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Direktori asas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Keterangan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Dibolehkan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -493,23 +401,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,70 +1043,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
 
 #~ msgid "Advanced"
 #~ msgstr "Lanjutan"

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -729,11 +729,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -919,11 +919,11 @@ msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Omstart"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Avanserte innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Last ned usikkert"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Nedlastingsparametre"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Påskrudd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Generelle innstillinger"
 
@@ -493,23 +401,23 @@ msgstr "Generelle innstillinger"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6-støtte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Info"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Sist kjørt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Gjenoppfrisk"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Omstart"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,20 +722,20 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 #, fuzzy
 msgid "Run Flags"
 msgstr "Kjøringsflagg"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -847,23 +751,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -872,7 +776,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -880,7 +784,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -896,57 +800,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -958,13 +862,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -999,29 +903,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1033,11 +937,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1064,11 +972,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versjon"
 
@@ -1076,8 +984,8 @@ msgstr "Versjon"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1085,8 +993,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1100,7 +1008,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1136,67 +1044,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-300"
-#~ msgstr "-300"
 
 #~ msgid "Unable to save changes: %s"
 #~ msgstr "Kunne ikke lagre endringer: %s"

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -218,8 +218,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Landen"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1169,9 +1169,6 @@ msgstr "waarschuwen"
 #~ "github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
 #~ "target=\"_blank\" rel=\"noreferrer noopener\" >bekijk de online "
 #~ "documentatie</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Landen"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Externe toelatingslijstfeeds"

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -427,11 +427,11 @@ msgid "Highest Priority"
 msgstr "Hoogste prioriteit"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -765,11 +765,11 @@ msgid "Run Information"
 msgstr "Informatie uitvoeren"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -963,11 +963,11 @@ msgid "Trigger Delay"
 msgstr "Trigger vertraging"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -96,7 +96,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Herstart"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Selectie instellen --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (uitschakelen)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -255,6 +251,7 @@ msgstr ""
 "Detecteer automatisch relevante netwerkapparaten, interfaces, subnetten, "
 "protocollen en hulpprogramma's."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Uitschakelen"

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -14,157 +14,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Selectie instellen --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (uitschakelen)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (standaard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (standaard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (standaard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN's"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Actieve apparaten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Actieve feeds"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Actieve uplink"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Extra activeringsvertraging in seconden tijdens het opnieuw laden en "
 "opstarten van de interface."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Geavanceerde instellingen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "VLAN-forwards toestaan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Alleen toelatingslijst"
 
@@ -176,41 +80,45 @@ msgstr ""
 "Wijzigingen op de toelatingslijst zijn opgeslagen, start de Domain Lookup of "
 "herstart banIP om de wijzigingen door te voeren."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Uplink automatisch toestaan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Automatische toelatingslijst"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Subnet automatisch blokkeren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Automatische blokkeerlijst"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Autodetectie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -218,7 +126,7 @@ msgstr ""
 "Voeg automatisch hele subnetten toe aan de blokkeerlijst Set op basis van "
 "een extra RDAP-verzoek met het verdachte IP-adres."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -226,7 +134,7 @@ msgstr ""
 "Voeg automatisch opgeloste domeinen en verdachte IP's toe aan de lokale "
 "banIP-blokkeerlijst."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -234,31 +142,31 @@ msgstr ""
 "Voeg automatisch opgeloste domeinen en uplink-IP's toe aan de lokale banIP-"
 "toelatingslijst."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Backup Directory"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Basismap"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Basiswerkmap tijdens banIP-verwerking."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Vervaldatum van blokkeerlijst ingesteld"
 
@@ -270,7 +178,7 @@ msgstr ""
 "Bloklijstwijzigingen zijn opgeslagen, start de Domain Lookup of herstart "
 "banIP om de wijzigingen door te voeren."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -278,7 +186,7 @@ msgstr ""
 "Standaard is elke feed actief in alle ondersteunde reeks. Beperk het "
 "standaard blokkeerbeleid tot een bepaalde reeks."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "CPU-kernen"
 
@@ -287,14 +195,14 @@ msgstr "CPU-kernen"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Reeks Prioriteit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Wijzigingen op dit tabblad hebben een herstart van de banIP-service nodig om "
@@ -304,7 +212,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Aangepaste feeds wissen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -313,7 +221,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -321,17 +229,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Aangepaste feededitor"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "IP's ontdubbelen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Standaard blokkeringsbeleid"
 
@@ -339,7 +247,7 @@ msgstr "Standaard blokkeringsbeleid"
 msgid "Description"
 msgstr "Beschrijving"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -347,15 +255,15 @@ msgstr ""
 "Detecteer automatisch relevante netwerkapparaten, interfaces, subnetten, "
 "protocollen en hulpprogramma's."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Uitschakelen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Domein opzoeken"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Tijdens download niet de SSL server certificaten controleren."
 
@@ -363,49 +271,49 @@ msgstr "Tijdens download niet de SSL server certificaten controleren."
 msgid "Download Custom Feeds"
 msgstr "Aangepaste feeds downloaden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Onbeveiligd downloaden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Parameters downloaden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Nieuwe pogingen downloaden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Download hulpprogramma"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-Mail notificatie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Mail profiel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail adres van ontvanger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-Mail adres van verzender"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Email instellingen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-Mail onderwerp"
 
@@ -421,7 +329,7 @@ msgstr "Blokkeerlijst bewerken"
 msgid "Edit Custom Feeds"
 msgstr "Aangepaste feeds bewerken"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Aantal elementen"
 
@@ -431,49 +339,49 @@ msgstr "Elementen"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Leeg veld niet toegestaan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Activeer de banIP service."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "Schakel uitgebreide logboekregistratie voor foutopsporing, in geval van "
 "verwerkingsfouten."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Schakelt IPv4-ondersteuning in."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Schakelt IPv6-ondersteuning in."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr "Vervaltijd voor automatisch toegevoegde blocklist Set-leden."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -481,11 +389,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Feednaam"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Feed selectie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -505,7 +413,7 @@ msgstr "Vlag"
 msgid "Flag not supported"
 msgstr "Vlag niet ondersteund"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Algemene instellingen"
 
@@ -513,23 +421,23 @@ msgstr "Algemene instellingen"
 msgid "Grant access to LuCI app banIP"
 msgstr "Geef toegang tot LuCI app banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Hoge prioriteit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Hoogste prioriteit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -541,23 +449,23 @@ msgstr "IP zoeken"
 msgid "IP Search..."
 msgstr "IP Zoeken..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 ondersteuning"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 ondersteuning"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -565,12 +473,12 @@ msgstr ""
 "Verhoog het maximale aantal geopende bestanden, b.v. om het aantal "
 "tijdelijke gesplitste bestanden te verwerken tijdens het laden van de Sets."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informatie"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Ongeldige tekens"
 
@@ -578,7 +486,7 @@ msgstr "Ongeldige tekens"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Ongeldige invoerwaarden, kan wijzigingen niet opslaan."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -586,44 +494,44 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (pakketten)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "LAN-Forward Reeks"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Laatst gedraaid"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Laagste prioriteit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Lage prioriteit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Beperk bepaalde feeds tot de LAN-Forward-reeks."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Beperk bepaalde feeds tot de WAN-Forward-reeks."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Beperk bepaalde feeds tot de WAN-invoer reeks."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "Beperk de cpu-cores die banIP gebruikt om RAM te besparen."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Beperk de uplink autoallow-functie."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -631,7 +539,7 @@ msgstr ""
 "Lijst Stel elementen in de status en rapport in, schakel dit uit om de CPU-"
 "belasting te verminderen."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -640,85 +548,85 @@ msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 "Maak een lijst van de elementen van een specifieke banIP-gerelateerde Set."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Aantal logboeken"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Logboek LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Log limiet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Logboek instellingen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Logboek termen (sleutelwoorden)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Logboek WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Logboek WAN-invoer"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Max Open Bestanden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "NFT Informatie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Netwerk apparaten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Mooi niveau"
 
@@ -731,11 +639,11 @@ msgstr "Geen zoekresultaten!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Nog geen banIP gerelateerde firewall logboeken!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Normale prioriteit (standaard)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Normale prioriteit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -743,14 +651,14 @@ msgstr ""
 "Aantal downloadpogingen in geval van een fout (niet ondersteund door uclient-"
 "fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Aantal mislukte inlogpogingen van hetzelfde IP-adres in het logboek vóór "
 "blokkering."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -762,7 +670,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Overzicht"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -779,26 +687,26 @@ msgstr ""
 msgid "Processing Log"
 msgstr "Logboek verwerken"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Profiel gebruikt voor 'msmtp' voor banIP E-Mail berichten/notificaties."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Protocol/URL-formaat wordt niet ondersteund"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Ontvang e-mailmeldingen bij elke banIP-run."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -810,35 +718,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Herladen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Herladen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Rapportage directory"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Rapporteer elementen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Herstart"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr "Beperk de internettoegang van/tot een klein aantal beveiligde IP's."
 
@@ -855,19 +759,19 @@ msgstr "Rulev4"
 msgid "Rulev6"
 msgstr "Rulev6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Vlaggen uitvoeren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informatie uitvoeren"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -883,23 +787,23 @@ msgstr "Zoeken"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Zoek in de banIP-gerelateerde sets naar een specifiek IP-adres."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Selecteer een van de vooraf geconfigureerde downloadhulpprogramma's."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Selecteer het/de WAN-netwerkapparaat(en)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Selecteer de logische WAN IPv4-netwerkinterface(s)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Selecteer de logische WAN IPv6-netwerkinterface(s)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Afzender e-mailadres voor de banIP email meldingen."
 
@@ -908,7 +812,7 @@ msgstr "Afzender e-mailadres voor de banIP email meldingen."
 msgid "Set"
 msgstr "Instellen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Beleid instellen"
 
@@ -916,7 +820,7 @@ msgstr "Beleid instellen"
 msgid "Set Reporting"
 msgstr "Rapportage instellen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Splitsgrootte instellen"
 
@@ -932,57 +836,57 @@ msgstr "Enquête instellen..."
 msgid "Set details"
 msgstr "Details instellen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Stel het nft-beleid in voor banIP-gerelateerde sets."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Stel het syslog-niveau in voor NFT-logboekregistratie."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Instellingen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr "Splits het laden van externe sets na elke n leden om RAM te besparen."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Status"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Stop"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Subnet (standaard)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Subnet"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Enquête"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Systeem informatie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Doelmap voor banIP-gerelateerde rapportbestanden."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Doelmap voor back-ups van gecomprimeerde feeds."
 
@@ -995,13 +899,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "De blokkeerlijst is te groot, kan wijzigingen niet opslaan."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "De geselecteerde prioriteit wordt gebruikt voor banIP-achtergrondverwerking."
@@ -1041,7 +945,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Tijdstempel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1049,23 +953,23 @@ msgstr ""
 "Om e-mailmeldingen in te schakelen, stelt u het 'msmtp'-pakket in en geeft u "
 "een geldig e-mailontvangeradres op."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Onderwerp voor banIP notificatie e-mails."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Trigger vertraging"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1077,11 +981,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1108,11 +1016,11 @@ msgstr "Aangepaste feeds uploaden"
 msgid "Upload of the custom feed file failed."
 msgstr "Het uploaden van het aangepaste feedbestand is mislukt."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Uitgebreide logboekregistratie voor foutopsporing"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versie"
 
@@ -1120,8 +1028,8 @@ msgstr "Versie"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (pakketten)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "WAN-Forward Reeks"
 
@@ -1129,8 +1037,8 @@ msgstr "WAN-Forward Reeks"
 msgid "WAN-Input (packets)"
 msgstr "WAN-invoer (pakketten)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "WAN-invoer reeks"
 
@@ -1151,7 +1059,7 @@ msgstr ""
 "versie van de beheerder leegt u het aangepaste feedbestand opnieuw (niet "
 "verwijderen!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "alarm"
 
@@ -1187,73 +1095,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "crit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "debuggen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "tevoorschijn komen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "fout"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "lokale toelatingslijst"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "lokale blokkeerlijst"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "geheugen (standaard)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "geheugen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "kennisgeving"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "prestatie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "waarschuwen (standaard)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (standaard)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "waarschuwen"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Toegestane feedselectie"
@@ -1362,11 +1258,8 @@ msgstr "waarschuwen (standaard)"
 #~ msgid "reload"
 #~ msgstr "herladen"
 
-#~ msgid "restart"
-#~ msgstr "herstarten"
-
 #~ msgid "start (default)"
-#~ msgstr "start (standaard)"
+#~ msgstr "start"
 
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
@@ -1484,7 +1377,7 @@ msgstr "waarschuwen (standaard)"
 #~ "aanpassing te activeren."
 
 #~ msgid "-m limit --limit 2/sec (default)"
-#~ msgstr "-m-limiet --limiet 2/sec (standaard)"
+#~ msgstr "-m-limiet --limiet 2/sec"
 
 #~ msgid "1 hour"
 #~ msgstr "1 uur"

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -439,11 +439,11 @@ msgid "Highest Priority"
 msgstr "Najwyższy priorytet"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr "Próg ICMP"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "Próg ICMP w pakietach na sekundę do zapobiegania atakom WAN-DDoS."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -781,11 +781,11 @@ msgid "Run Information"
 msgstr "Informacje uruchomieniowe"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr "Próg SYN"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "Próg SYN w pakietach na sekundę do zapobiegania atakom WAN-DDoS."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -991,11 +991,11 @@ msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr "Próg UDP"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "Próg UDP w pakietach na sekundę do zapobiegania atakom WAN-DDoS."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Wybór zestawu --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (wyłączone)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - obsługuje region Afryki i Oceanu Indyjskiego"
@@ -265,6 +261,7 @@ msgstr ""
 "Automatycznie wykrywaj odpowiednie urządzenia sieciowe, interfejsy, "
 "podsieci, protokoły i narzędzia."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Wyłącz"

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -226,8 +226,8 @@ msgstr ""
 "target=\"_blank\" rel=\"noreferrer noopener\" >dokumentację online</a>"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr "Państwa (RIR)"
+msgid "Countries"
+msgstr "Kraje"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1175,6 +1175,9 @@ msgstr "odrzucaj"
 msgid "warn"
 msgstr "ostrzeżenie"
 
+#~ msgid "Countries (RIR)"
+#~ msgstr "Państwa (RIR)"
+
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Wybór źródeł listy dozwolonych"
 
@@ -1196,9 +1199,6 @@ msgstr "ostrzeżenie"
 #~ "informacji <a href=\"https://github.com/openwrt/packages/blob/master/net/"
 #~ "banip/files/README.md\" target=\"_blank\" rel=\"noreferrer noopener\" "
 #~ ">znajduje się w dokumentacji online</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Kraje"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Zewnętrzne źródła listy dozwolonych"

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -15,157 +15,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Wybór zestawu --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr "-100 (domyślnie)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr "-150"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr "-200"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (wyłączone)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr "10 (domyślnie)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr "100"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (domyślne)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (domyślne)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (domyślne)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - obsługuje region Afryki i Oceanu Indyjskiego"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr "APNIC - obsługuje region Azji i Pacyfiku"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr "ARIN - obsługuje Kanadę i Stany Zjednoczone"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN-y"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktywne urządzenia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Aktywne źródła"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Aktywne łącze nadrzędne"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach podczas przeładowywania i "
 "uruchamiania interfejsu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr "Zezwalaj na protokół/porty"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Zezwalaj na przekazywanie VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr "Adresy URL źródeł listy dozwolonych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Tylko lista dozwolonych"
 
@@ -177,7 +81,7 @@ msgstr ""
 "Modyfikacje listy dozwolonych zostały zapisane, rozpocznij wyszukiwanie "
 "domen lub zrestartuj banIP, aby zmiany zaczęły obowiązywać."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
@@ -185,35 +89,39 @@ msgstr ""
 "Zawsze zezwalaj na protokół (tcp/udp) z określonymi portami lub zakresami "
 "portów w łańcuchu wejścia WAN i przekazywania WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Zawsze zezwalaj na przekazywanie niektórych VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Zawsze blokuj przekazywanie niektórych VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Automatycznie zezwalaj na łącze nadrzędne"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Automatyczna lista dozwolonych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Automatyczne blokowanie podsieci"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Automatyczna lista zablokowanych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automatyczne wykrywanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -221,7 +129,7 @@ msgstr ""
 "Automatycznie dodawaj całe podsieci do zestawu listy zablokowanych na "
 "podstawie dodatkowego żądania RDAP z podejrzanym adresem IP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -229,7 +137,7 @@ msgstr ""
 "Automatycznie dodawaj rozpoznane domeny i podejrzane adresy IP do lokalnej "
 "listy zablokowanych banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -237,31 +145,31 @@ msgstr ""
 "Automatycznie dodawaj rozpoznane domeny i adresy IP łącza nadrzędnego do "
 "lokalnej listy dozwolonych banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Katalog główny"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Główny katalog roboczy podczas przetwarzania banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Typ blokowania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Blokuj przekazywanie VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr "Źródło listy zablokowanych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Wygaśnięcie zestawu listy zablokowanych"
 
@@ -273,7 +181,7 @@ msgstr ""
 "Modyfikacje listy zablokowanych zostały zapisane, rozpocznij wyszukiwanie "
 "domen lub zrestartuj banIP, aby zmiany zaczęły obowiązywać."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -281,7 +189,7 @@ msgstr ""
 "Domyślnie każde źródło jest aktywne we wszystkich obsługiwanych łańcuchach. "
 "Ogranicz domyślne zasady blokowania do określonego łańcucha."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Rdzenie procesora"
 
@@ -290,14 +198,14 @@ msgstr "Rdzenie procesora"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Priorytet łańcucha"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Zmiany na tej karcie wymagają ponownego uruchomienia usługi banIP, aby "
@@ -307,7 +215,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Wyczyść źródła niestandardowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -317,11 +225,11 @@ msgid ""
 msgstr ""
 "Konfiguracja pakietu banIP w celu blokowania przychodzących i wychodzących "
 "adresów IP za pośrednictwem nazwanych zestawów nftables. Aby uzyskać więcej "
-"informacji, sprawdź <a style=\"color:#37c;font-weight:bold;\" href=\"https"
-"://github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
+"informacji, sprawdź <a style=\"color:#37c;font-weight:bold;\" href=\"https://"
+"github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
 "target=\"_blank\" rel=\"noreferrer noopener\" >dokumentację online</a>"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr "Państwa (RIR)"
 
@@ -329,7 +237,7 @@ msgstr "Państwa (RIR)"
 msgid "Custom Feed Editor"
 msgstr "Edytor źródeł niestandardowych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -337,11 +245,11 @@ msgstr ""
 "Deduplikuj adresy IP we wszystkich aktywnych zestawach i uporządkuj lokalną "
 "listę zablokowanych."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Deduplikacja adresów IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Domyślne zasady blokowania"
 
@@ -349,7 +257,7 @@ msgstr "Domyślne zasady blokowania"
 msgid "Description"
 msgstr "Opis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -357,15 +265,15 @@ msgstr ""
 "Automatycznie wykrywaj odpowiednie urządzenia sieciowe, interfejsy, "
 "podsieci, protokoły i narzędzia."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Wyłącz"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Wyszukiwanie domen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Nie sprawdzaj certyfikatów SSL serwera podczas pobierania."
 
@@ -373,23 +281,23 @@ msgstr "Nie sprawdzaj certyfikatów SSL serwera podczas pobierania."
 msgid "Download Custom Feeds"
 msgstr "Pobierz źródła niestandardowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Niezabezpieczone pobieranie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Ponowne próby pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -397,27 +305,27 @@ msgstr ""
 "Porzucaj pakiety po cichu lub aktywnie odrzucaj ruch w łańcuchach wejścia "
 "WAN i przekazywania WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Powiadomienie e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Ustawienia e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
@@ -433,7 +341,7 @@ msgstr "Edytuj listę zablokowanych"
 msgid "Edit Custom Feeds"
 msgstr "Edytuj źródła niestandardowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Liczba elementów"
 
@@ -443,49 +351,49 @@ msgstr "Elementy"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Puste pole jest niedozwolone"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Włącz zdalne rejestrowanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Włącz usługę banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "Włącz interfejs cgi, aby otrzymywać zdarzenia zdalnego rejestrowania."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "Włącz pełne rejestrowanie debugowania w przypadku błędów przetwarzania."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Włączone"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Włącza obsługę IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Włącza obsługę IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Czas wygaśnięcia automatycznie dodawanych członków zestawu listy zablokowych."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr "Zewnętrzne źródła listy dozwolonych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr "Zewnętrzne źródła listy zablokowanych"
 
@@ -493,11 +401,11 @@ msgstr "Zewnętrzne źródła listy zablokowanych"
 msgid "Feed Name"
 msgstr "Nazwa źródła"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Wybór źródeł"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr "Ustawienia źródła/zestawu"
 
@@ -517,7 +425,7 @@ msgstr "Flaga"
 msgid "Flag not supported"
 msgstr "Flaga jest nieobsługiwana"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
@@ -525,23 +433,23 @@ msgstr "Ustawienia główne"
 msgid "Grant access to LuCI app banIP"
 msgstr "Udziel dostępu do aplikacji LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Wysoki priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Najwyższy priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr "Próg ICMP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "Próg ICMP w pakietach na sekundę do zapobiegania atakom WAN-DDoS."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -553,23 +461,23 @@ msgstr "Wyszukiwanie IP"
 msgid "IP Search..."
 msgstr "Wyszukiwanie IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "Interfejsy sieciowe IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Obsługa IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "Interfejsy sieciowe IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Obsługa IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -577,12 +485,12 @@ msgstr ""
 "Zwiększ maksymalną liczbę otwartych plików, np. do obsługi liczby "
 "tymczasowych plików podzielonych podczas ładowania zestawów."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informacje"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Nieprawidłowe znaki"
 
@@ -590,7 +498,7 @@ msgstr "Nieprawidłowe znaki"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Nieprawidłowe wartości wejściowe, nie można zapisać zmian."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr "LACNIC - obsługuje region Ameryki Łacińskiej i Karaibów"
 
@@ -598,46 +506,46 @@ msgstr "LACNIC - obsługuje region Ameryki Łacińskiej i Karaibów"
 msgid "LAN-Forward (packets)"
 msgstr "Przekazywanie LAN (pakiety)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Łańcuch przekazywania LAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Najniższy priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Mniejszy priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Ogranicz niektóre źródła do łańcucha przekazywania LAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Ogranicz niektóre źródła do łańcucha przekazywania WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Ogranicz niektóre źródła do łańcucha wejścia WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 "Ogranicz liczbę rdzeni procesora używanych przez banIP, aby oszczędzać "
 "pamięć RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Ogranicz funkcję automatycznego zezwalania na łącze nadrzędne."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -645,7 +553,7 @@ msgstr ""
 "Wymień elementy zestawów w statusie i raporcie. Wyłącz tę opcję, aby "
 "zmniejszyć obciążenie procesora."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr "Lista dostępnych interfejsów wyzwalacza przeładowania."
 
@@ -653,11 +561,11 @@ msgstr "Lista dostępnych interfejsów wyzwalacza przeładowania."
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Wymień elementy określonego zestawu związanego z banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr "Ustawienia lokalnego źródła"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
@@ -665,75 +573,75 @@ msgstr ""
 "Lokalizacja do analizy pliku dziennika, np. poprzez syslog-ng, aby "
 "dezaktywować standardowe analizowanie poprzez logread."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Liczba dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Rejestrowanie przekazywania LAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Limit dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr "Wstępne trasowanie dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Ustawienia dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Warunki dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Rejestrowanie przekazywania WAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Rejestrowanie wejścia WAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr "Rejestruj podejrzane pakiety ze wstępnego trasowania."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr "Rejestruj podejrzane przekazywane pakiety LAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr "Rejestruj podejrzane przekazywazane pakiety WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr "Rejestruj podejrzane pakiety przychodzące WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "Lokalizacja pliku dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Maksymalna liczba otwartych plików"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Informacje NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "Poziom rejestrowania NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Urządzenia sieciowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Poziom nice"
 
@@ -746,11 +654,11 @@ msgstr "Brak wyników wyszukiwania!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Nie ma jeszcze dzienników zapory związanych z banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Normalny priorytet (domyślny)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -758,14 +666,14 @@ msgstr ""
 "Liczba prób pobierania w przypadku błędu (nieobsługiwane przez uclient-"
 "fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Liczba nieudanych prób logowania z tego samego adresu IP w dzienniku przed "
 "zablokowaniem."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -777,7 +685,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -794,26 +702,26 @@ msgstr "Limit portu/protokołu"
 msgid "Processing Log"
 msgstr "Dziennik przetwarzania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Profil używany przez \"msmtp\" dla wiadomości e-mail z powiadomieniem banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Format protokołu/adresu URL jest nieobsługiwany"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr "RIPE - obsługuje Europę, Bliski Wschód i Azję Środkową"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Otrzymuj powiadomienia e-mail przy każdym uruchomieniu banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -825,35 +733,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr "Regionalny Rejestr Internetowy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Przeładuj"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr "Interfejs wyzwalacza przeładowania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "Zdalny token"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Katalog raportu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Elementy raportu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Restartuj"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Ogranicz dostęp do Internetu z/do niewielkiej liczby bezpiecznych adresów IP."
@@ -871,19 +775,19 @@ msgstr "Regułav4"
 msgid "Rulev6"
 msgstr "Regułav6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Flagi uruchomieniowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informacje uruchomieniowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr "Próg SYN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "Próg SYN w pakietach na sekundę do zapobiegania atakom WAN-DDoS."
 
@@ -899,23 +803,23 @@ msgstr "Szukaj"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Przeszukaj zestawy związane z banIP dla określonego adresu IP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Wybierz jedno ze wstępnie skonfigurowanych narzędzi do pobierania."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Wybierz urządzenie(-a) sieciowe WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Wybierz logiczne interfejsy sieciowe IPv4 WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Wybierz logiczne interfejsy sieciowe IPv6 WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Adres nadawcy wiadomości e-mail z powiadomieniem banIP."
 
@@ -924,7 +828,7 @@ msgstr "Adres nadawcy wiadomości e-mail z powiadomieniem banIP."
 msgid "Set"
 msgstr "Zestaw"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Zasady zestawu"
 
@@ -932,7 +836,7 @@ msgstr "Zasady zestawu"
 msgid "Set Reporting"
 msgstr "Raportowanie zestawu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Rozmiar podziału zestawu"
 
@@ -948,7 +852,7 @@ msgstr "Badanie zestawu..."
 msgid "Set details"
 msgstr "Szczegóły zestawu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
@@ -956,53 +860,53 @@ msgstr ""
 "Ustaw priorytet łańcucha nft w tablicy banIP, niższe wartości oznaczają "
 "wyższy priorytet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Ustaw zasady nft dla zestawów związanych z banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Ustaw poziom dziennika syslog dla rejestrowania NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Podziel ładowanie zestawu zewnętrznego po każdych n członkach, aby "
 "zaoszczędzić pamięć RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Status"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Podsieć (domyślne)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Podsieć"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Badanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Informacje systemowe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr "Ustawienia tablicy/łańcucha"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Katalog docelowy dla plików raportów związanych z banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Katalog docelowy dla kopii zapasowych skompresowanych źródeł."
 
@@ -1014,7 +918,7 @@ msgstr "Lista dozwolonych jest za duża, nie można zapisać zmian."
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "Lista zablokowanych jest za duża, nie można zapisać zmian."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
@@ -1022,7 +926,7 @@ msgstr ""
 "Domyślne wyrażenia regularne filtrują podejrzany ruch ssh, LuCI, nginx i "
 "asterisk."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr "Wybrany priorytet będzie używany do przetwarzania banIP w tle."
 
@@ -1069,7 +973,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Sygnatura czasowa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1077,23 +981,23 @@ msgstr ""
 "Aby włączyć powiadomienia e-mail, skonfiguruj pakiet 'msmtp' i podaj "
 "prawidłowy adres e-mail odbiorcy."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr "Token do komunikacji z interfejsem cgi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Temat wiadomości e-mail z powiadomieniem banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr "Próg UDP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "Próg UDP w pakietach na sekundę do zapobiegania atakom WAN-DDoS."
 
@@ -1105,11 +1009,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr "Nie można przeanalizować pliku niestandardowego źródła: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr "Nie można przeanalizować pliku domyślnego źródła: %s"
 
@@ -1136,11 +1044,11 @@ msgstr "Prześlij źródła niestandardowe"
 msgid "Upload of the custom feed file failed."
 msgstr "Przesyłanie pliku źródeł niestandardowych nie powiodło się."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Wersja"
 
@@ -1148,8 +1056,8 @@ msgstr "Wersja"
 msgid "WAN-Forward (packets)"
 msgstr "Przekazywanie WAN (pakiety)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Łańcuch przekazywania WAN"
 
@@ -1157,8 +1065,8 @@ msgstr "Łańcuch przekazywania WAN"
 msgid "WAN-Input (packets)"
 msgstr "Wejście WAN (pakiety)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Łańcuch wejścia WAN"
 
@@ -1178,7 +1086,7 @@ msgstr ""
 "zapasową. Aby wrócić do wersji opiekunów, po prostu ponownie opróżnij plik "
 "źródeł niestandardowych (nie usuwaj go!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "alarm"
 
@@ -1214,73 +1122,61 @@ msgstr "zablokowane pakiety syn-flood"
 msgid "blocked udp-flood packets"
 msgstr "zablokowane pakiety udp-flood"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "krytyczny"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "debugowanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr "porzucaj (domyślnie)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "ratunkowy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "błąd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "informacyjny"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "lokalna lista dozwolonych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "lokalna lista zablokowanych"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "pamięć (domyślne)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "pamięć"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "spostrzeżenie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "wydajność"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "odrzucaj"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "ostrzeżenie (domyślne)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (domyślne)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "ostrzeżenie"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Wybór źródeł listy dozwolonych"
@@ -1390,11 +1286,8 @@ msgstr "ostrzeżenie (domyślne)"
 #~ msgid "reload"
 #~ msgstr "przeładuj"
 
-#~ msgid "restart"
-#~ msgstr "restartuj"
-
 #~ msgid "start (default)"
-#~ msgstr "uruchom (domyślne)"
+#~ msgstr "uruchom"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "Zezwalaj na przekazywanie VLAN"

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -1286,12 +1286,6 @@ msgstr "ostrzeżenie"
 #~ msgid "start (default)"
 #~ msgstr "uruchom"
 
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "Zezwalaj na przekazywanie VLAN"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Blokuj przekazywanie VLAN"
-
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
 #~ "blocklist."

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -99,7 +99,7 @@ msgstr "Zawsze blokuj przekazywanie niektórych VLAN."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Restartuj"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -96,7 +96,7 @@ msgstr "Bloquear sempre determinados encaminhamentos de VLAN."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Reiniciar"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -14,157 +14,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Definir seleção --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (desabilitar)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (padrão)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (padrão)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (padrão)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASNs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aparelhos ativos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Feeds ativos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Uplink ativo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Atraso adicional de gatilho em segundos durante a recarga e inicialização da "
 "interface."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Permitir encaminhamentos de VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Apenas a lista dos permitidos"
 
@@ -176,41 +80,45 @@ msgstr ""
 "As alterações da lista de permissões foram salvas, inicie a pesquisa de "
 "domínio ou reinicie o banIP para que as alterações entrem em vigor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Permitir sempre determinados encaminhamentos de VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Bloquear sempre determinados encaminhamentos de VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Permitir uplink automático"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Lista automática dos permitidos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Sub-rede de bloqueio automático"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Lista automática de bloqueio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Deteção automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -218,7 +126,7 @@ msgstr ""
 "Adicione automaticamente sub-redes inteiras ao conjunto da lista de bloqueio "
 "com base numa solicitação adiciona RDAP com o IP suspeito."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -226,7 +134,7 @@ msgstr ""
 "Adicione automaticamente domínios resolvidos e IPs suspeitos à lista de "
 "bloqueio local banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -234,32 +142,32 @@ msgstr ""
 "Adicione automaticamente domínios resolvidos e IPs de uplink à lista de "
 "permissões banIP local."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Diretório base"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 "Diretório principal de trabalho usado durante o processamento do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Tipo de bloco"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Bloquear encaminhamentos de VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Expiração definida da lista de bloqueio"
 
@@ -271,7 +179,7 @@ msgstr ""
 "As alterações da lista de bloqueio foram salvas, inicie a pesquisa de "
 "domínio ou reinicie o banIP para que as alterações entrem em vigor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -279,7 +187,7 @@ msgstr ""
 "Por padrão, cada feed está ativo em todas as cadeias suportadas. Limite a "
 "política de bloqueio padrão a uma determinada cadeia."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Núcleos da CPU"
 
@@ -288,14 +196,14 @@ msgstr "Núcleos da CPU"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Prioridade da cadeia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "As alterações nesta guia precisam de uma reinicialização do serviço banIP "
@@ -305,7 +213,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Limpar feeds personalizados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -314,7 +222,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -322,7 +230,7 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Editor de feed personalizado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -330,11 +238,11 @@ msgstr ""
 "Elimine endereços IP em todos os conjuntos ativos e limpe a lista local de "
 "bloqueio."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Eliminar IPs duplicados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Política de bloqueio padrão"
 
@@ -342,7 +250,7 @@ msgstr "Política de bloqueio padrão"
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -350,15 +258,15 @@ msgstr ""
 "Detecte os aparelhos relevantes de rede, as interfaces, as sub-redes, os "
 "protocolos e os utilitários automaticamente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Desativar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Busca por domínio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Não verificar os certificados de SSL do servidor durante a descarrega."
 
@@ -366,23 +274,23 @@ msgstr "Não verificar os certificados de SSL do servidor durante a descarrega."
 msgid "Download Custom Feeds"
 msgstr "Baixar feeds personalizados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Descarregar inseguro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Parâmetros de Descarregamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Novas tentativas de download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -390,27 +298,27 @@ msgstr ""
 "Descartar pacotes silenciosamente ou rejeitar ativamente o tráfego nas "
 "cadeias WAN-Input e WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Configurações do e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
@@ -426,7 +334,7 @@ msgstr "Editar a lista de bloqueio"
 msgid "Edit Custom Feeds"
 msgstr "Editar feeds personalizados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Contagem dos elementos"
 
@@ -436,50 +344,50 @@ msgstr "Elementos"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Campo vazio não permitido"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Ativar o registo remoto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Ative o serviço banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "Ativar a interface cgi para receber eventos de registo remotos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "Ative o registo de depuração detalhado em caso de erros de processamento."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Ativa o suporte IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Ativa o suporte IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Tempo de expiração para membros do conjunto de lista de bloqueio adicionados "
 "automaticamente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -487,11 +395,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Nome do feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Seleção do feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -511,7 +419,7 @@ msgstr "Bandeira"
 msgid "Flag not supported"
 msgstr "Bandeira não suportada"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -519,23 +427,23 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app banIP"
 msgstr "Conceda acesso à app LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Alta prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Máxima Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -547,23 +455,23 @@ msgstr "Busca IP"
 msgid "IP Search..."
 msgstr "Busca IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "Interfaces de rede IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Suporte ao IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "Interfaces de rede IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Suporte de IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -572,12 +480,12 @@ msgstr ""
 "quantidade de arquivos divididos temporários durante o carregamento dos "
 "conjuntos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informação"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Caracteres inválidos"
 
@@ -585,7 +493,7 @@ msgstr "Caracteres inválidos"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Valores de entrada inválidos, não é possível salvar as modificações."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -593,45 +501,45 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (pacotes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Cadeia LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Mínima Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Menor Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Limite certos feeds à cadeia LAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Limite certos feeds à cadeia WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Limite certos feeds à cadeia WAN-Input."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 "Limite a quantidade dos núcleos da CPU usados pelo banIP para economizar RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Limite a função de permissão automática de uplink."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -639,7 +547,7 @@ msgstr ""
 "Relate e liste o conjunto dos elementos na condição geral, desative-o para "
 "reduzir a carga da CPU."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr "Lista de interface de gatilho de recarga disponível(s)."
 
@@ -647,11 +555,11 @@ msgstr "Lista de interface de gatilho de recarga disponível(s)."
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Liste os elementos de um conjunto específico relacionado ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
@@ -659,75 +567,75 @@ msgstr ""
 "Localização para analisar o ficheiro de registo, por exemplo, via syslog-ng, "
 "para desativar a análise padrão via logread."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Contagem dos registos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Registo LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Limite do Registo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Configurações do registo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Termos do registo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Registo WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Registo WAN-Input"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "Localização do ficheiro de registo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Quantidade máxima de ficheiros abertos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Informação NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "Nível de registos NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Dispositivos de rede"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Nível de Nice"
 
@@ -740,11 +648,11 @@ msgstr "A busca não retornou nada!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Ainda não há registos do firewall relacionados ao banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Prioridade Normal (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Prioridade Normal"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -752,14 +660,14 @@ msgstr ""
 "Número de tentativas de download em caso de erro (não suportado pelo uclient-"
 "fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Quantidade de tentativas de login com falha do mesmo IP no registo antes do "
 "bloqueio."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -771,7 +679,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -787,25 +695,25 @@ msgstr "Limite de Porto/Protocolo"
 msgid "Processing Log"
 msgstr "Registo de processamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "O perfil usado pelo 'msmtp' para os e-mails de notificação do banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Formato de protocolo/URL não suportado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Receba notificações por e-mail a cada execução do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -817,35 +725,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Recarregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr "Recarregar a interface do gatilho"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "Token remoto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Elementos do relatório"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Restrinja o acesso à Internet de/para uma pequena quantidade de IPs seguros."
@@ -863,19 +767,19 @@ msgstr "Rulev4"
 msgid "Rulev6"
 msgstr "Rulev6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Flags de Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informações de Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -891,23 +795,23 @@ msgstr "Busca"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Faça a busca de um IP específico nos conjuntos relacionados ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Selecione um dos utilitários de descarga pré-configurados."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Selecione o(s) aparelho(s) da rede WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Selecione a(s) interface(s) lógica(s) da rede WAN IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Selecione a(s) interface(s) lógica(s) da rede WAN IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Endereço do remetente para os e-mails de notificação do banIP."
 
@@ -916,7 +820,7 @@ msgstr "Endereço do remetente para os e-mails de notificação do banIP."
 msgid "Set"
 msgstr "Definir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Definir a política"
 
@@ -924,7 +828,7 @@ msgstr "Definir a política"
 msgid "Set Reporting"
 msgstr "Definir o relatório"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Definir o tamanho da divisão"
 
@@ -940,60 +844,60 @@ msgstr "Definir a pesquisa..."
 msgid "Set details"
 msgstr "Definir os detalhes"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Defina a política nft para conjuntos relacionados ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Define o nível do syslog para os registos NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Divide o carregamento do conjunto externo após cada n membros para "
 "economizar RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Estado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Parar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Sub-rede (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Sub-rede"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Pesquisa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Informação do sistema"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 "Diretório de destino para os ficheiros do relatório relacionados ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Diretório de destino para os backups comprimidos do feed."
 
@@ -1007,13 +911,13 @@ msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 "A lista de bloqueio é grande demais, não é possível salvar as alterações."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "A prioridade selecionada será usada pelo banIP para o processamento em "
@@ -1062,7 +966,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Marca de Tempo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1070,23 +974,23 @@ msgstr ""
 "Para ativar as notificações por e-mail, configure o pacote 'msmtp' e "
 "especifique um endereço de e-mail com um destinatário válido."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr "Token para comunicar com a interface cgi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Tópico para e-mails de notificação do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1098,11 +1002,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1129,11 +1037,11 @@ msgstr "Enviar os feeds personalizados"
 msgid "Upload of the custom feed file failed."
 msgstr "O upload do ficheiro com os feeds personalizados falhou."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versão"
 
@@ -1141,8 +1049,8 @@ msgstr "Versão"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (pacotes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Cadeia WAN-Forward"
 
@@ -1150,8 +1058,8 @@ msgstr "Cadeia WAN-Forward"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Input (pacotes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Cadeia WAN-Input"
 
@@ -1171,7 +1079,7 @@ msgstr ""
 "local. Para voltar à versão do mantenedor, apenas deixe o ficheiro de feed "
 "personalizado vazio (mas não o exclua!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "alerta"
 
@@ -1207,73 +1115,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "crítico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "detalhado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
-msgstr "descartar (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
+msgstr "descartar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "urgente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "erro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "lista dos permitidos local"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "lista de bloqueio local"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "memória (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "memória"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "aviso"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "desempenho"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "rejeitar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "alertar (padrão)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (padrão)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "alertar"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Seleção de feed da lista de permissões"
@@ -1383,11 +1279,8 @@ msgstr "alertar (padrão)"
 #~ msgid "reload"
 #~ msgstr "recarregar"
 
-#~ msgid "restart"
-#~ msgstr "reiniciar"
-
 #~ msgid "start (default)"
-#~ msgstr "iniciar (padrão)"
+#~ msgstr "iniciar"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "Permitir encaminhamentos de VLAN"

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -1276,12 +1276,6 @@ msgstr "alertar"
 #~ msgid "start (default)"
 #~ msgstr "iniciar"
 
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "Permitir encaminhamentos de VLAN"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Bloquear encaminhamentos de VLAN"
-
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
 #~ "blocklist."

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -219,8 +219,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Países"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1189,9 +1189,6 @@ msgstr "alertar"
 #~ "github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
 #~ "target=\"_blank\" rel=\"noreferrer noopener\" >verifique a documentação "
 #~ "on-line</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Países"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Feeds externos de lista de permissões"

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Definir seleção --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (desabilitar)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -258,6 +254,7 @@ msgstr ""
 "Detecte os aparelhos relevantes de rede, as interfaces, as sub-redes, os "
 "protocolos e os utilitários automaticamente."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Desativar"

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -433,11 +433,11 @@ msgid "Highest Priority"
 msgstr "Máxima Prioridade"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -773,11 +773,11 @@ msgid "Run Information"
 msgstr "Informações de Execução"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -984,11 +984,11 @@ msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -219,8 +219,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Países"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1186,9 +1186,6 @@ msgstr "alertar"
 #~ "href=\"https://github.com/openwrt/packages/blob/master/net/banip/files/"
 #~ "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" > consulte a "
 #~ "documentação online </a>"
-
-#~ msgid "Countries"
-#~ msgstr "Países"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Feeds externos da lista dos permitidos"

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -157,7 +157,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
-msgstr ""
+msgstr "Bloquear os encaminhamentos da VLAN"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
@@ -1272,12 +1272,6 @@ msgstr "alertar"
 
 #~ msgid "start (default)"
 #~ msgstr "iniciar"
-
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "Permitir encaminhamentos da VLAN"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Bloquear os encaminhamentos da VLAN"
 
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -431,11 +431,11 @@ msgid "Highest Priority"
 msgstr "Máxima Prioridade"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -770,11 +770,11 @@ msgid "Run Information"
 msgstr "Informações de Execução"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -981,11 +981,11 @@ msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -14,157 +14,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Definir seleção --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (desativar)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (padrão)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (padrão)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (padrão)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASNs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Dispositivos Ativos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Feeds ativos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Enlace ativo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Atraso adicional de gatilho em segundos durante a recarga e inicialização da "
 "interface."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Permitir encaminhamentos de VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Apenas a lista dos permitidos"
 
@@ -176,41 +80,45 @@ msgstr ""
 "As alterações da lista de permissões foram salvas, inicie a pesquisa de "
 "domínio ou reinicie o banIP para que as alterações entrem em vigor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Sempre permita certos encaminhamentos da VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Sempre negue certos encaminhamentos da VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Permite o enlace automático"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Lista automática dos permitidos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Sub-rede de bloqueio automático"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Lista automática de bloqueio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Detecção Automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -218,7 +126,7 @@ msgstr ""
 "Adicione automaticamente sub-redes inteiras ao conjunto da lista de bloqueio "
 "com base numa solicitação adiciona RDAP com o IP suspeito."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -226,7 +134,7 @@ msgstr ""
 "Adicione automaticamente os domínios resolvidos e os IPs suspeitos à lista "
 "de bloqueio local do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -234,32 +142,32 @@ msgstr ""
 "Adicione automaticamente os domínios resolvidos e os IPs do enlace à lista "
 "de permissões locais do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Diretório base"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 "Diretório principal de trabalho usado durante o processamento do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Expiração do conjunto das listas de bloqueio"
 
@@ -271,7 +179,7 @@ msgstr ""
 "As alterações da lista de bloqueio foram salvas, inicie a pesquisa de "
 "domínio ou reinicie o banIP para que as alterações entrem em vigor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -279,7 +187,7 @@ msgstr ""
 "Por padrão, cada feed está ativo em todas as cadeias suportadas. Limite a "
 "política de bloqueio padrão a uma determinada cadeia."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Núcleos da CPU"
 
@@ -288,14 +196,14 @@ msgstr "Núcleos da CPU"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Prioridade da cadeia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "As alterações nesta guia precisam de uma reinicialização do serviço banIP "
@@ -305,7 +213,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Limpar os feeds personalizados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -314,7 +222,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -322,7 +230,7 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Editor do feed personalizado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -330,11 +238,11 @@ msgstr ""
 "Elimine endereços IP em todos os conjuntos ativos e limpe a lista local de "
 "bloqueio."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Eliminar IPs duplicados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Política de bloqueio padrão"
 
@@ -342,7 +250,7 @@ msgstr "Política de bloqueio padrão"
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -350,15 +258,15 @@ msgstr ""
 "Detecte os dispositivos relevantes de rede, as interfaces, as sub-redes, os "
 "protocolos e os utilitários automaticamente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Desativar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Busca por domínio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Não verifique os certificados do servidor SSL durante o download."
 
@@ -366,49 +274,49 @@ msgstr "Não verifique os certificados do servidor SSL durante o download."
 msgid "Download Custom Feeds"
 msgstr "Baixar feeds personalizados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Download inseguro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Tentativas de download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Configurações do e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -424,7 +332,7 @@ msgstr "Editar a lista de bloqueio"
 msgid "Edit Custom Feeds"
 msgstr "Editar os feeds personalizados"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Contagem dos elementos"
 
@@ -434,50 +342,50 @@ msgstr "Elementos"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Campo vazio não permitido"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Ative o serviço banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "Ative o registro de depuração detalhado em caso de erros de processamento."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Ativa o suporte IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Ativa o suporte IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Tempo de expiração para os membros do conjunto da lista de bloqueio que "
 "foram adicionados automaticamente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -485,11 +393,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Nome do feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Seleção do feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -509,7 +417,7 @@ msgstr "Sinalizador"
 msgid "Flag not supported"
 msgstr "Sinalizador não suportado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -517,23 +425,23 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app banIP"
 msgstr "Conceda acesso ao aplicativo LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Alta prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Máxima Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -545,23 +453,23 @@ msgstr "Busca IP"
 msgid "IP Search..."
 msgstr "Busca IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Suporte ao IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Suporte ao IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -570,12 +478,12 @@ msgstr ""
 "quantidade temporária de arquivos divididos durante o carregamento dos "
 "conjuntos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informações"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Caracteres inválidos"
 
@@ -583,7 +491,7 @@ msgstr "Caracteres inválidos"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Valores inválidos da entrada, não é possível salvar as alterações."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -591,45 +499,45 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (pacotes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Cadeia LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Mínima Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Menor Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Limite certos feeds à cadeia LAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Limite certos feeds à cadeia WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Limite certos feeds à cadeia WAN-Input."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 "Limite a quantidade dos núcleos da CPU usados pelo banIP para economizar RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Limite a função de permissão automática do enlace."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -637,7 +545,7 @@ msgstr ""
 "Relate e liste o conjunto dos elementos na condição geral, desabilite-o para "
 "reduzir a carga da CPU."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -645,85 +553,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Liste os elementos de um conjunto específico relacionado ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Contagem dos registros"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Registro LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Limite do Registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Configurações do registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Termos do registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Registro WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Registro WAN-Input"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Quantidade máxima de arquivos abertos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Informação NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Dispositivos de rede"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Nível bom"
 
@@ -736,11 +644,11 @@ msgstr "A busca não retornou nada!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Ainda não há registros do firewall relacionados ao banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Prioridade Normal (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Prioridade Normal"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -748,14 +656,14 @@ msgstr ""
 "Quantidade de tentativas de download em caso de erro (não suportado pelo "
 "uclient-fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Quantidade de tentativas de login com falha do mesmo IP no registro antes do "
 "bloqueio."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -767,7 +675,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -784,25 +692,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr "Registro de processamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "O perfil usado pelo 'msmtp' para os e-mails de notificação do banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Formato de protocolo/URL não suportado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Receba notificações por e-mail a cada execução do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -814,35 +722,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Recarregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Elementos do relatório"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Reiniciar"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Restrinja o acesso à Internet de/para uma pequena quantidade de IPs seguros."
@@ -860,19 +764,19 @@ msgstr "Rulev4"
 msgid "Rulev6"
 msgstr "Rulev6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Executar Flags"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informações de Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -888,23 +792,23 @@ msgstr "Busca"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Faça a busca de um IP específico nos conjuntos relacionados ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Selecione um dos utilitários de download pré-configurados."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Selecione o(s) dispositivo(s) da rede WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Selecione a(s) interface(s) lógica(s) da rede WAN IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Selecione a(s) interface(s) lógica(s) da rede WAN IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Endereço do remetente para os e-mails de notificação do banIP."
 
@@ -913,7 +817,7 @@ msgstr "Endereço do remetente para os e-mails de notificação do banIP."
 msgid "Set"
 msgstr "Definir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Definir a política"
 
@@ -921,7 +825,7 @@ msgstr "Definir a política"
 msgid "Set Reporting"
 msgstr "Definir o relatório"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Definir o tamanho da divisão"
 
@@ -937,60 +841,60 @@ msgstr "Definir a pesquisa..."
 msgid "Set details"
 msgstr "Definir os detalhes"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Defina a política NFT para os conjuntos relacionados ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Define o nível do syslog para os registros NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Divide o carregamento do conjunto externo após cada n membros para "
 "economizar RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Status"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Parar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Sub-rede (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Sub-rede"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Pesquisa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Informação do sistema"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 "Diretório de destino para os arquivos do relatório relacionados ao banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Diretório de destino para os backups comprimidos do feed."
 
@@ -1004,13 +908,13 @@ msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 "A lista de bloqueio é grande demais, não é possível salvar as alterações."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "A prioridade selecionada será usada pelo banIP para o processamento em "
@@ -1059,7 +963,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Marca de Tempo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1067,23 +971,23 @@ msgstr ""
 "Para ativar as notificações por e-mail, configure o pacote 'msmtp' e "
 "especifique um endereço de e-mail com um destinatário válido."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Tópico para e-mails de notificação do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1095,11 +999,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1126,11 +1034,11 @@ msgstr "Fazer upload dos feeds personalizados"
 msgid "Upload of the custom feed file failed."
 msgstr "O upload do arquivo com os feeds personalizados falhou."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versão"
 
@@ -1138,8 +1046,8 @@ msgstr "Versão"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (pacotes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Cadeia WAN-Forward"
 
@@ -1147,8 +1055,8 @@ msgstr "Cadeia WAN-Forward"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Input (pacotes)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Cadeia WAN-Input"
 
@@ -1168,7 +1076,7 @@ msgstr ""
 "um backup local. Para voltar para a versão do mantenedor, apenas deixe o "
 "arquivo de feed personalizado vazio (mas não o exclua!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "alerta"
 
@@ -1204,73 +1112,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "crítico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "detalhado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "urgente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "erro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "lista dos permitidos local"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "lista de bloqueio local"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "memória (padrão)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "memória"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "aviso"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "desempenho"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "alertar (padrão)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (padrão)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "alertar"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Seleção do feed da lista dos permitidos"
@@ -1380,11 +1276,8 @@ msgstr "alertar (padrão)"
 #~ msgid "reload"
 #~ msgstr "recarregar"
 
-#~ msgid "restart"
-#~ msgstr "reiniciar"
-
 #~ msgid "start (default)"
-#~ msgstr "iniciar (padrão)"
+#~ msgstr "iniciar"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "Permitir encaminhamentos da VLAN"
@@ -1550,7 +1443,7 @@ msgstr "alertar (padrão)"
 #~ msgstr "Impossível salvar as modificações: %s"
 
 #~ msgid "-m limit --limit 2/sec (default)"
-#~ msgstr "-m limit --limit 2/seg (padrão)"
+#~ msgstr "-m limit --limit 2/seg"
 
 #~ msgid "1 hour"
 #~ msgstr "1 hora"

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -96,7 +96,7 @@ msgstr "Sempre negue certos encaminhamentos da VLAN."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Reiniciar"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Definir seleção --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (desativar)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -258,6 +254,7 @@ msgstr ""
 "Detecte os dispositivos relevantes de rede, as interfaces, as sub-redes, os "
 "protocolos e os utilitários automaticamente."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Desativar"

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -219,8 +219,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Țări"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1180,9 +1180,6 @@ msgstr "avertisment"
 #~ "suplimentare <a href=\"https://github.com/openwrt/packages/blob/master/"
 #~ "net/banip/files/README.md\" target=\"_blank\" rel=\"noreferrer noopener\" "
 #~ ">check the online documentation</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Țări"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Fluxuri allowlist externe"

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Selecția setului --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (dezactivare)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -258,6 +254,7 @@ msgstr ""
 "Detectarea automată a dispozitivelor de rețea, interfețelor, subrețelelor, "
 "protocoalelor și utilităților relevante."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Dezactivați"

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -15,157 +15,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Selecția setului --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (dezactivare)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (implicit)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (implicit)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (implicit)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN-uri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Dispozitive active"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Fluxuri active"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Uplink activ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Întârziere suplimentară de declanșare în secunde în timpul reîncărcării și "
 "pornirii interfeței."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Setări avansate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Permiteți redirecționarea VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Doar Allowlist"
 
@@ -177,41 +81,45 @@ msgstr ""
 "Lista cu modificările permise au fost salvate, porniți căutarea domeniului "
 "sau reporniți banIP pentru ca modificările să intre în vigoare."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Permiteți întotdeauna anumite transmisiuni VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Blocați întotdeauna anumite transmisiuni VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Permite automat legătura ascendentă"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Allowlist Automată"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Blocaj automat Subnet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Lista de blocare automată"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Detecție automată"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -219,7 +127,7 @@ msgstr ""
 "Adăugați automat subrețele întregi la lista de blocare Set bazat pe o cerere "
 "RDAP suplimentară cu IP-ul suspect."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -227,7 +135,7 @@ msgstr ""
 "Adăugarea automată a domeniilor rezolvate și a IP-urilor suspecte la lista "
 "de blocare banIP locală."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -235,31 +143,31 @@ msgstr ""
 "Adăugați automat domeniile rezolvate și IP-urile de legătură ascendentă la "
 "lista de permise banIP locală."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Director de bază"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Directorul de lucru de bază în timpul procesării banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Tip de bloc"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Blocați transmisiile VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Expirarea setului Blocklist"
 
@@ -271,7 +179,7 @@ msgstr ""
 "Modificările cu lista de blocare au fost salvate, porniți căutarea "
 "domeniului sau reporniți banIP-ul, iar modificările intră în vigoare."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -279,7 +187,7 @@ msgstr ""
 "În mod implicit, fiecare alimentare este activă în toate lanțurile "
 "acceptate. Limitați politica de blocare implicită la un anumit lanț."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Nuclee CPU"
 
@@ -288,14 +196,14 @@ msgstr "Nuclee CPU"
 msgid "Cancel"
 msgstr "Anulare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Prioritatea Chain"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Modificările din această filă necesită o repornire a serviciului banIP "
@@ -305,7 +213,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Ștergeți fluxurile personalizate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -314,7 +222,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -322,7 +230,7 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Editor de fluxuri personalizate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -330,11 +238,11 @@ msgstr ""
 "Deduplicați adresele IP în toate seturile active și faceți ordine în lista "
 "de blocuri locale."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Deduplicați IP-uri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Politica de blocare implicită"
 
@@ -342,7 +250,7 @@ msgstr "Politica de blocare implicită"
 msgid "Description"
 msgstr "Descriere"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -350,15 +258,15 @@ msgstr ""
 "Detectarea automată a dispozitivelor de rețea, interfețelor, subrețelelor, "
 "protocoalelor și utilităților relevante."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Dezactivați"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Căutare domeniu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Nu verificați certificatele serverului SSL în timpul descărcării."
 
@@ -366,49 +274,49 @@ msgstr "Nu verificați certificatele serverului SSL în timpul descărcării."
 msgid "Download Custom Feeds"
 msgstr "Descărcați fluxuri personalizate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Descărcați Insecure"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Parametrii de descărcare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Descărcați Reîncercări"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Notificare prin e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Profil de e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Adresa de e-mail a destinatarului"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Adresa expeditorului de e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Setări e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -424,7 +332,7 @@ msgstr "Editarea listei de blocuri"
 msgid "Edit Custom Feeds"
 msgstr "Editați fluxurile personalizate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Număr de elemente"
 
@@ -434,48 +342,48 @@ msgstr "Elemente"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Câmpul gol nu este permis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Activați serviciul banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "Activați înregistrarea verbală a depanării în caz de erori de procesare."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "activat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Activează suportul IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Activează suportul IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr "Timpul de expirare pentru membrii setului blocklist adăugat automat."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -483,11 +391,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Denumirea furajului"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Selecția Feed"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -507,7 +415,7 @@ msgstr "Indicator"
 msgid "Flag not supported"
 msgstr "Indicator neacceptat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Setări generale"
 
@@ -515,23 +423,23 @@ msgstr "Setări generale"
 msgid "Grant access to LuCI app banIP"
 msgstr "Acordarea accesului la aplicația LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Prioritate ridicată"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Cea mai mare prioritate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -543,23 +451,23 @@ msgstr "Căutare IP"
 msgid "IP Search..."
 msgstr "Căutare IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Suport IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Suport IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -567,12 +475,12 @@ msgstr ""
 "Creșteți numărul maxim de fișiere deschise, de exemplu, pentru a gestiona "
 "numărul de fișiere divizate temporar în timpul încărcării seturilor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Informație"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Caractere invalide"
 
@@ -580,7 +488,7 @@ msgstr "Caractere invalide"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Valori de intrare nevalabile, nu se pot salva modificările."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -588,44 +496,44 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (pachete)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Chain LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Ultima rulare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Cea mai mică prioritate"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Prioritate mai mică"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Limitați anumite fluxuri la lanțul LAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Limitați anumite fluxuri la lanțul WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Limitarea anumitor fluxuri în lanțul WAN-Input."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "Limitați nucleele CPU utilizate de banIP pentru a economisi RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Limitați funcția uplink autoallow."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -633,7 +541,7 @@ msgstr ""
 "Listă Set de elemente în stare și raport, dezactivați acest lucru pentru a "
 "reduce sarcina CPU."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -641,85 +549,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Enumeră elementele unui anumit set legat de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Număr de jurnale"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Jurnalul LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Limita de jurnal"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Setări jurnal"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Termeni de jurnal"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Jurnal WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Jurnal WAN-Input"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Maxim de fișiere deschise"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Informații NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Dispozitive de rețea"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Nivel Bun"
 
@@ -732,11 +640,11 @@ msgstr "Nu există rezultate de căutare!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Nu există încă jurnale de firewall legate de banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr "Prioritate normală (implicită)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -744,14 +652,14 @@ msgstr ""
 "Numărul de încercări de descărcare în caz de eroare (nu este suportat de "
 "uclient-fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Numărul de încercări de conectare eșuate ale aceluiași IP din jurnal înainte "
 "de blocare."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -763,7 +671,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -779,26 +687,26 @@ msgstr ""
 msgid "Processing Log"
 msgstr "Jurnal de procesare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Profilul utilizat de 'msmtp' pentru mesajele electronice de notificare banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Formatul protocolului/URL nu este acceptat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Primiți notificări prin e-mail la fiecare banIP rulat."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -810,35 +718,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Reîncărcați"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Director de rapoarte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Elemente de raport"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Reporniți"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Restricționați accesul la internet de la/către un număr mic de IP-uri "
@@ -857,19 +761,19 @@ msgstr "Rulev4"
 msgid "Rulev6"
 msgstr "Rulev6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Fixați indicatoarele"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Informații despre cursă"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -885,23 +789,23 @@ msgstr "Căutați"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Căutați un anumit IP în seturile legate de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Selectați unul dintre utilitățile de descărcare preconfigurate."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Selectați dispozitivul (dispozitivele) de rețea WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Selectați interfața (interfețele) logică (logice) de rețea WAN IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Selectați interfața (e) logică de rețea WAN IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Adresa expeditorului pentru e-mailurile de notificare banIP."
 
@@ -910,7 +814,7 @@ msgstr "Adresa expeditorului pentru e-mailurile de notificare banIP."
 msgid "Set"
 msgstr "Setați"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Stabilirea politicii"
 
@@ -918,7 +822,7 @@ msgstr "Stabilirea politicii"
 msgid "Set Reporting"
 msgstr "Set raportare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Setați Dimensiunea Divizată"
 
@@ -934,59 +838,59 @@ msgstr "Setați Survey..."
 msgid "Set details"
 msgstr "Setați detaliile"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Setați politica nft pentru seturile legate de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Setați nivelul syslog pentru jurnalizarea NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Setări"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Împărțiți încărcarea setului extern după fiecare n membri pentru a economisi "
 "RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Stare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Stop"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Subnet (implicit)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Subnet"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Sondaj"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Informații de sistem"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Directorul țintă pentru fișierele de raportare referitoare la banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Directorul țintă pentru copiile de rezervă ale fluxurilor comprimate."
 
@@ -998,13 +902,13 @@ msgstr "Lista de permise este prea mare, nu se pot salva modificările."
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "Lista de blocuri este prea mare, nu se pot salva modificările."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 "Prioritatea selectată va fi utilizată pentru procesarea în fundal a banIP."
@@ -1052,7 +956,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Înregistrarea timpului"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1060,23 +964,23 @@ msgstr ""
 "Pentru a activa notificările prin e-mail, configurați pachetul \"msmtp\" și "
 "specificați o adresă de destinatar de e-mail validă."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Subiect pentru e-mailurile de notificare banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1088,11 +992,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1119,11 +1027,11 @@ msgstr "Încărcați fluxuri personalizate"
 msgid "Upload of the custom feed file failed."
 msgstr "Încărcarea fișierului de feed personalizat a eșuat."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Jurnalizare Verbală de Depanare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versiune"
 
@@ -1131,8 +1039,8 @@ msgstr "Versiune"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (pachete)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Chain WAN-Forward"
 
@@ -1140,8 +1048,8 @@ msgstr "Chain WAN-Forward"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Input (pachete)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Chain WAN-Input"
 
@@ -1162,7 +1070,7 @@ msgstr ""
 "întreținere, doar goliți din nou fișierul de feed-uri personalizate (nu îl "
 "ștergeți!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "alertă"
 
@@ -1198,73 +1106,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "critic"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "depanare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "urgență"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "eroare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "informații"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "lista locală de permise"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "lista de blocare locală"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "memorie (implicit)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "memorie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "notificare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "performanță"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "avertisment (implicit)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (implicit)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "avertisment"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Selecție Allowlist Feed"
@@ -1374,11 +1270,8 @@ msgstr "avertisment (implicit)"
 #~ msgid "reload"
 #~ msgstr "reîncărcare"
 
-#~ msgid "restart"
-#~ msgstr "reporniți"
-
 #~ msgid "start (default)"
-#~ msgstr "start (implicit)"
+#~ msgstr "start"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "Permiteți VLAN Forwads"

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -1267,12 +1267,6 @@ msgstr "avertisment"
 #~ msgid "start (default)"
 #~ msgstr "start"
 
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "Permiteți VLAN Forwads"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Blocare VLAN Forwads"
-
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
 #~ "blocklist."

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -429,11 +429,11 @@ msgid "Highest Priority"
 msgstr "Cea mai mare prioritate"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -767,11 +767,11 @@ msgid "Run Information"
 msgstr "Informații despre cursă"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -974,11 +974,11 @@ msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -97,7 +97,7 @@ msgstr "Blocați întotdeauna anumite transmisiuni VLAN."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Reporniți"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -438,11 +438,11 @@ msgid "Highest Priority"
 msgstr "Наивысший приоритет"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr "ICMP-порог"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "ICMP - порог в пакетах в секунду для предотвращения WAN-DDoS-атак."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -780,11 +780,11 @@ msgid "Run Information"
 msgstr "Информация о запуске"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr "SYN-порог"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "SYN-порог в пакетах в секунду для предотвращения WAN-DDoS-атак."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -990,11 +990,11 @@ msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr "UDP-порог"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "UDP-порог в пакетах в секунду для предотвращения WAN-DDoS-атак."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -99,7 +99,7 @@ msgstr "Всегда блокировать определенные переа�
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Применить и перезапустить"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -15,157 +15,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Выберите набор --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr "-100 (по умолчанию)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr "-150"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr "-200"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (отключить)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr "10 (по умолчанию)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr "100"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (по умолчанию)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (по умолчанию)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (по умолчанию)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - обслуживание Африки и региона Индийского океана"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr "APNIC - обслуживание Азиатско-Тихоокеанского региона"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr "ARIN - обслуживание Канады и США"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "Автономные системы"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Активные устройства"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Активные каналы"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Активный аплинк"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Дополнительная задержка срабатывания в секундах при перезагрузке и загрузке "
 "интерфейса."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr "Разрешить протокол/порты"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "Разрешить переадресацию VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr "Разрешенные URL-адреса каналов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Только список разрешений"
 
@@ -177,7 +81,7 @@ msgstr ""
 "Изменения в списке Allowlist были сохранены, запустите программу Domain "
 "Lookup или перезапустите banIP, чтобы изменения вступили в силу."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
@@ -185,35 +89,39 @@ msgstr ""
 "Всегда разрешать протокол (tcp/udp) с определенными портами или диапазонами "
 "портов в цепочке WAN-Input и WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Всегда разрешать определенные переадресации VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Всегда блокировать определенные переадресации VLAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Автоматически разрешать исходящие соединения"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Автоматический список разрешений"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Автоблокировка подсети"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Автоматический блок-лист"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Автоопределение"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -221,7 +129,7 @@ msgstr ""
 "Автоматическое добавление целых подсетей в список блокировки Set на основе "
 "дополнительного запроса RDAP с подозрительным IP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -229,7 +137,7 @@ msgstr ""
 "Автоматическое добавление разрешенных доменов и подозрительных IP-адресов в "
 "локальный блок-лист banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -237,31 +145,31 @@ msgstr ""
 "Автоматическое добавление разрешенных доменов и IP-адресов исходящих "
 "соединений в локальный список разрешений banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Базовый каталог"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Базовый рабочий каталог при обработке banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Тип блока"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Блокировка переадресации VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr "Источник блок-листа"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Задать срок действия блок-листа"
 
@@ -273,7 +181,7 @@ msgstr ""
 "Изменения в блок-листе были сохранены, запустите программу Domain Lookup или "
 "перезапустите banIP, чтобы изменения вступили в силу."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -281,7 +189,7 @@ msgstr ""
 "По умолчанию каждый канал активен во всех поддерживаемых цепочках. "
 "Ограничьте политику блоков по умолчанию определенной цепочкой."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Ядра ЦП"
 
@@ -290,14 +198,14 @@ msgstr "Ядра ЦП"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Приоритет цепочки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Для вступления в силу изменений на этой вкладке требуется перезапуск службы "
@@ -307,7 +215,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Очистить пользовательские каналы"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -321,7 +229,7 @@ msgstr ""
 "://github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
 "target=\"_blank\" rel=\"noreferrer noopener\" >онлайн-документацией</a>"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr "Страны (RIR)"
 
@@ -329,7 +237,7 @@ msgstr "Страны (RIR)"
 msgid "Custom Feed Editor"
 msgstr "Пользовательский редактор каналов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -337,11 +245,11 @@ msgstr ""
 "Исключите дублирование IP-адресов во всех активных наборах и приведите в "
 "порядок локальный список блокировки."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Дублирование IP-адресов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Политика блокировки по умолчанию"
 
@@ -349,7 +257,7 @@ msgstr "Политика блокировки по умолчанию"
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -357,15 +265,15 @@ msgstr ""
 "Автоматическое обнаружение соответствующих сетевых устройств, интерфейсов, "
 "подсетей, протоколов и утилит."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Отключить"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Поиск домена"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Не проверять SSL сертификаты сервера во время загрузки."
 
@@ -373,23 +281,23 @@ msgstr "Не проверять SSL сертификаты сервера во �
 msgid "Download Custom Feeds"
 msgstr "Скачать пользовательские каналы"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Небезопасная загрузка"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Параметры загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Попытки загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Утилита для загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -397,27 +305,27 @@ msgstr ""
 "Тихо отбрасывать пакеты или активно отклонять трафик в цепочках WAN-Input и "
 "WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Уведомление по электронной почте"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Адрес отправителя"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Настройки электронной почты"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -433,7 +341,7 @@ msgstr "Редактировать черный список"
 msgid "Edit Custom Feeds"
 msgstr "Редактировать пользовательские каналы"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Количество элементов"
 
@@ -443,48 +351,48 @@ msgstr "Элементы"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Пустое поле не допускается"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Включить удаленное ведение журнала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Включить сервис banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "Включите интерфейс cgi для получения удаленных событий."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "Включите ведение подробного журнала отладки в случае ошибок обработки."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Включено"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Включает поддержку IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Включает поддержку IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Срок действия для автоматически добавленных блоклистов Задать участников."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr "Внешние каналы разрешенных список"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr "Внешние каналы запрещенных списков"
 
@@ -492,11 +400,11 @@ msgstr "Внешние каналы запрещенных списков"
 msgid "Feed Name"
 msgstr "Название канала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Выбор канала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr "Настройки каналов/сетов"
 
@@ -516,7 +424,7 @@ msgstr "Флаг"
 msgid "Flag not supported"
 msgstr "Флаг не поддерживается"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Основные настройки"
 
@@ -524,23 +432,23 @@ msgstr "Основные настройки"
 msgid "Grant access to LuCI app banIP"
 msgstr "Предоставить доступ LuCI к приложению banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Высокий приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Наивысший приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr "ICMP-порог"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "ICMP - порог в пакетах в секунду для предотвращения WAN-DDoS-атак."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -552,23 +460,23 @@ msgstr "Поиск IP-адресов"
 msgid "IP Search..."
 msgstr "Поиск IP-адресов..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "Сетевые интерфейсы IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Поддержка iPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "Сетевые интерфейсы IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Поддержка IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -576,12 +484,12 @@ msgstr ""
 "Увеличьте максимальное количество открытых файлов, например, чтобы "
 "справиться с количеством временных разделенных файлов при загрузке наборов."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Информация"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Недопустимые символы"
 
@@ -589,7 +497,7 @@ msgstr "Недопустимые символы"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Недопустимые входные значения, невозможно сохранить изменения."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr "LACNIC - обслуживание региона Латинской Америки и Карибского бассейна"
 
@@ -597,46 +505,46 @@ msgstr "LACNIC - обслуживание региона Латинской Ам
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (пакеты)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Цепочка LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Последний запуск"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Наименьший приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Меньший приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Ограничить определенные каналы в цепи LAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Ограничьте определенные каналы в цепи WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Ограничить определенные каналы в цепи WAN-вход."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 "Ограничьте количество ядер процессора, используемых banIP для экономии "
 "оперативной памяти."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Ограничить функцию автоматического разрешения исходящего канала."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -644,7 +552,7 @@ msgstr ""
 "Список Набор элементов в статусе и отчете, отключите его для снижения "
 "нагрузки на процессор."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr "Список доступных интерфейсов триггера перезагрузки."
 
@@ -652,11 +560,11 @@ msgstr "Список доступных интерфейсов триггера 
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Перечислите элементы конкретного набора, связанного с запретом."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr "Настройки локальных каналов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
@@ -664,75 +572,75 @@ msgstr ""
 "Место для разбора лог-файла, например, через syslog-ng, для отключения "
 "стандартного разбора через logread."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Счетчик журналов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Журнал LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Ограничение журнала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr "Журнал предварительной маршрутизации"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Настройки журнала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Условия ведения журнала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Журнал WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Журнал WAN-Input"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr "Журнал подозрительных пакетов предварительной маршрутизации."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr "Журнал подозрительных пересылаемых пакетов локальной сети."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr "Журнал подозрительных пересылаемых пакетов WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr "Журнал подозрительных входящих пакетов WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "Файл журнала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Максимальное количество открытых файлов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Информация NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "Уровень журнала NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Сетевые устройства"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Уровень nice"
 
@@ -745,11 +653,11 @@ msgstr "Нет результатов поиска!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Журналы брандмауэра, связанные с banIP, пока отсутствуют!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Нормальный приоритет (по умолчанию)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Нормальный приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -757,14 +665,14 @@ msgstr ""
 "Количество попыток загрузки в случае ошибки (не поддерживается uclient-"
 "fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Количество неудачных попыток входа с одного и того же IP в журнале перед "
 "блокировкой."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -776,7 +684,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -793,26 +701,26 @@ msgstr "Лимит портов/протоколов"
 msgid "Processing Log"
 msgstr "Обработка журнала"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Профиль, используемый 'msmtp' для электронной почты с уведомлением banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Формат протокола/URL не поддерживается"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr "RIPE - обслуживание Европы, Ближнего Востока и Центральной Азии"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Получайте уведомления по электронной почте при каждом запуске banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -824,35 +732,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Обновить"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr "Региональный интернет-регистр"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Перезапустить"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr "Интерфейс триггера перезарядки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "Удаленный токен"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Папка для отчётов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Элементы отчета"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Перезапустить"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 "Ограничить доступ в Интернет с/на небольшое количество защищенных IP-адресов."
@@ -870,19 +774,19 @@ msgstr "Rulev4"
 msgid "Rulev6"
 msgstr "Rulev6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Флаги запуска"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Информация о запуске"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr "SYN-порог"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "SYN-порог в пакетах в секунду для предотвращения WAN-DDoS-атак."
 
@@ -898,23 +802,23 @@ msgstr "Поиск"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Поиск определенного IP-адреса в наборе banIP-related."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Выберите одну из предварительно настроенных утилит загрузки."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Выберите устройство (устройства) сети WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Выберите логический сетевой интерфейс (интерфейсы) WAN IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Выберите логический сетевой интерфейс (интерфейсы) WAN IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Адрес отправителя для электронных писем с уведомлением banIP."
 
@@ -923,7 +827,7 @@ msgstr "Адрес отправителя для электронных писе
 msgid "Set"
 msgstr "Набор"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Настройка политики"
 
@@ -931,7 +835,7 @@ msgstr "Настройка политики"
 msgid "Set Reporting"
 msgstr "Настройка отчетов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Установить размер разделения"
 
@@ -947,7 +851,7 @@ msgstr "Сетевой опрос..."
 msgid "Set details"
 msgstr "Сведения о наборе"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
@@ -955,53 +859,53 @@ msgstr ""
 "Устанавливает приоритет цепочки nft в таблице banIP, меньшие значения "
 "означают более высокий приоритет."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Установите политику nft для наборов, связанных с banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Установите уровень syslog для ведения журнала NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "Разделение загрузки внешнего набора после каждых n записей для экономии "
 "оперативной памяти."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Статус"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Остановить"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Подсеть (по умолчанию)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Подсеть"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Опрос"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Системная информация"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr "Настройки таблиц/цепочек"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Целевой каталог для файлов отчетов, связанных с banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Целевой каталог для сжатых резервных копий."
 
@@ -1013,7 +917,7 @@ msgstr "Список разрешений слишком большой, не у
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "Блок-лист слишком большой, не удается сохранить изменения."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
@@ -1021,7 +925,7 @@ msgstr ""
 "Регулярные выражения по умолчанию фильтруют подозрительный трафик ssh, LuCI, "
 "nginx и asterisk."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr "Выбранный приоритет будет использоваться для фоновой обработки banIP."
 
@@ -1068,7 +972,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Временная метка"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1076,23 +980,23 @@ msgstr ""
 "Чтобы включить уведомления по электронной почте, установите пакет 'msmtp' и "
 "укажите правильный адрес получателя электронной почты."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr "Токен для связи с интерфейсом cgi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Тема для электронной почты с уведомлением о banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr "UDP-порог"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "UDP-порог в пакетах в секунду для предотвращения WAN-DDoS-атак."
 
@@ -1104,11 +1008,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr "Невозможно разобрать файл пользовательского канала: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr "Невозможно разобрать файл канала по умолчанию: %s"
 
@@ -1135,11 +1043,11 @@ msgstr "Загрузить пользовательские каналы"
 msgid "Upload of the custom feed file failed."
 msgstr "Загрузка файла пользовательского канала не удалась."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Версия"
 
@@ -1147,8 +1055,8 @@ msgstr "Версия"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-Forward (пакеты)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Цепочка WAN-Forward"
 
@@ -1156,8 +1064,8 @@ msgstr "Цепочка WAN-Forward"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Input (пакеты)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Цепочка WAN-Input"
 
@@ -1177,7 +1085,7 @@ msgstr ""
 "новые или делать локальную резервную копию. Чтобы вернуться исходной версии, "
 "загрузите пустой файл (не удаляйте его!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "оповещение"
 
@@ -1213,73 +1121,61 @@ msgstr "заблокированные пакеты syn-флуда"
 msgid "blocked udp-flood packets"
 msgstr "заблокированные пакеты udp-флуда"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "крит"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "отладка"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
-msgstr "отбрасывание (по умолчанию)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
+msgstr "отбрасывание"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "чрезв"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "ошибка"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "инфо"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "локальный список разрешений"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "локальный черный список"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "память (по умолчанию)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "память"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "уведомление"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "производительность"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "отклонить"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "предупреждение (по умолчанию)"
-
-#~ msgid "-100"
-#~ msgstr "−100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "−200 (по умолчанию)"
-
-#~ msgid "-300"
-#~ msgstr "−300"
-
-#~ msgid "-400"
-#~ msgstr "−400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "предупреждение"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Выбор канала из белого списка"
@@ -1389,11 +1285,8 @@ msgstr "предупреждение (по умолчанию)"
 #~ msgid "reload"
 #~ msgstr "перечитать конфиг"
 
-#~ msgid "restart"
-#~ msgstr "перезапустить"
-
 #~ msgid "start (default)"
-#~ msgstr "старт (по умолчанию)"
+#~ msgstr "старт"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "Разрешить переадресацию VLAN"

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -226,8 +226,8 @@ msgstr ""
 "target=\"_blank\" rel=\"noreferrer noopener\" >онлайн-документацией</a>"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr "Страны (RIR)"
+msgid "Countries"
+msgstr "Страны"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1195,9 +1195,6 @@ msgstr "предупреждение"
 #~ "href=\"https://github.com/openwrt/packages/blob/master/net/banip/files/"
 #~ "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >ознакомьтесь с "
 #~ "онлайн-документацией</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Страны"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Внешние каналы списка разрешенний"

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -1282,12 +1282,6 @@ msgstr "предупреждение"
 #~ msgid "start (default)"
 #~ msgstr "старт"
 
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "Разрешить переадресацию VLAN"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Блокировать переадресацию VLAN"
-
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
 #~ "blocklist."

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Выберите набор --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (отключить)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - обслуживание Африки и региона Индийского океана"
@@ -265,6 +261,7 @@ msgstr ""
 "Автоматическое обнаружение соответствующих сетевых устройств, интерфейсов, "
 "подсетей, протоколов и утилит."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Отключить"

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Zapnuté"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -493,23 +401,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Verzia"
 
@@ -1075,8 +983,8 @@ msgstr "Verzia"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Active Sources"

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Ställ in val --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (stäng av)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (standard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (standard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (standard)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN:er"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktiva enheter"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Aktiva flöden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Aktiv uppkoppling"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Endast tillåt-listan"
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Tillåt alltid vissa VLAN-vidarebefordringar."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Blockera alltid vissa VLAN-vidarebefordringar."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Automatisk tillåt-lista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Blockera undernät automatiskt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Automatisk blockeringslista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Automatisk detektering"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Bas-katalog"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Typ av blockering"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "Blockera vidarebefordring av VLAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Ställ in utgångstid för blockeringslista"
 
@@ -260,7 +168,7 @@ msgstr ""
 "Ändringar av blockeringslistan har sparats, påbörja domän-uppslagningen "
 "eller starta om banIP som gör att ändringarna får effekt."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -268,7 +176,7 @@ msgstr ""
 "Varje flöde är aktivt som standard i alla stödda kedjor. Begränsa "
 "standardpolicyn för blockering till en viss kedja."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Processorkärnor"
 
@@ -277,14 +185,14 @@ msgstr "Processorkärnor"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -292,7 +200,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Rensa bort anpassade flöden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -301,7 +209,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -309,17 +217,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Anpassad flödesredigerare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Blockeringspolicy-standard"
 
@@ -327,7 +235,7 @@ msgstr "Blockeringspolicy-standard"
 msgid "Description"
 msgstr "Beskrivning"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -335,15 +243,15 @@ msgstr ""
 "Upptäck automatiskt relevanta nätverksenheter, gränssnitt, undernät, "
 "protokoll och verktyg."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Stäng av"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Domän-uppslagning"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Kontrollera inte serverns SSL-certifikat under hämtning."
 
@@ -351,49 +259,49 @@ msgstr "Kontrollera inte serverns SSL-certifikat under hämtning."
 msgid "Download Custom Feeds"
 msgstr "Hämta anpassade flöden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Ladda ner osäkert"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Ladda ner parametrar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Mottagarens e-postadress"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "E-postinställningar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
@@ -409,7 +317,7 @@ msgstr "Redigera blockeringslistan"
 msgid "Edit Custom Feeds"
 msgstr "Redigera anpassade flöden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Antal element"
 
@@ -419,47 +327,47 @@ msgstr "Element"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Tomt fält tillåts inte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Aktivera banIP-tjänsten."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "Aktivera detaljerad debug-loggning i händelse av behandlingsfel."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Aktiverar IPv4-stöd."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Aktiverar IPv6-stöd."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -467,11 +375,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Namn på flödet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -491,7 +399,7 @@ msgstr "Flagga"
 msgid "Flag not supported"
 msgstr "Flaggan stöds inte"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Generella inställningar"
 
@@ -499,23 +407,23 @@ msgstr "Generella inställningar"
 msgid "Grant access to LuCI app banIP"
 msgstr "Godkänn åtkomst till LuCi-appen banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Hög prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Högsta prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -527,34 +435,34 @@ msgstr "IP-sökning"
 msgid "IP Search..."
 msgstr "Sök IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4-stöd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6-stöd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Information"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Ogiltiga tecken"
 
@@ -562,7 +470,7 @@ msgstr "Ogiltiga tecken"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Ogiltiga inmatningsvärden, kunde inte spara ändringarna."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -570,50 +478,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Kördes senast"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Lägst prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Lägre prioritet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -621,85 +529,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -712,22 +620,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -737,7 +645,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Överblick"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -751,25 +659,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -779,35 +687,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Uppdatera"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Ladda om"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Rapportkatalog"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Starta om"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -824,19 +728,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Förflaggor"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -852,23 +756,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -877,7 +781,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -885,7 +789,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -901,57 +805,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Inställningar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -963,13 +867,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -1004,29 +908,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1038,11 +942,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1069,11 +977,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1081,8 +989,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1090,8 +998,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1105,7 +1013,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1141,73 +1049,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (standard)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
 
 #~ msgid "Countries"
 #~ msgstr "Länder"

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -206,8 +206,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Länder"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1101,9 +1101,6 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
 msgid "warn"
 msgstr ""
-
-#~ msgid "Countries"
-#~ msgstr "Länder"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Externa flöden för tillåt-listan"

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -1108,9 +1108,6 @@ msgstr ""
 #~ msgid "External blocklist feeds"
 #~ msgstr "External flöden för blockeringslistan"
 
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "Blockera vidarebefordringar på VLAN"
-
 #~ msgid "Active Subnets"
 #~ msgstr "Aktiva undernät"
 

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Ställ in val --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (stäng av)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -243,6 +239,7 @@ msgstr ""
 "Upptäck automatiskt relevanta nätverksenheter, gränssnitt, undernät, "
 "protokoll och verktyg."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Stäng av"

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -413,11 +413,11 @@ msgid "Highest Priority"
 msgstr "Högsta prioritet"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -734,11 +734,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -924,11 +924,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -92,7 +92,7 @@ msgstr "Blockera alltid vissa VLAN-vidarebefordringar."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Starta om"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/sw/banip.po
+++ b/applications/luci-app-banip/po/sw/banip.po
@@ -202,7 +202,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/sw/banip.po
+++ b/applications/luci-app-banip/po/sw/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Vifaa Vinavyotumika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -273,14 +181,14 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -345,49 +253,49 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -403,7 +311,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -413,47 +321,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr ""
 
@@ -493,23 +401,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -706,22 +614,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -871,7 +775,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -879,7 +783,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -895,57 +799,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -957,13 +861,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -998,29 +902,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr ""
 
@@ -1075,8 +983,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1084,8 +992,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1135,60 +1043,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Active Subnets"

--- a/applications/luci-app-banip/po/sw/banip.po
+++ b/applications/luci-app-banip/po/sw/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/sw/banip.po
+++ b/applications/luci-app-banip/po/sw/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -5,10 +5,6 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -228,6 +224,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -398,11 +398,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -719,11 +719,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -909,11 +909,11 @@ msgid "Trigger Delay"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -193,7 +193,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -5,119 +5,23 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "-- Set Selection --"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:567
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:322
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:448
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:325
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:449
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:326
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:570
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:323
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:353
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:450
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:568
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:350
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
@@ -141,19 +45,19 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:749
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -163,17 +67,17 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
@@ -181,19 +85,19 @@ msgstr ""
 msgid "Apply & Restart"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:718
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
@@ -201,49 +105,49 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:718
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:380
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:376
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:470
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:640
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:739
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -253,13 +157,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -268,14 +172,14 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:338
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -292,7 +196,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -300,17 +204,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:388
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:388
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -324,7 +228,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:724
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
@@ -332,7 +236,7 @@ msgstr ""
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
@@ -340,7 +244,7 @@ msgstr ""
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr ""
 
@@ -356,25 +260,25 @@ msgstr ""
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:470
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:615
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:619
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr ""
 
@@ -382,7 +286,7 @@ msgstr ""
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -408,11 +312,11 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
@@ -420,7 +324,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
@@ -440,15 +344,15 @@ msgstr ""
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:739
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:637
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -488,23 +392,23 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:726
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -532,7 +436,7 @@ msgstr ""
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:349
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -543,7 +447,7 @@ msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:598
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -551,7 +455,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -559,8 +463,8 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
@@ -568,35 +472,35 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:357
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:722
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:392
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -610,29 +514,29 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:716
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
@@ -640,39 +544,39 @@ msgstr ""
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:581
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:349
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
@@ -680,7 +584,7 @@ msgstr ""
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:538
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
@@ -688,7 +592,7 @@ msgstr ""
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -701,8 +605,8 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
@@ -711,7 +615,7 @@ msgid ""
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
@@ -726,7 +630,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -740,25 +644,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:612
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:615
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -768,7 +672,7 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:670
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
@@ -780,19 +684,19 @@ msgstr ""
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:590
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:392
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:749
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -817,11 +721,11 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -853,7 +757,7 @@ msgstr ""
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:619
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -862,7 +766,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:464
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -870,7 +774,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -886,17 +790,17 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:464
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:538
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
@@ -904,7 +808,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
@@ -916,8 +820,8 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
@@ -932,11 +836,11 @@ msgstr ""
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:384
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:380
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -948,13 +852,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:581
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -989,17 +893,17 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:610
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:590
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
@@ -1007,11 +911,11 @@ msgstr ""
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1023,15 +927,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:663
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
 msgid "Unable to parse the countries file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1070,8 +974,8 @@ msgstr ""
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1079,8 +983,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:477
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1094,7 +998,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1130,58 +1034,58 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:539
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:542
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:522
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:544
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Seçimi Ayarla --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (devre dışı bırak)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - Afrika ve Hint Okyanusu bölgesine hizmet vermektedir"
@@ -264,6 +260,7 @@ msgstr ""
 "İlgili ağ cihazlarını, arayüzleri, alt ağları, protokolleri ve yardımcı "
 "programları otomatik olarak tespit et."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Devre dışı bırak"

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -98,7 +98,7 @@ msgstr "Her zaman belirli VLAN iletimlerini engelle."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Yeniden Başlat"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -439,11 +439,11 @@ msgid "Highest Priority"
 msgstr "En yüksek öncelik"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr "ICMP Eşiği"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 "WAN-DDoS saldırılarını önlemek için saniye başına paket cinsinden ICMP-Eşiği."
 
@@ -780,11 +780,11 @@ msgid "Run Information"
 msgstr "Çalıştırma Bilgileri"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr "SYN Eşiği"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 "WAN-DDoS saldırılarını önlemek için saniye başına paket cinsinden SYN-Eşiği."
 
@@ -992,11 +992,11 @@ msgid "Trigger Delay"
 msgstr "Tetikleme Gecikmesi"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr "UDP Eşiği"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 "UDP-WAN-DDoS saldırılarını önlemek için saniye başına paket cinsinden eşik."
 

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -14,157 +14,61 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Seçimi Ayarla --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr "-100 (varsayılan)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr "-150"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr "-200"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (devre dışı bırak)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr "10 (varsayılan)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr "100"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (varsayılan)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (varsayılan)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (varsayılan)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - Afrika ve Hint Okyanusu bölgesine hizmet vermektedir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr "APNIC - Asya Pasifik bölgesine hizmet vermektedir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr "ARIN - Kanada ve Amerika Birleşik Devletleri'ne hizmet vermektedir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASN'ler"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Aktif Cihazlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Aktif Akışlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Aktif Yukarı Bağlantı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 "Arayüzün yeniden yüklenmesi ve başlatılması sırasında saniye cinsinden ek "
 "tetikleme gecikmesi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Gelişmiş Ayarlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr "Protokol ve Bağlantı Noktalarına İzin Ver"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "VLAN Yönlendirmelerine İzin Ver"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr "Besleme URL'lerini İzin Ver"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Yalnızca İzin Verilenler Listesi"
 
@@ -176,7 +80,7 @@ msgstr ""
 "İzin verilenler listesi değişiklikleri kaydedildi, Etki Alanı Arama'yı "
 "başlatın veya değişikliklerin etkili olması için banIP'yi yeniden başlatın."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
@@ -184,35 +88,39 @@ msgstr ""
 "WAN-Giriş ve WAN-İleri zincirinde her zaman belirli bağlantı noktalarına "
 "veya bağlantı noktası aralıklarına sahip bir protokole (tcp/udp) izin verin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "Her zaman belirli VLAN yönlendirmelerine izin verin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "Her zaman belirli VLAN iletimlerini engelle."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Yukarı Bağlantıya Otomatik İzin Ver"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Otomatik İzin Verilenler Listesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Alt Ağı Otomatik Engelle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Otomatik Engelleme Listesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Otomatik Algılama"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -220,7 +128,7 @@ msgstr ""
 "Şüpheli IP'ye sahip ek bir RDAP isteğine dayalı olarak tüm alt ağları "
 "otomatik olarak engelleme listesi kümesine ekle."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -228,7 +136,7 @@ msgstr ""
 "Çözümlenen etki alanlarını ve şüpheli IP'leri otomatik olarak yerel banIP "
 "engelleme listesine ekle."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -236,31 +144,31 @@ msgstr ""
 "Çözümlenmiş etki alanlarını ve yukarı bağlantı IP'lerini yerel banIP izin "
 "verilenler listesine otomatik olarak ekle."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Yedekleme Dizini"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Temel Dizin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "BanIP işlenirken temel çalışma dizini."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "Blok Türü"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "VLAN İletimlerini Engelle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr "Engelleme Listesi Beslemesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Engellenenler Listesinin Sona Ermesi"
 
@@ -272,7 +180,7 @@ msgstr ""
 "Engelleme listesi değişiklikleri kaydedildi, Etki Alanı Aramayı başlatın "
 "veya değişikliklerin etkili olması için banIP'yi yeniden başlatın."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -280,7 +188,7 @@ msgstr ""
 "Varsayılan olarak her feed, desteklenen tüm zincirlerde etkindir. Varsayılan "
 "engelleme politikasını belirli bir zincirle sınırlandır."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "CPU Çekirdekleri"
 
@@ -289,14 +197,14 @@ msgstr "CPU Çekirdekleri"
 msgid "Cancel"
 msgstr "İptal"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "Zincir Önceliği"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Bu sekmedeki değişikliklerin etkili olması için banIP hizmetinin yeniden "
@@ -306,7 +214,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Özel Akışları Temizle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -320,7 +228,7 @@ msgstr ""
 "openwrt/packages/blob/master/net/banip/files/README.md\" target=\"_blank\" "
 "rel=\"noreferrer noopener\" >çevrimiçi dokümantasyon</a>"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr "Ülkeler (RIR)"
 
@@ -328,7 +236,7 @@ msgstr "Ülkeler (RIR)"
 msgid "Custom Feed Editor"
 msgstr "Özel Akış Düzenleyicisi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -336,11 +244,11 @@ msgstr ""
 "Tüm aktif Setlerdeki IP adreslerini tekilleştirin ve yerel engelleme "
 "listesini düzenleyin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "IP'leri tekilleştirme"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Varsayılan Engelleme Politikası"
 
@@ -348,7 +256,7 @@ msgstr "Varsayılan Engelleme Politikası"
 msgid "Description"
 msgstr "Açıklama"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -356,15 +264,15 @@ msgstr ""
 "İlgili ağ cihazlarını, arayüzleri, alt ağları, protokolleri ve yardımcı "
 "programları otomatik olarak tespit et."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Devre dışı bırak"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Alan Adı Arama"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "İndirme sırasında SSL sunucu sertifikalarını kontrol etme."
 
@@ -372,23 +280,23 @@ msgstr "İndirme sırasında SSL sunucu sertifikalarını kontrol etme."
 msgid "Download Custom Feeds"
 msgstr "Özel Akışları İndir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Güvensiz İndir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "İndirme Parametreleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Yeniden İndirme Denemeleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
@@ -396,27 +304,27 @@ msgstr ""
 "Paketleri sessizce bırak veya WAN-Giriş ve WAN-İleri zincirlerindeki trafiği "
 "aktif olarak reddet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-Posta Bildirimi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Posta Profili"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "E-Posta Alıcı Adresi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-Posta Gönderen Adresi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "E mail ayarları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "E-Posta Konusu"
 
@@ -432,7 +340,7 @@ msgstr "Engellenenler Listesini Düzenle"
 msgid "Edit Custom Feeds"
 msgstr "Özel Akışları Düzenle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Öğe Sayısı"
 
@@ -442,50 +350,50 @@ msgstr "Öğeler"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Boş alana izin verilmiyor"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "Uzak Günlük Kaydını Etkinleştir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "BanIP hizmetini etkinleştirin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "Uzak günlük olaylarını almak için cgi arayüzünü etkinleştirin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 "İşleme hataları durumunda ayrıntılı hata ayıklama günlüğünü etkinleştir."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Etkin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "IPv4 desteğini etkinleştirir."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "IPv6 desteğini etkinleştirir."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 "Otomatik olarak eklenen engellenenler listesi Kümesi üyelerinin sona erme "
 "süresi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr "Harici İzin Listesi Beslemeleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr "Harici Engelleme Listesi Beslemeleri"
 
@@ -493,11 +401,11 @@ msgstr "Harici Engelleme Listesi Beslemeleri"
 msgid "Feed Name"
 msgstr "Akış Adı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Akış Seçimi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr "Besleme/Ayarlar"
 
@@ -517,7 +425,7 @@ msgstr "Bayrak"
 msgid "Flag not supported"
 msgstr "Bayrak desteklenmiyor"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
@@ -525,24 +433,24 @@ msgstr "Genel Ayarlar"
 msgid "Grant access to LuCI app banIP"
 msgstr "LuCI uygulaması banIP'ye erişim izni verin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Yüksek öncelik"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "En yüksek öncelik"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr "ICMP Eşiği"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 "WAN-DDoS saldırılarını önlemek için saniye başına paket cinsinden ICMP-Eşiği."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -554,23 +462,23 @@ msgstr "IP Arama"
 msgid "IP Search..."
 msgstr "IP Arama..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "IPv4 Ağ Arayüzleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 Desteği"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "IPv6 Ağ Arayüzleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 Desteği"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -578,12 +486,12 @@ msgstr ""
 "Maksimum açık dosya sayısını artır, örn. Setleri yüklerken geçici bölünmüş "
 "dosyaların miktarını yönetmek için."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Bilgi"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Geçersiz karakter"
 
@@ -591,7 +499,7 @@ msgstr "Geçersiz karakter"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Geçersiz giriş değerleri, değişiklikler kaydedilemiyor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr "LACNIC - Latin Amerika ve Karayipler bölgesine hizmet vermektedir"
 
@@ -599,46 +507,46 @@ msgstr "LACNIC - Latin Amerika ve Karayipler bölgesine hizmet vermektedir"
 msgid "LAN-Forward (packets)"
 msgstr "LAN-İleri (paketler)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "LAN-İleri Zincir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "En Az Öncelik"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Daha Az Öncelik"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Belirli akışları LAN-İleri zinciriyle sınırla."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Belirli akışları WAN-İleri zinciriyle sınırla."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Belirli akışları WAN-Giriş zinciriyle sınırla."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 "RAM'den tasarruf etmek için banIP tarafından kullanılan işlemci "
 "çekirdeklerini sınırla."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Yukarı bağlantı otomatik izin verme işlevini sınırla."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -646,7 +554,7 @@ msgstr ""
 "Durum ve rapordaki öğeleri listele, CPU yükünü azaltmak için bunu devre dışı "
 "bırakın."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr "Mevcut yeniden yükleme tetikleyici arayüz(ler)in listesi."
 
@@ -654,11 +562,11 @@ msgstr "Mevcut yeniden yükleme tetikleyici arayüz(ler)in listesi."
 msgid "List the elements of a specific banIP-related Set."
 msgstr "BanIP ile ilgili belirli bir kümenin öğelerinin listesi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr "Yerel Besleme Ayarları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
@@ -666,75 +574,75 @@ msgstr ""
 "Logread aracılığıyla standart ayrıştırmayı devre dışı bırakmak için günlük "
 "dosyasını, örneğin syslog-ng aracılığıyla ayrıştırma konumu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Günlük Sayısı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "LAN-İleriyi Günlükle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Günlük Sınırı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr "Günlük Ön Yönlendirme"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Günlük Ayarları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Günlük Şartları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "WAN-İleriyi Günlükle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "WAN-Girişi Günlükle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr "Şüpheli Ön Yönlendirme paketlerini günlüğe kaydedin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr "Şüpheli iletilen LAN paketlerini günlüğe kaydedin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr "İletilen şüpheli WAN paketlerini günlüğe kaydedin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr "Şüpheli gelen WAN paketlerini günlüğe kaydedin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "Günlük Dosyası Konumu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Maksimum Açık Dosya Sayısı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "NFT Bilgileri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "NFT Günlük Kaydı Seviyesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Ağ cihazları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Güzel Düzey"
 
@@ -747,11 +655,11 @@ msgstr "Arama sonucu bulunamadı!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Henüz banIP ile ilgili güvenlik duvarı kaydı yok!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Normal Öncelik (varsayılan)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Normal Öncelik"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -759,14 +667,14 @@ msgstr ""
 "Hata durumunda indirme denemelerinin sayısı (uclient-fetch tarafından "
 "desteklenmez)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Engellemeden önce günlükteki aynı IP ile yapılan başarısız oturum açma "
 "denemelerinin sayısı."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -778,7 +686,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -795,25 +703,25 @@ msgstr "Bağlantı Noktası/Protokol Sınırı"
 msgid "Processing Log"
 msgstr "İşlem Günlüğü"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "BanIP bildirim e-postaları için 'msmtp' tarafından kullanılan profil."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Protokol/URL formatı desteklenmiyor"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr "RIPE - Avrupa, Orta Doğu ve Orta Asya'ya hizmet vermektedir"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Her banIP çalıştırmasında E-Posta bildirimleri alın."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -825,35 +733,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Yenile"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr "Bölgesel İnternet Tescili"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Yeniden yükle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr "Tetikleyici Arayüzünü Yeniden Yükle"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "Uzak Belirteç"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Rapor Dizini"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Rapor Unsurları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Yeniden Başlat"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr "İnternet erişimini az sayıda güvenli IP'ye kısıtlayın."
 
@@ -870,19 +774,19 @@ msgstr "Kuralv4"
 msgid "Rulev6"
 msgstr "Kuralv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Bayrakları Çalıştır"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Çalıştırma Bilgileri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr "SYN Eşiği"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 "WAN-DDoS saldırılarını önlemek için saniye başına paket cinsinden SYN-Eşiği."
@@ -899,23 +803,23 @@ msgstr "Ara"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Belirli bir IP için banIP ile ilgili Setleri ara."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Önceden yapılandırılmış indirme yardımcı programlarından birini seçin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "WAN ağ aygıtını/cihazlarını seçin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Mantıksal WAN IPv4 ağ arayüzünü/arayüzlerini seçin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Mantıksal WAN IPv6 ağ arayüzünü/arayüzlerini seçin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "BanIP bildirim e-postaları için gönderen adresi."
 
@@ -924,7 +828,7 @@ msgstr "BanIP bildirim e-postaları için gönderen adresi."
 msgid "Set"
 msgstr "Ayarla"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "Politika Belirleyin"
 
@@ -932,7 +836,7 @@ msgstr "Politika Belirleyin"
 msgid "Set Reporting"
 msgstr "Raporlamayı Ayarla"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Bölme Boyutunu Ayarla"
 
@@ -948,7 +852,7 @@ msgstr "Araştırmayı Ayarla..."
 msgid "Set details"
 msgstr "Ayrıntıları ayarla"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
@@ -956,52 +860,52 @@ msgstr ""
 "BanIP tablosunda nft zincir önceliğini ayarlayın, düşük değerler daha yüksek "
 "öncelik anlamına gelir."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "banIP ile ilgili Setler için nft politikasını ayarlayın."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "NFT günlüğü için sistem günlüğü düzeyini ayarlayın."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 "RAM'den tasarruf etmek için harici Set yüklemesini her n üyeden sonra böl."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Durum"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Dur"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Alt ağ (varsayılan)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Alt ağ"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Araştırma"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Sistem bilgisi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr "Tablo/Zincir Ayarları"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "banIP ile ilgili rapor dosyaları için hedef dizin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Sıkıştırılmış akış yedeklemeleri için hedef dizin."
 
@@ -1015,7 +919,7 @@ msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 "Engellenenler listesi çok büyük olduğundan değişiklikler kaydedilemiyor."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
@@ -1023,7 +927,7 @@ msgstr ""
 "Varsayılan düzenli ifadeler şüpheli ssh, LuCI, nginx ve asterisk trafiğini "
 "filtrelemektedir."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr "Seçilen öncelik banIP'in arka planda işlenmesi için kullanılacaktır."
 
@@ -1070,7 +974,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Zaman damgası"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1078,23 +982,23 @@ msgstr ""
 "E-posta bildirimlerini etkinleştirmek için 'msmtp' paketini kurun ve geçerli "
 "bir E-Posta alıcı adresi belirtin."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr "cgi arayüzü ile iletişim kurmak için belirteç."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "BanIP bildirim e-postaları için konu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Tetikleme Gecikmesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr "UDP Eşiği"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 "UDP-WAN-DDoS saldırılarını önlemek için saniye başına paket cinsinden eşik."
@@ -1107,11 +1011,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr "Özel besleme dosyası ayrıştırılamıyor: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr "Varsayılan besleme dosyası ayrıştırılamıyor: %s"
 
@@ -1138,11 +1046,11 @@ msgstr "Özel Akışları Yükle"
 msgid "Upload of the custom feed file failed."
 msgstr "Özel akış dosyasının yüklenmesi başarısız oldu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Ayrıntılı Hata Ayıklama Günlüğü"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Versiyon"
 
@@ -1150,8 +1058,8 @@ msgstr "Versiyon"
 msgid "WAN-Forward (packets)"
 msgstr "WAN-İleri (paketler)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "WAN-İleri (Zincir)"
 
@@ -1159,8 +1067,8 @@ msgstr "WAN-İleri (Zincir)"
 msgid "WAN-Input (packets)"
 msgstr "WAN-Giriş (paketler)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "WAN-Giriş (Zincir)"
 
@@ -1180,7 +1088,7 @@ msgstr ""
 "yedekleme yapabilirsiniz. Bakımcı sürümüne geri dönmek için özel besleme "
 "dosyasını tekrar boşaltmanız yeterlidir (silmeyin!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "uyarı"
 
@@ -1216,73 +1124,61 @@ msgstr "engellenen syn-flood paketleri"
 msgid "blocked udp-flood packets"
 msgstr "engellenen udp-flood paketleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "kritik"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "hata ayıklama"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
-msgstr "bırak (varsayılan)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
+msgstr "bırak"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "ortaya çıkan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "hata"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "bilgi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "yerel izin verilenler listesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "yerel engellenenler listesi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "bellek (varsayılan)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "bellek"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "ikaz"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "performans"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "reddet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "uyar (varsayılan)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (varsayılan)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "uyar"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "İzin Verilenler Listesi Akış Seçimi"
@@ -1416,7 +1312,7 @@ msgstr "uyar (varsayılan)"
 #~ msgstr "Değişiklikler kaydedilemiyor: %s"
 
 #~ msgid "-m limit --limit 2/sec (default)"
-#~ msgstr "-m limit --limit 2/sn (varsayılan)"
+#~ msgstr "-m limit --limit 2/sn"
 
 #~ msgid "1 hour"
 #~ msgstr "1 saat"

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -225,8 +225,8 @@ msgstr ""
 "rel=\"noreferrer noopener\" >çevrimiçi dokümantasyon</a>"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr "Ülkeler (RIR)"
+msgid "Countries"
+msgstr "Ülkeler"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1198,9 +1198,6 @@ msgstr "uyar"
 #~ "için<a href=\"https://github.com/openwrt/packages/blob/master/net/banip/"
 #~ "files/README.md\" target=\"_blank\" rel=\"noreferrer noopener\" "
 #~ ">çevrimiçi belgelere bakın </a>"
-
-#~ msgid "Countries"
-#~ msgstr "Ülkeler"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Harici izin verilenler listesi akışları"

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -93,7 +93,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Перезапустити"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "— Встановити Обране —"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -238,6 +234,7 @@ msgid ""
 "utilities automatically."
 msgstr ""
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Вимкнути"

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -15,155 +15,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "— Встановити Обране —"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Розширені налаштування"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr ""
 
@@ -173,83 +77,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Тека для резервних копій"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -259,13 +167,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr ""
 
@@ -274,14 +182,14 @@ msgstr ""
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -289,7 +197,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -298,7 +206,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -306,17 +214,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -324,21 +232,21 @@ msgstr ""
 msgid "Description"
 msgstr "Опис"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Вимкнути"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Не перевіряти SSL-сертифікати сервера під час завантаження."
 
@@ -346,49 +254,49 @@ msgstr "Не перевіряти SSL-сертифікати сервера пі
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Завантажувати небезпечним шляхом"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Параметри завантаження"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Утиліта для завантаження"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "E-Mail повідомлення"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "E-Mail профіль"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail адреса отримувача"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "E-Mail адреса відправника"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -404,7 +312,7 @@ msgstr ""
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr ""
 
@@ -414,47 +322,47 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -462,11 +370,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -486,7 +394,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Загальні налаштування"
 
@@ -494,23 +402,23 @@ msgstr "Загальні налаштування"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -522,34 +430,34 @@ msgstr ""
 msgid "IP Search..."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 підтримка"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -557,7 +465,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -565,50 +473,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Останній запуск"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -616,85 +524,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr ""
 
@@ -707,22 +615,22 @@ msgstr ""
 msgid "No banIP related firewall logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -732,7 +640,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -746,25 +654,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -774,35 +682,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Оновити"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Тека для звітів"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Перезапустити"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr ""
 
@@ -819,19 +723,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Прапорці запуску"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -847,23 +751,23 @@ msgstr ""
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
@@ -872,7 +776,7 @@ msgstr ""
 msgid "Set"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -880,7 +784,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr ""
 
@@ -896,57 +800,57 @@ msgstr ""
 msgid "Set details"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Налаштування"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Статус"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Зупинити"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr ""
 
@@ -958,13 +862,13 @@ msgstr ""
 msgid "The blocklist is too big, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr ""
 
@@ -999,29 +903,29 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Затримка запуску"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1033,11 +937,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1064,11 +972,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Докладний журнал відлагодження"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Версія"
 
@@ -1076,8 +984,8 @@ msgstr "Версія"
 msgid "WAN-Forward (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr ""
 
@@ -1085,8 +993,8 @@ msgstr ""
 msgid "WAN-Input (packets)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr ""
 
@@ -1100,7 +1008,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr ""
 
@@ -1136,60 +1044,60 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
 msgstr ""
 
 #~ msgid "Startup Trigger Interface"

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -203,7 +203,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
+msgid "Countries"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -408,11 +408,11 @@ msgid "Highest Priority"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -729,11 +729,11 @@ msgid "Run Information"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -919,11 +919,11 @@ msgid "Trigger Delay"
 msgstr "Затримка запуску"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -94,7 +94,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "Khởi Động Lại"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -215,8 +215,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "Quốc gia"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1165,9 +1165,6 @@ msgstr "cảnh báo"
 #~ "github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
 #~ "target=\"_blank\" rel=\"noreferrer noopener\">kiểm tra tài liệu trực "
 #~ "tuyến</a>"
-
-#~ msgid "Countries"
-#~ msgstr "Quốc gia"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "Nguồn allowlist bên ngoài"

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Cài đặt lựa chọn --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (vô hiệu hóa)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -254,6 +250,7 @@ msgstr ""
 "Tự động phát hiện các thiết bị, giao diện, mạng con, giao thức và tiện ích "
 "mạng liên quan."
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Vô hiệu hóa"

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -424,11 +424,11 @@ msgid "Highest Priority"
 msgstr "Ưu tiên cao nhất"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -758,11 +758,11 @@ msgid "Run Information"
 msgstr "Thông tin chạy"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -960,11 +960,11 @@ msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- Cài đặt lựa chọn --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (vô hiệu hóa)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (mặc định)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (mặc định)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (mặc định)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "ASNs"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "Thiết bị hoạt động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "Feed hoạt động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "Uplink hoạt động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "Cài đặt Nâng cao"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "Chỉ sử dụng Allowlist"
 
@@ -174,41 +78,45 @@ msgstr ""
 "Các thay đổi Allowlist đã được lưu, bắt đầu Tra cứu tên miền hoặc khởi động "
 "lại banIP để áp dụng thay đổi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "Tự động cho phép Uplink"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "Allowlist tự động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "Chặn Subnet tự động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "Blocklist tự động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "Phát hiện tự động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
@@ -216,7 +124,7 @@ msgstr ""
 "Tự động thêm toàn bộ các subnet vào Blocklist dựa trên yêu cầu RDAP bổ sung "
 "với IP đáng ngờ."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
@@ -224,7 +132,7 @@ msgstr ""
 "Tự động thêm tên miền đã được giải quyết và các IP đáng ngờ vào danh sách "
 "chặn banIP cục bộ."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
@@ -232,31 +140,31 @@ msgstr ""
 "Tự động thêm tên miền đã được giải quyết và các IP uplink vào danh sách cho "
 "phép banIP cục bộ."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "Thư mục cơ sở"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "Thư mục làm việc cơ sở trong quá trình xử lý banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "Hết hạn của Blocklist Set"
 
@@ -268,7 +176,7 @@ msgstr ""
 "Các thay đổi Blocklist đã được lưu, bắt đầu Tra cứu tên miền hoặc khởi động "
 "lại banIP để áp dụng thay đổi."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
@@ -276,7 +184,7 @@ msgstr ""
 "Mặc định, mỗi feed hoạt động trong tất cả các chuỗi được hỗ trợ. Giới hạn "
 "chính sách chặn mặc định cho một chuỗi cụ thể."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "Số lõi CPU"
 
@@ -285,14 +193,14 @@ msgstr "Số lõi CPU"
 msgid "Cancel"
 msgstr "Hủy lệnh"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 "Các thay đổi trên tab này cần khởi động lại dịch vụ banIP để có hiệu lực."
@@ -301,7 +209,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr "Xóa Feed Tùy chỉnh"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -310,7 +218,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -318,7 +226,7 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr "Trình chỉnh sửa nguồn tùy chỉnh"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
@@ -326,11 +234,11 @@ msgstr ""
 "Loại bỏ trùng lặp địa chỉ IP trên tất cả các Sets hoạt động và dọn dẹp danh "
 "sách chặn cục bộ."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "Loại bỏ trùng lặp IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "Chính sách chặn mặc định"
 
@@ -338,7 +246,7 @@ msgstr "Chính sách chặn mặc định"
 msgid "Description"
 msgstr "Mô tả"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
@@ -346,15 +254,15 @@ msgstr ""
 "Tự động phát hiện các thiết bị, giao diện, mạng con, giao thức và tiện ích "
 "mạng liên quan."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "Vô hiệu hóa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "Tra cứu tên miền"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "Không kiểm tra chứng chỉ máy chủ SSL trong khi tải xuống."
 
@@ -362,49 +270,49 @@ msgstr "Không kiểm tra chứng chỉ máy chủ SSL trong khi tải xuống."
 msgid "Download Custom Feeds"
 msgstr "Tải xuống nguồn tùy chỉnh"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "Tải về không bảo mật"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "Tải xuống Parameters"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "Thử lại khi tải xuống"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "Tiện ích tải xuống"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "Thông báo Email"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "Hồ sơ Email"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "Địa chỉ người nhận Email"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "Địa chỉ người gửi Email"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "Cài đặt E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "Chủ đề Email"
 
@@ -420,7 +328,7 @@ msgstr "Chỉnh sửa danh sách chặn"
 msgid "Edit Custom Feeds"
 msgstr "Chỉnh sửa nguồn tùy chỉnh"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "Số lượng phần tử"
 
@@ -430,47 +338,47 @@ msgstr "Các phần tử"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "Không được để trống trường này"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "Bật dịch vụ banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "Bật ghi nhật ký debug chi tiết trong trường hợp xảy ra lỗi xử lý."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "Kích Hoạt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "Bật hỗ trợ IPv4."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "Bật hỗ trợ IPv6."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr "Thời gian hết hạn cho các thành viên danh sách chặn tự động thêm."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -478,11 +386,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr "Tên nguồn"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "Lựa chọn nguồn"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -502,7 +410,7 @@ msgstr "Cờ"
 msgid "Flag not supported"
 msgstr "Không hỗ trợ cờ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "Các cài đặt chung"
 
@@ -510,23 +418,23 @@ msgstr "Các cài đặt chung"
 msgid "Grant access to LuCI app banIP"
 msgstr "Cấp quyền truy cập cho ứng dụng LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "Ưu tiên cao"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "Ưu tiên cao nhất"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -538,23 +446,23 @@ msgstr "Tìm kiếm IP"
 msgid "IP Search..."
 msgstr "Tìm kiếm IP..."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "Hỗ trợ IPv4"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "Hỗ trợ IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
@@ -562,12 +470,12 @@ msgstr ""
 "Tăng số tệp mở tối đa, ví dụ: để xử lý số lượng tệp chia tạm thời khi tải "
 "các Sets."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "Thông Tin"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "Ký tự không hợp lệ"
 
@@ -575,7 +483,7 @@ msgstr "Ký tự không hợp lệ"
 msgid "Invalid input values, unable to save modifications."
 msgstr "Giá trị đầu vào không hợp lệ, không thể lưu các chỉnh sửa."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -583,44 +491,44 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "LAN-Forward (gói tin)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "Chuỗi LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "Lần chạy cuối cùng"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "Ưu tiên Thấp Nhất"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "Ưu tiên Thấp Hơn"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "Giới hạn một số feeds cho chuỗi LAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "Giới hạn một số feeds cho chuỗi WAN-Forward."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "Giới hạn một số feeds cho chuỗi WAN-Input."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "Giới hạn số nhân cpu được sử dụng bởi banIP để tiết kiệm RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "Giới hạn chức năng uplink autoallow."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
@@ -628,7 +536,7 @@ msgstr ""
 "Liệt kê các phần tử Set trong trạng thái và báo cáo, vô hiệu hóa điều này để "
 "giảm tải CPU."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -636,85 +544,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr "Liệt kê các phần tử của một Set liên quan đến banIP cụ thể."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "Số lượng Log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "Log LAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "Giới hạn Log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "Cài đặt Log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "Điều khoản Log"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "Log WAN-Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "Log WAN-Input"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "Số tệp Mở Tối đa"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "Thông tin NFT"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "Thiết bị Mạng"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Mức độ Nice"
 
@@ -727,11 +635,11 @@ msgstr "Không có kết quả Tìm kiếm!"
 msgid "No banIP related firewall logs yet!"
 msgstr "Chưa có log tường lửa liên quan đến banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "Ưu tiên Bình thường (mặc định)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "Ưu tiên Bình thường"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
@@ -739,13 +647,13 @@ msgstr ""
 "Số lần thử tải xuống trong trường hợp có lỗi (không được hỗ trợ bởi uclient-"
 "fetch)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr ""
 "Số lần đăng nhập không thành công của cùng một IP trong log trước khi chặn."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -757,7 +665,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Tổng quan"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -773,25 +681,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr "Log Xử lý"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "Hồ sơ được sử dụng bởi 'msmtp' cho thư thông báo banIP."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "Định dạng giao thức/URL không được hỗ trợ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "Nhận thông báo qua E-Mail mỗi khi chạy banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -803,35 +711,31 @@ msgstr ""
 msgid "Refresh"
 msgstr "Làm mới"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "Tải lại"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "Đường dẫn Report"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "Yếu tố báo cáo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "Khởi Động Lại"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr "Hạn chế truy cập internet từ/đến một số IP an toàn nhỏ."
 
@@ -848,19 +752,19 @@ msgstr "Quy tắc v4"
 msgid "Rulev6"
 msgstr "Quy tắc v6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "Run flags"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "Thông tin chạy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -876,23 +780,23 @@ msgstr "Tìm kiếm"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "Tìm kiếm các Bộ liên quan đến banIP cho một IP cụ thể."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "Chọn một trong các tiện ích tải xuống được cấu hình trước."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "Chọn thiết bị mạng WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "Chọn giao diện mạng IPv4 logic của WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "Chọn giao diện mạng IPv6 logic của WAN."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Địa chỉ người gửi cho thư thông báo banIP."
 
@@ -901,7 +805,7 @@ msgstr "Địa chỉ người gửi cho thư thông báo banIP."
 msgid "Set"
 msgstr "Đặt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr ""
 
@@ -909,7 +813,7 @@ msgstr ""
 msgid "Set Reporting"
 msgstr "Đặt báo cáo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "Đặt kích thước phân chia"
 
@@ -925,57 +829,57 @@ msgstr "Đặt khảo sát..."
 msgid "Set details"
 msgstr "Chi tiết đặt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "Đặt chính sách nft cho các Bộ liên quan đến banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "Đặt mức syslog cho việc ghi log NFT."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "Cài đặt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr "Phân chia tải Bộ ngoại vi sau mỗi n thành viên để tiết kiệm RAM."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "Trạng thái"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "Dừng"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "Mạng con (mặc định)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "Mạng con"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "Khảo sát"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "Thông tin hệ thống"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "Thư mục đích cho các tệp báo cáo liên quan đến banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "Thư mục đích cho sao lưu nguồn cấp dữ liệu được nén."
 
@@ -987,13 +891,13 @@ msgstr "Danh sách cho phép quá lớn, không thể lưu các chỉnh sửa."
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "Danh sách chặn quá lớn, không thể lưu các chỉnh sửa."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr "Ưu tiên được chọn sẽ được sử dụng cho xử lý nền banIP."
 
@@ -1038,7 +942,7 @@ msgstr ""
 msgid "Timestamp"
 msgstr "Dấu thời gian"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
@@ -1046,23 +950,23 @@ msgstr ""
 "Để bật thông báo qua email, thiết lập gói 'msmtp' và chỉ định địa chỉ email "
 "người nhận hợp lệ."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "Chủ đề cho Email thông báo banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1074,11 +978,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1105,11 +1013,11 @@ msgstr "Tải lên Bộ sưu tập Tùy chỉnh"
 msgid "Upload of the custom feed file failed."
 msgstr "Tải lên tệp Bộ sưu tập Tùy chỉnh không thành công."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "Ghi nhật ký gỡ lỗi chi tiết (Verbose Debug Logging)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "Phiên bản"
 
@@ -1117,8 +1025,8 @@ msgstr "Phiên bản"
 msgid "WAN-Forward (packets)"
 msgstr "Chuyển tiếp WAN (gói tin)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "Rào cản Chuyển tiếp WAN"
 
@@ -1126,8 +1034,8 @@ msgstr "Rào cản Chuyển tiếp WAN"
 msgid "WAN-Input (packets)"
 msgstr "Đầu vào WAN (gói tin)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "Rào cản Đầu vào WAN"
 
@@ -1147,7 +1055,7 @@ msgstr ""
 "quay lại phiên bản của người duy trì, chỉ cần làm trống lại tệp Bộ sưu tập "
 "Tùy chỉnh (không xóa nó!)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "cảnh báo"
 
@@ -1183,73 +1091,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "crit"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "debug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "emerg"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "err"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "danh sách cho phép cục bộ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "danh sách chặn cục bộ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "bộ nhớ (mặc định)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "bộ nhớ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "thông báo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "hiệu suất"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "cảnh báo (mặc định)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (mặc định)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "cảnh báo"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "Lựa chọn Feed cho Allowlist"
@@ -1358,11 +1254,8 @@ msgstr "cảnh báo (mặc định)"
 #~ msgid "reload"
 #~ msgstr "tải lại"
 
-#~ msgid "restart"
-#~ msgstr "khởi động lại"
-
 #~ msgid "start (default)"
-#~ msgstr "khởi động (mặc định)"
+#~ msgstr "khởi động"
 
 #~ msgid "Advanced"
 #~ msgstr "Nâng cao"

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -15,10 +15,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- IP 集选择 --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr "0 (禁用)"
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - 服务非洲和印度洋区域"
@@ -243,6 +239,7 @@ msgid ""
 "utilities automatically."
 msgstr "自动检测相关的网络设备、接口、子网、协议和工具。"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "禁用"

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -1212,12 +1212,6 @@ msgstr "警告"
 #~ msgid "start (default)"
 #~ msgstr "启动"
 
-#~ msgid "Allow VLAN Forwads"
-#~ msgstr "允许 VLAN 转发"
-
-#~ msgid "Block VLAN Forwads"
-#~ msgstr "拦截 VLAN 转发"
-
 #~ msgid ""
 #~ "Deduplicate IP addresses across all active Sets and and tidy up the local "
 #~ "blocklist."

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -413,12 +413,12 @@ msgid "Highest Priority"
 msgstr "最高优先级"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
-msgstr "ICMP-Treshold"
+msgid "ICMP-Threshold"
+msgstr "ICMP-Threshold"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
-msgstr "每秒钟数据包中的 ICMP-Treshold ，防止 WAN-DDOS 攻击。"
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
+msgstr "每秒钟数据包中的 ICMP-Threshold ，防止 WAN-DDOS 攻击。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
@@ -735,12 +735,12 @@ msgid "Run Information"
 msgstr "运行信息"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
-msgstr "SYN-Treshold"
+msgid "SYN-Threshold"
+msgstr "SYN-Threshold"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
-msgstr "每秒钟数据包中的 SYN-Treshold，防止 WAN-DDoS 攻击。"
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
+msgstr "每秒钟数据包中的 SYN-Threshold，防止 WAN-DDoS 攻击。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
 msgid "Save Custom Feeds"
@@ -931,12 +931,12 @@ msgid "Trigger Delay"
 msgstr "触发延时"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
-msgstr "UDP-Treshold"
+msgid "UDP-Threshold"
+msgstr "UDP-Threshold"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
-msgstr "每秒钟数据包内的 UDP-Treshold，防止 WAN-DDoS 攻击。"
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
+msgstr "每秒钟数据包内的 UDP-Threshold，防止 WAN-DDoS 攻击。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203
 msgid "URLv4"

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -93,7 +93,7 @@ msgstr "始终拦截特定的 VLAN 转发。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "重启"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -208,8 +208,8 @@ msgstr ""
 "target=\"_blank\" rel=\"noreferrer noopener\" >在线文档</a>"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr "国家或地区（RIR）"
+msgid "Countries"
+msgstr "国家或地区"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1133,9 +1133,6 @@ msgstr "警告"
 #~ "href=\"https://github.com/openwrt/packages/blob/master/net/banip/files/"
 #~ "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >查看在线文档</"
 #~ "a>"
-
-#~ msgid "Countries"
-#~ msgstr "地区"
 
 #~ msgid "External allowlist feeds"
 #~ msgstr "外部白名单源"

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -15,155 +15,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- IP 集选择 --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr "-100 (默认)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr "-150"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr "-200"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr "0 (禁用)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr "1"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr "10"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr "10 (默认)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr "100"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (默认)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (默认)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr "20"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr "3"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr "5 (默认)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr "AFRINIC - 服务非洲和印度洋区域"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr "APNIC - 服务亚太区域"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr "ARIN - 服务加拿大和美国"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "平均取样数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "活动设备"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "活跃源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr "活跃的上行线路"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr "接口重载和启动之间额外的触发间隔（单位：秒）。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr "允许协议/端口"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr "允许 VLAN 转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr "白名单源 URL"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "仅白名单"
 
@@ -173,83 +77,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr "已保存白名单更改，启动域名查询或要让更改生效请重启 banIP。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr "在 WAN-Input 和 Wan-Forward 链中始终允许协议（tcp/udp）特定端口或端口区间。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr "始终允许特定的 VLAN 转发。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr "始终拦截特定的 VLAN 转发。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr "自动允许上行线路"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "自动白名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr "自动拦截子网"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "自动黑名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "自动检测"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr "基于和可疑 IP 地址的额外 RDAP 请求自动添加条目子网到黑名单集。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr "自动添加已解析域名和可疑 IP 到本地 banIP 黑名单。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr "自动添加已解析域名和上行线路 IP 到本地 banIP 白名单。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "备份目录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "基础目录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "banIP 处理时的基础工作目录。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr "拦截类型"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr "拦截 VLAN 转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr "黑名单源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr "黑名单集过期时间"
 
@@ -259,14 +167,14 @@ msgid ""
 "banIP that changes take effect."
 msgstr "已保存黑名单更改，启动域名查询或要让更改生效请重启 banIP。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 "每个订阅源默认在所有受支持的链中处于活跃状态。将默认拦截策略限制到特定的链。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "CPU 核心"
 
@@ -275,14 +183,14 @@ msgstr "CPU 核心"
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "链优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr "此标签页上进行的更改需要重启 banIP 服务才能生效。"
 
@@ -290,7 +198,7 @@ msgstr "此标签页上进行的更改需要重启 banIP 服务才能生效。"
 msgid "Clear Custom Feeds"
 msgstr "清除自定义源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -303,7 +211,7 @@ msgstr ""
 "://github.com/openwrt/packages/blob/master/net/banip/files/README.md\" "
 "target=\"_blank\" rel=\"noreferrer noopener\" >在线文档</a>"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr "国家或地区（RIR）"
 
@@ -311,17 +219,17 @@ msgstr "国家或地区（RIR）"
 msgid "Custom Feed Editor"
 msgstr "自定义源的编辑器"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr "去除所有活跃集合中的重复 IP 地址并整理本地黑名单。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "IP 去重"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr "默认拦截策略"
 
@@ -329,21 +237,21 @@ msgstr "默认拦截策略"
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr "自动检测相关的网络设备、接口、子网、协议和工具。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr "禁用"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr "域名查询"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "下载期间不检查 SSL 服务器证书。"
 
@@ -351,49 +259,49 @@ msgstr "下载期间不检查 SSL 服务器证书。"
 msgid "Download Custom Feeds"
 msgstr "下载自定义源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "下载不安全"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr "下载重试"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr "静默丢弃数据包或主动拒绝 WAN-Input 和 WAN 转发链上的流量。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "电子邮件通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "电子邮件设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -409,7 +317,7 @@ msgstr "编辑黑名单"
 msgid "Edit Custom Feeds"
 msgstr "编辑自定义源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "元素数量"
 
@@ -419,47 +327,47 @@ msgstr "元素"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr "不允许空白字段"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr "开启远程日志记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "启用 banIP 服务。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr "允许 cgi 接口接收远程日志记录事件。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "如遇处理错误启用详细调试记录。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "已启用"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "启用 IPv4 支持。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "启用 IPv6 支持。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr "自动添加的黑名单集成员的过期时间。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr "外部白名单源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr "外部黑名单源"
 
@@ -467,11 +375,11 @@ msgstr "外部黑名单源"
 msgid "Feed Name"
 msgstr "源名称"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "源选择"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr "源/集合设置"
 
@@ -491,7 +399,7 @@ msgstr "标记"
 msgid "Flag not supported"
 msgstr "此标记不受支持"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "常规设置"
 
@@ -499,23 +407,23 @@ msgstr "常规设置"
 msgid "Grant access to LuCI app banIP"
 msgstr "授予访问 LuCI 应用 banIP 的权限"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "较高优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "最高优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr "ICMP-Treshold"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "每秒钟数据包中的 ICMP-Treshold ，防止 WAN-DDOS 攻击。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr "IP"
 
@@ -527,34 +435,34 @@ msgstr "IP 搜索"
 msgid "IP Search..."
 msgstr "IP 搜索…"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr "IPv4 网络接口"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 支持"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr "IPv6 网络接口"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "IPv6 支持"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr "提升打开文件的最大数目来应对加载集合时的众多临时分割文件。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "信息"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr "无效字符"
 
@@ -562,7 +470,7 @@ msgstr "无效字符"
 msgid "Invalid input values, unable to save modifications."
 msgstr "无效的输入值，无法保存更改。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr "LACNIC - 服务拉丁美洲和加勒比地区"
 
@@ -570,50 +478,50 @@ msgstr "LACNIC - 服务拉丁美洲和加勒比地区"
 msgid "LAN-Forward (packets)"
 msgstr "局域网转发（数据包）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "局域网转发链"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "最后运行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "最低优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "较低优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "限制特定源到局域网转发链。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "限制特定源到广域网转发链。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "限制特定源到广域网输入链。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "限制 banIP 使用的 cpu 核心数来节省内存。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr "限制上行线路自动允许功能。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr "在状态和报告中列出集元素，禁用此功能可减少 CPU 负荷。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr "可用的重载触发接口的列表。"
 
@@ -621,85 +529,85 @@ msgstr "可用的重载触发接口的列表。"
 msgid "List the elements of a specific banIP-related Set."
 msgstr "列出与某一特定 banIP 有关的集的元素。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr "本地源设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr "通过 syslog-ng 解析日志文件来取消通过 logread 的标准解析的位置。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "日志数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "记录局域网转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "日志限制"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr "记录预路由"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "日志设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "日志项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "记录广域网转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "记录广域网输入"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr "记录可疑的预路由包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr "记录可疑的已转发的 LAN 数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr "记录可疑的已转发的 WAN 数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr "记录可疑的传入 WAN 数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr "日志文件位置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "打开文件的最大数目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "NFT 信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr "NFT 日志级别"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "网络设备"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Nice 级别"
 
@@ -712,22 +620,22 @@ msgstr "无搜索结果！"
 msgid "No banIP related firewall logs yet!"
 msgstr "还没有 banIP 相关的防火墙日志！"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "正常优先级（默认）"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "正常优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr "下载出错时的重试次数（uclient-fetch 不支持）。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr "进行拦截前允许同一 IP 的失败登录尝试在日志中出现几次。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -737,7 +645,7 @@ msgstr "对所选的下载工具绕过预先配置的下载选项。"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -752,25 +660,25 @@ msgstr "端口/协议限制"
 msgid "Processing Log"
 msgstr "处理日志"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "“msmtp”所用的 banIP 电子邮件通知配置。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr "不受支持的协议/URL 格式"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr "RIPE - 服务欧洲、中东和中亚"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr "接收每次 banIP 运行的电子邮件通知。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -780,35 +688,31 @@ msgstr "banIP 通知电子邮件的接收地址，要开启电子邮件功能必
 msgid "Refresh"
 msgstr "刷新"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr "区域互联网注册系统"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "重新载入"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr "重载触发接口"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr "远端令牌"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "报告元素"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "重启"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr "限制来自/对少量安全 IP 的互联网访问。"
 
@@ -825,19 +729,19 @@ msgstr "v4规则"
 msgid "Rulev6"
 msgstr "v6规则"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "运行标记"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "运行信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr "SYN-Treshold"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "每秒钟数据包中的 SYN-Treshold，防止 WAN-DDoS 攻击。"
 
@@ -853,23 +757,23 @@ msgstr "搜索"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "在 banIP 相关的集中搜索一个特定的 IP。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "选择一个预先配置的下载工具。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "选择广域网网络设备。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "选择逻辑广域网 IPv4 网络接口。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "选择逻辑广域网 IPv6 网络接口。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "banIP 通知邮件的发送地址。"
 
@@ -878,7 +782,7 @@ msgstr "banIP 通知邮件的发送地址。"
 msgid "Set"
 msgstr "设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "设置策略"
 
@@ -886,7 +790,7 @@ msgstr "设置策略"
 msgid "Set Reporting"
 msgstr "设置报告"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "设置分割尺寸"
 
@@ -902,57 +806,57 @@ msgstr "设置调查…"
 msgid "Set details"
 msgstr "集详情"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr "设置 banIP 包内部的 nft 链优先级，值越低，优先级越高。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr "设置 banIP 相关集合的 nft 策略。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "设定 NFT 日志记录的 syslog 级别。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr "每 n 个成员后分割外部集加载来节省内存。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "状态"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "停止"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
-msgstr "子网（默认）"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
+msgstr "子网"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "调查"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "系统信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr "表/链设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "banIP 相关报告文件的目标目录。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "压缩的源备份文件的目标目录。"
 
@@ -964,13 +868,13 @@ msgstr "白名单过大，无法保存更改。"
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "黑名单过大，无法保存更改。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr "默认正则表达式过滤可疑的 ssh、LuCI、nginx 和星号流量。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr "所选的优先级将用于 banIP 后台处理。"
 
@@ -1011,29 +915,29 @@ msgstr "此标签页显示最后生成的集报告，按下“刷新“按钮获
 msgid "Timestamp"
 msgstr "时间戳"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr "要开启电子邮件通知，请设置 'msmtp' 包并指定有效的电子邮件接收者地址。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr "和 cgi 接口通信的令牌。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "banIP 通知邮件的主题。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "触发延时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr "UDP-Treshold"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr "每秒钟数据包内的 UDP-Treshold，防止 WAN-DDoS 攻击。"
 
@@ -1045,11 +949,15 @@ msgstr "URLv4"
 msgid "URLv6"
 msgstr "URLv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr "无法解析自定义的源文件：%s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr "无法解析默认的源文件：%s"
 
@@ -1076,11 +984,11 @@ msgstr "上传自定义源"
 msgid "Upload of the custom feed file failed."
 msgstr "上传自定义源失败。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "版本"
 
@@ -1088,8 +996,8 @@ msgstr "版本"
 msgid "WAN-Forward (packets)"
 msgstr "广域网转发（数据包）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "广域网转发链"
 
@@ -1097,8 +1005,8 @@ msgstr "广域网转发链"
 msgid "WAN-Input (packets)"
 msgstr "广域网输入（数据包）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "广域网输入链"
 
@@ -1116,7 +1024,7 @@ msgstr ""
 "或添加条目或进行本地备份。要返回维护者版本，只需再次清空自定义源的文件（不是"
 "删除！）。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "报警"
 
@@ -1152,73 +1060,61 @@ msgstr "拦截了 syn-flood 包"
 msgid "blocked udp-flood packets"
 msgstr "拦截了 udp-flood 包"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "关键项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "调试"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
-msgstr "丢弃（默认）"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
+msgstr "丢弃"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "紧急项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "错误项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "信息项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr "本地白名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr "本地黑名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "内存（默认）"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "内存"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "性能"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr "拒绝"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "警告（默认）"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (默认)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "警告"
 
 #~ msgid "Allowlist Feed Selection"
 #~ msgstr "白名单源选择"
@@ -1319,11 +1215,8 @@ msgstr "警告（默认）"
 #~ msgid "reload"
 #~ msgstr "重新加载"
 
-#~ msgid "restart"
-#~ msgstr "重启"
-
 #~ msgid "start (default)"
-#~ msgstr "启动（默认）"
+#~ msgstr "启动"
 
 #~ msgid "Allow VLAN Forwads"
 #~ msgstr "允许 VLAN 转发"
@@ -1458,7 +1351,7 @@ msgstr "警告（默认）"
 #~ msgstr "无法保存更改：%s"
 
 #~ msgid "-m limit --limit 2/sec (default)"
-#~ msgstr "-m limit --limit 2/sec（默认）"
+#~ msgstr "-m limit --limit 2/sec"
 
 #~ msgid "1 hour"
 #~ msgstr "1 小时"

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -14,10 +14,6 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- IP 集合選擇 --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
-msgid "0 (disable)"
-msgstr ""
-
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
@@ -237,6 +233,7 @@ msgid ""
 "utilities automatically."
 msgstr "自動偵測相關的網路裝置、介面、子網路、協定和工具。"
 
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -202,8 +202,8 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
-msgid "Countries (RIR)"
-msgstr ""
+msgid "Countries"
+msgstr "地區"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:174
 msgid "Custom Feed Editor"
@@ -1098,9 +1098,6 @@ msgstr "警告"
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "IP 鏈結/集合設定"
-
-#~ msgid "Countries"
-#~ msgstr "地區"
 
 #~ msgid "Log suspicious forwarded LAN packets (rejected)."
 #~ msgstr "記錄可疑的轉發區域網路資料封包 (已拒絕)。"

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -14,155 +14,59 @@ msgstr ""
 msgid "-- Set Selection --"
 msgstr "-- IP 集合選擇 --"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
-msgid "-100 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:396
-msgid "-150"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:397
-msgid "-200"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:394
-msgid "0"
-msgstr "0"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:557
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:577
 msgid "0 (disable)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:312
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:418
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:428
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:438
-msgid "1"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:315
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
-msgid "10"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:429
-msgid "10 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "100"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:441
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:559
-msgid "100 (default)"
-msgstr "100 (預設)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:562
-msgid "1000"
-msgstr "1000"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
-msgid "1024 (default)"
-msgstr "1024 (預設)"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
-msgid "20"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
-msgid "2048"
-msgstr "2048"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:422
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:432
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
-msgid "250"
-msgstr "250"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:313
-msgid "3"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
-msgid "4096"
-msgstr "4096"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:314
-msgid "5 (default)"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:430
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:440
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:558
-msgid "50"
-msgstr "50"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:423
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:433
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:561
-msgid "500"
-msgstr "500"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:340
-msgid "512"
-msgstr "512"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:656
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:682
 msgid "AFRINIC - serving Africa and the Indian Ocean region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:657
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
 msgid "APNIC - serving the Asia Pacific region"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:658
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:684
 msgid "ARIN - serving Canada and the United States"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:664
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
 msgid "ASNs"
 msgstr "平均取樣數"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:171
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:181
 msgid "Active Devices"
 msgstr "使用中的裝置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:167
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:177
 msgid "Active Feeds"
 msgstr "使用中來源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:175
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:185
 msgid "Active Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Additional trigger delay in seconds during interface reload and boot."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:237
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
 msgid "Advanced Settings"
 msgstr "進階設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Allow Protocol/Ports"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Allow VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:673
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
 msgid "Allowlist Feed URLs"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Allowlist Only"
 msgstr "僅白名單"
 
@@ -172,83 +76,87 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:401
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid ""
 "Always allow a protocol (tcp/udp) with certain ports or port ranges in WAN-"
 "Input and WAN-Forward chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:405
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:419
 msgid "Always allow certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Always block certain VLAN forwards."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
+msgid "Apply & Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Auto Allowlist"
 msgstr "自動白名單"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid "Auto Block Subnet"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid "Auto Blocklist"
 msgstr "自動黑名單"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid "Auto Detection"
 msgstr "自動偵測"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:715
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:746
 msgid ""
 "Automatically add entire subnets to the blocklist Set based on an additional "
 "RDAP request with the suspicious IP."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:711
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:742
 msgid ""
 "Automatically add resolved domains and suspicious IPs to the local banIP "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:699
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid ""
 "Automatically add resolved domains and uplink IPs to the local banIP "
 "allowlist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base Directory"
 msgstr "基礎目錄"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:366
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:379
 msgid "Base working directory while banIP processing."
 msgstr "banIP 處理時的基礎工作目錄。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid "Block Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Block VLAN Forwards"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:651
 msgid "Blocklist Feed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Blocklist Set Expiry"
 msgstr ""
 
@@ -258,13 +166,13 @@ msgid ""
 "banIP that changes take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid ""
 "By default each feed is active in all supported chains. Limit the default "
 "block policy to a certain chain."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "CPU Cores"
 msgstr "CPU 核心"
 
@@ -273,14 +181,14 @@ msgstr "CPU 核心"
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid "Chain Priority"
 msgstr "鏈優先順序"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:328
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:452
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:526
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:404
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:545
 msgid "Changes on this tab needs a banIP service restart to take effect."
 msgstr ""
 
@@ -288,7 +196,7 @@ msgstr ""
 msgid "Clear Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:30
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:40
 msgid ""
 "Configuration of the banIP package to ban incoming and outgoing IPs via "
 "named nftables Sets. For further information please check the <a "
@@ -297,7 +205,7 @@ msgid ""
 "rel=\"noreferrer noopener\" >online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:644
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:665
 msgid "Countries (RIR)"
 msgstr ""
 
@@ -305,17 +213,17 @@ msgstr ""
 msgid "Custom Feed Editor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid ""
 "Deduplicate IP addresses across all active Sets and tidy up the local "
 "blocklist."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:378
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
 msgid "Deduplicate IPs"
 msgstr "刪除重複 IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:466
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Default Block Policy"
 msgstr ""
 
@@ -323,21 +231,21 @@ msgstr ""
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:253
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:263
 msgid ""
 "Detect relevant network devices, interfaces, subnets, protocols and "
 "utilities automatically."
 msgstr "自動偵測相關的網路裝置、介面、子網路、協定和工具。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:735
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:214
 msgid "Domain Lookup"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Don't check SSL server certificates during download."
 msgstr "下載期間不檢查 SSL 伺服器證書。"
 
@@ -345,49 +253,49 @@ msgstr "下載期間不檢查 SSL 伺服器證書。"
 msgid "Download Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:320
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Download Insecure"
 msgstr "下載不安全"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid "Download Parameters"
 msgstr "下載參數"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid "Download Retries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Download Utility"
 msgstr "下載工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:460
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:478
 msgid ""
 "Drop packets silently or actively reject the traffic on WAN-Input and WAN-"
 "Forward chains."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "E-Mail Profile"
 msgstr "電郵設定檔"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid "E-Mail Receiver Address"
 msgstr "電郵收件人位址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "E-Mail Sender Address"
 msgstr "電郵寄件人位址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:241
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:251
 msgid "E-Mail Settings"
 msgstr "電子郵件設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "E-Mail Topic"
 msgstr "電郵主旨"
 
@@ -403,7 +311,7 @@ msgstr "編輯黑名單"
 msgid "Edit Custom Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:173
 msgid "Element Count"
 msgstr "元素數量"
 
@@ -413,47 +321,47 @@ msgstr "元素"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:195
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:233
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:585
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
 msgid "Empty field not allowed"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable Remote Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enable the banIP service."
 msgstr "啟用 banIP 服務。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:575
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:596
 msgid "Enable the cgi interface to receive remote logging events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Enable verbose debug logging in case of processing errors."
 msgstr "如遇處理錯誤啟用詳細偵錯記錄。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:247
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:257
 msgid "Enabled"
 msgstr "啟用"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "Enables IPv4 support."
 msgstr "啟用 IPv4 支援。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "Enables IPv6 support."
 msgstr "啟用 IPv6 支援。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:751
 msgid "Expiry time for auto added blocklist Set members."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:671
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "External Allowlist Feeds"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:627
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:648
 msgid "External Blocklist Feeds"
 msgstr ""
 
@@ -461,11 +369,11 @@ msgstr ""
 msgid "Feed Name"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:242
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:252
 msgid "Feed Selection"
 msgstr "來源選擇"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:239
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:249
 msgid "Feed/Set Settings"
 msgstr ""
 
@@ -485,7 +393,7 @@ msgstr ""
 msgid "Flag not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:246
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -493,23 +401,23 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app banIP"
 msgstr "授予存取 LuCI 應用 banIP 的權限"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:332
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:343
 msgid "High Priority"
 msgstr "較高優先順序"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:342
 msgid "Highest Priority"
 msgstr "最高優先順序"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:417
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
 msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:707
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
 msgid "IP"
 msgstr ""
 
@@ -521,34 +429,34 @@ msgstr "IP 搜尋"
 msgid "IP Search..."
 msgstr "IP 搜尋…"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "IPv4 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:256
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
 msgid "IPv4 Support"
 msgstr "IPv4 支援"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "IPv6 Network Interfaces"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:261
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:271
 msgid "IPv6 Support"
 msgstr "支援 IPv6"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid ""
 "Increase the maximal number of open files, e.g. to handle the amount of "
 "temporary split files while loading the Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:163
 msgid "Information"
 msgstr "資訊"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:198
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:588
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
 msgid "Invalid characters"
 msgstr ""
 
@@ -556,7 +464,7 @@ msgstr ""
 msgid "Invalid input values, unable to save modifications."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:659
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:685
 msgid "LACNIC - serving the Latin American and Caribbean region"
 msgstr ""
 
@@ -564,50 +472,50 @@ msgstr ""
 msgid "LAN-Forward (packets)"
 msgstr "區域網路轉發 (資料封包)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:469
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "LAN-Forward Chain"
 msgstr "區域網路轉發鏈"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:191
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:201
 msgid "Last Run"
 msgstr "最後執行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:335
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:346
 msgid "Least Priority"
 msgstr "最低優先順序"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:334
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:345
 msgid "Less Priority"
 msgstr "較低優先順序"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Limit certain feeds to the LAN-Forward chain."
 msgstr "限制特定來源到區域網路轉發鏈。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "Limit certain feeds to the WAN-Forward chain."
 msgstr "限制特定來源到廣域網路轉發鏈。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "Limit certain feeds to the WAN-Input chain."
 msgstr "限制特定來源到廣域網路輸入鏈。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:347
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:360
 msgid "Limit the cpu cores used by banIP to save RAM."
 msgstr "限制 banIP 使用的 cpu 核心數來節省記憶體。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:703
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Limit the uplink autoallow function."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "List Set elements in the status and report, disable this to reduce the CPU "
 "load."
 msgstr "在狀態和報告中列出集合元素，停用此功能可減少 CPU 負荷。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "List of available reload trigger interface(s)."
 msgstr ""
 
@@ -615,85 +523,85 @@ msgstr ""
 msgid "List the elements of a specific banIP-related Set."
 msgstr "列出與某一特定 banIP 有關的集合的元素。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:727
 msgid "Local Feed Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid ""
 "Location for parsing the log file, e.g. via syslog-ng, to deactivate the "
 "standard parsing via logread."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid "Log Count"
 msgstr "日誌數"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log LAN-Forward"
 msgstr "記錄區域網路轉發"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid "Log Limit"
 msgstr "日誌限制"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log Prerouting"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:240
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
 msgid "Log Settings"
 msgstr "日誌設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid "Log Terms"
 msgstr "日誌項目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log WAN-Forward"
 msgstr "記錄廣域網路轉發"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log WAN-Input"
 msgstr "記錄廣域網路輸入"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:540
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:560
 msgid "Log suspicious Prerouting packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
 msgid "Log suspicious forwarded LAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:546
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
 msgid "Log suspicious forwarded WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:543
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:563
 msgid "Log suspicious incoming WAN packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:572
 msgid "Logfile Location"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:339
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:351
 msgid "Max Open Files"
 msgstr "開啟檔案的最大數目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:179
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:189
 msgid "NFT Information"
 msgstr "NFT 資訊"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "NFT Log Level"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Network Devices"
 msgstr "網路裝置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "Nice Level"
 msgstr "Nice 級別"
 
@@ -706,22 +614,22 @@ msgstr "無搜尋結果！"
 msgid "No banIP related firewall logs yet!"
 msgstr "還沒有 banIP 相關的防火牆日誌！"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:333
-msgid "Normal Priority (default)"
-msgstr "正常優先順序 (預設)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:344
+msgid "Normal Priority"
+msgstr "正常優先順序"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:321
 msgid ""
 "Number of download attempts in case of an error (not supported by uclient-"
 "fetch)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:566
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:587
 msgid ""
 "Number of failed login attempts of the same IP in the log before blocking."
 msgstr "進行攔截前允許同一 IP 的失敗登錄嘗試在日誌中出現幾次。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:296
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
 msgid ""
 "Override the pre-configured download options for the selected download "
 "utility."
@@ -731,7 +639,7 @@ msgstr "對所選的下載工具繞過預先設定的下載選項。"
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:556
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:576
 msgid ""
 "Parse only the last stated number of log entries for suspicious events. To "
 "disable the log monitor at all set it to '0'."
@@ -745,25 +653,25 @@ msgstr ""
 msgid "Processing Log"
 msgstr "處理日誌"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:638
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "「msmtp」所用的 banIP 電子郵件通知設定。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:209
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:222
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:690
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:720
 msgid "Protocol/URL format not supported"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:660
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:686
 msgid "RIPE - serving Europe, Middle East and Central Asia"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:623
 msgid "Receive E-Mail notifications with every banIP run."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:605
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:626
 msgid ""
 "Receiver address for banIP notification E-Mails, this information is "
 "required to enable E-Mail functionality."
@@ -773,35 +681,31 @@ msgstr "banIP 通知電子郵件的接收位址，要開啟電子郵件功能必
 msgid "Refresh"
 msgstr "重新整理"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:655
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:681
 msgid "Regional Internet Registry"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:218
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:228
 msgid "Reload"
 msgstr "重新載入"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:301
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:311
 msgid "Reload Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Remote Token"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:382
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "Report Elements"
 msgstr "報告元素"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:225
-msgid "Restart"
-msgstr "重新啟動"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:761
 msgid "Restrict the internet access from/to a small number of secure IPs."
 msgstr "限制來自/對少量安全 IP 的網際網路存取。"
 
@@ -818,19 +722,19 @@ msgstr ""
 msgid "Rulev6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:187
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:197
 msgid "Run Flags"
 msgstr "執行旗標"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:183
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:193
 msgid "Run Information"
 msgstr "執行資訊"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:427
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
 msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -846,23 +750,23 @@ msgstr "搜尋"
 msgid "Search the banIP-related Sets for a specific IP."
 msgstr "在 banIP 相關的集合中搜尋一個特定的 IP。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:287
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:297
 msgid "Select one of the pre-configured download utilities."
 msgstr "選擇一個預先設定的下載工具。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:266
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:276
 msgid "Select the WAN network device(s)."
 msgstr "選擇廣域網路網路裝置。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:273
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:283
 msgid "Select the logical WAN IPv4 network interface(s)."
 msgstr "選擇邏輯廣域網路 IPv4 網路介面。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:280
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:290
 msgid "Select the logical WAN IPv6 network interface(s)."
 msgstr "選擇邏輯廣域網路 IPv6 網路介面。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:609
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:630
 msgid "Sender address for banIP notification E-Mails."
 msgstr "banIP 通知郵件的傳送位址。"
 
@@ -871,7 +775,7 @@ msgstr "banIP 通知郵件的傳送位址。"
 msgid "Set"
 msgstr "設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set Policy"
 msgstr "設定原則"
 
@@ -879,7 +783,7 @@ msgstr "設定原則"
 msgid "Set Reporting"
 msgstr "設定報告"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Set Split Size"
 msgstr "設定分割尺寸"
 
@@ -895,57 +799,57 @@ msgstr "設定調查…"
 msgid "Set details"
 msgstr "集合詳情"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:393
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
 msgid ""
 "Set the nft chain priority within the banIP table, lower values means higher "
 "priority."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:454
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the nft policy for banIP-related Sets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:528
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:547
 msgid "Set the syslog level for NFT logging."
 msgstr "設定 NFT 日誌記錄的 syslog 級別。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:234
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:244
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:356
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:369
 msgid "Split external Set loading after every n members to save RAM."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:155
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:165
 msgid "Status"
 msgstr "狀態"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:211
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:221
 msgid "Stop"
 msgstr "停止"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
-msgid "Subnet (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:736
+msgid "Subnet"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js:129
 msgid "Survey"
 msgstr "調查"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:195
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:205
 msgid "System Information"
 msgstr "系統資訊"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:238
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:248
 msgid "Table/Chain Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:374
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:387
 msgid "Target directory for banIP-related report files."
 msgstr "banIP 相關報告檔案的目標目錄。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:370
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:383
 msgid "Target directory for compressed feed backups."
 msgstr "壓縮的來源備份檔案的目標目錄。"
 
@@ -957,13 +861,13 @@ msgstr "白名單過大，無法儲存變更。"
 msgid "The blocklist is too big, unable to save modifications."
 msgstr "黑名單過大，無法儲存變更。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:571
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:592
 msgid ""
 "The default regular expressions are filtering suspicious ssh, LuCI, nginx "
 "and asterisk traffic."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:330
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:341
 msgid "The selected priority will be used for banIP background processing."
 msgstr "所選的優先順序將用於 banIP 背景處理。"
 
@@ -998,29 +902,29 @@ msgstr "此標籤頁顯示最後產生的集合報告，按下「更新」按鈕
 msgid "Timestamp"
 msgstr "時間戳"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:600
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid ""
 "To enable email notifications, set up the 'msmtp' package and specify a "
 "vaild E-Mail receiver address."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:601
 msgid "Token to communicate with the cgi interface."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:613
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:634
 msgid "Topic for banIP notification E-Mails."
 msgstr "banIP 通知郵件的主題。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:306
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:316
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:437
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
 msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
@@ -1032,11 +936,15 @@ msgstr ""
 msgid "URLv6"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:674
+msgid "Unable to parse the countries file: %s"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
 msgid "Unable to parse the custom feed file: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "Unable to parse the default feed file: %s"
 msgstr ""
 
@@ -1063,11 +971,11 @@ msgstr ""
 msgid "Upload of the custom feed file failed."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:250
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:260
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:159
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:169
 msgid "Version"
 msgstr "版本"
 
@@ -1075,8 +983,8 @@ msgstr "版本"
 msgid "WAN-Forward (packets)"
 msgstr "廣域網路轉發 (資料封包)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:468
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:519
 msgid "WAN-Forward Chain"
 msgstr "廣域網路轉發鏈"
 
@@ -1084,8 +992,8 @@ msgstr "廣域網路轉發鏈"
 msgid "WAN-Input (packets)"
 msgstr "廣域網路輸入 (資料封包)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:509
 msgid "WAN-Input Chain"
 msgstr "廣域網路輸入鏈"
 
@@ -1099,7 +1007,7 @@ msgid ""
 "it!)."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:549
 msgid "alert"
 msgstr "報警"
 
@@ -1135,73 +1043,61 @@ msgstr ""
 msgid "blocked udp-flood packets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:550
 msgid "crit"
 msgstr "關鍵項目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:536
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:555
 msgid "debug"
 msgstr "偵錯"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
-msgid "drop (default)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:479
+msgid "drop"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:548
 msgid "emerg"
 msgstr "緊急項目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:532
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:551
 msgid "err"
 msgstr "錯誤項目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:535
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:554
 msgid "info"
 msgstr "資訊項目"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:510
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:520
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:530
 msgid "local allowlist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:512
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:511
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:521
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:531
 msgid "local blocklist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
-msgid "memory (default)"
-msgstr "記憶體 (預設)"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+msgid "memory"
+msgstr "記憶體"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:534
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:553
 msgid "notice"
 msgstr "通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:456
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:473
 msgid "performance"
 msgstr "效能"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:462
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:480
 msgid "reject"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:533
-msgid "warn (default)"
-msgstr "警告 (預設)"
-
-#~ msgid "-100"
-#~ msgstr "-100"
-
-#~ msgid "-200 (default)"
-#~ msgstr "-200 (預設)"
-
-#~ msgid "-300"
-#~ msgstr "-300"
-
-#~ msgid "-400"
-#~ msgstr "-400"
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:552
+msgid "warn"
+msgstr "警告"
 
 #~ msgid "Chain/Set Settings"
 #~ msgstr "IP 鏈結/集合設定"
@@ -1367,7 +1263,7 @@ msgstr "警告 (預設)"
 #~ msgstr "無法儲存變更（訊息：%s）"
 
 #~ msgid "-m limit --limit 2/sec (default)"
-#~ msgstr "-m limit --limit 2/秒 (預設)"
+#~ msgstr "-m limit --limit 2/秒"
 
 #~ msgid "1 hour"
 #~ msgstr "1 小時"

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -92,7 +92,7 @@ msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:235
 msgid "Apply & Restart"
-msgstr ""
+msgstr "重新啟動"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:733
 msgid "Auto Allow Uplink"

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -407,11 +407,11 @@ msgid "Highest Priority"
 msgstr "最高優先順序"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold"
+msgid "ICMP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
-msgid "ICMP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "ICMP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:737
@@ -728,11 +728,11 @@ msgid "Run Information"
 msgstr "執行資訊"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold"
+msgid "SYN-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:442
-msgid "SYN-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "SYN-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:296
@@ -918,11 +918,11 @@ msgid "Trigger Delay"
 msgstr "觸發延遲"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold"
+msgid "UDP-Threshold"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:453
-msgid "UDP-Treshold in packets per second to prevent WAN-DDoS attacks."
+msgid "UDP-Threshold in packets per second to prevent WAN-DDoS attacks."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js:203


### PR DESCRIPTION
Maintainer: @dibdot

The app has a lot of options and translations for them.
This translations are precious: there are a lot of non technical people who use OpenWrt who can't even read English letters.
 
I noticed that when you changing a name of an option we need to translate all the keys again for all languages.

For example the `Countries` was changed to `Countries (RIR)`.
This is very easy to add the RIR to all existing translations with a bulk replace.
But instead I made it simpler: I moved the RIR out of translation and the key become just the  `Countries` again and old translations were saved.

Similarly we had a button `restart` that was renamed to `Restart`. While the difference only in case this made all old translations commented out.
I restored them by simply renaming their key from the `restart` to the new `Restart`.
Yes, their translations remain in lower case but I was just too lazy to upper case them.

But then you again renamed the `Restart` to `Apply & Restart`. So I just renamed the key in translation too. Users will see just the old `Restart` in their lanuage but that's really a minor thing. The Weblate must show such changed strings as "Unchecked" so translators can find them easily and easily improve to the `Apply & Restart`.
The rename wasn't really changed a meaning of the button so in this case it's totally safe to just rename its key in po files.

Another problem is that some options have the ` (default)` suffix. In fact the Luci allows to specify `o.default` so that this is not needed but creates a burden fro translators.
I fixed that too.

So please review the PR. This changes should significantly reduce amount of time for translators (e.g. me too).

Once you reviewed please merge the Weblate changes first #7084
Then I'll fix merge conflicts and we can merge it.