### PR TITLE
luci-mod-network: steering flow - permit only integer value

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1611,6 +1611,7 @@ return view.extend({
 		o.value('256', _('256'));
 		o.depends('packet_steering', '1');
 		o.depends('packet_steering', '2');
+		o.datatype = 'uinteger';
 		o.default = steer_flow;
 
 		if (dslModemType != null) {


### PR DESCRIPTION
An user can insert a strange value right now, with this commit, only integer value can be insert.

Tested working ok