### PR TITLE
luci-theme-boostrap: dark realtime graphs - fix 

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2568,17 +2568,17 @@ div.cbi-value var.cbi-tooltip-container,
 }
 
 [data-darkmode="true"] [data-page="admin-status-channel_analysis"] #view> div > div > div > div > div[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div > div > div[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > div > div > div[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style] {
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > div > div[style] {
 	background-color: var(--background-color-high)!important;
 }
 
 [data-darkmode="true"] [data-page="admin-status-channel_analysis"] #view> div > div > div > div > div > svg > line[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div > svg > line[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div > div > div > svg > line[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div > svg > line[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > div > div > div > svg > line[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > svg > line[style] {
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > div > div > svg > line[style] {
 	stroke: #fff!important;
 }


### PR DESCRIPTION
This fixes the realtime graphs in Luci Bootstrap Dark theme after extra divs were added in https://github.com/openwrt/luci/pull/7079

