### PR TITLE
luci-app-keepalived: move status page to status menu

### DIFF
--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
@@ -48,14 +48,14 @@ return view.extend({
 								}
 							}
 						}
-						return  [ 
+						return  [
 							target.data.iname,
 							target.data.ifp_ifname,
 							state,
 							target.stats.advert_sent,
 							target.stats.advert_rcvd,
 							new Date(target.data.last_transition * 1000)
-						];	
+						];
 					}),
 					E('em', _('There are no active instances'))
 				);

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
@@ -62,10 +62,10 @@ return view.extend({
 			});
 		});
 
-		return E([
-			E('h3', _('VRRP')),
-			E('br'),
-			table
+		return E('div', {'class': 'cbi-map'}, [
+			E('h2', _('VRRP')),
+			E('div', {'class': 'cbi-map-descr'}, _('This overview shows the current status of the VRRP instances on this device.')),
+			E('div', { 'class': 'cbi-section' }, table)
 		]);
 	},
 

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
@@ -63,7 +63,7 @@ return view.extend({
 		});
 
 		return E([
-			E('h3', _('Keepalived Instances Status')),
+			E('h3', _('VRRP')),
 			E('br'),
 			table
 		]);

--- a/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
+++ b/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
@@ -1,6 +1,6 @@
 {
 	"admin/services/keepalived": {
-		"title": "Keepalived",
+		"title": "VRRP",
 		"order": 1,
 		"action": {
 			"type": "alias",

--- a/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
+++ b/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
@@ -4,16 +4,7 @@
 		"order": 1,
 		"action": {
 			"type": "alias",
-			"path": "admin/services/keepalived/overview"
-		}
-	},
-
-	"admin/services/keepalived/overview": {
-		"title": "Overview",
-		"order": 10,
-		"action": {
-			"type": "view",
-			"path": "keepalived/overview"
+			"path": "admin/services/keepalived/globals"
 		}
 	},
 
@@ -104,6 +95,15 @@
 		"action": {
 			"type": "view",
 			"path": "keepalived/vrrp_sync_group"
+		}
+	},
+
+	"admin/status/keepalived": {
+		"title": "VRRP",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "keepalived/overview"
 		}
 	}
 }


### PR DESCRIPTION
@jempatel 

The main change her is moving the overview page to the status menu entry.
So the status page of keepalived is new under the status menu pages.
Old:
![old](https://github.com/openwrt/luci/assets/553091/232d8cfc-0dce-4e33-94d9-5e7a754bd9d0)

New:
![new](https://github.com/openwrt/luci/assets/553091/ef7f8846-f371-42a2-9390-3e00d0c50168)

While we are at it also add the missing cbi CSS class so it looks better on luci-theme-material and add a missing cbi-descr.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
