### PR TITLE
luci-mod-status: auto-refresh system log and kernel log

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -1,21 +1,37 @@
 'use strict';
 'require view';
 'require fs';
+'require poll';
 'require ui';
 
 return view.extend({
-	load: function() {
-		return fs.exec_direct('/bin/dmesg', [ '-r' ]).catch(function(err) {
+	retrieveLog: async function() {
+		return fs.exec_direct('/bin/dmesg', [ '-r' ]).then(logdata => {
+			const loglines = logdata.trim().split(/\n/).map(function(line) {
+				return line.replace(/^<\d+>/, '');
+			});
+			return { value: loglines.join('\n'), rows: loglines.length + 1 };
+		}).catch(function(err) {
 			ui.addNotification(null, E('p', {}, _('Unable to load log data: ' + err.message)));
 			return '';
 		});
 	},
 
-	render: function(logdata) {
-		var loglines = logdata.trim().split(/\n/).map(function(line) {
-			return line.replace(/^<\d+>/, '');
-		});
+	pollLog: async function() {
+		const element = document.getElementById('syslog');
+		if (element) {
+			const log = await this.retrieveLog();
+			element.value = log.value;
+			element.rows = log.rows;
+		}
+	},
 
+	load: async function() {
+		poll.add(this.pollLog.bind(this));
+		return await this.retrieveLog();
+	},
+
+	render: function(loglines) {
 		var scrollDownButton = E('button', { 
 				'id': 'scrollDownButton',
 				'class': 'cbi-button cbi-button-neutral',
@@ -43,8 +59,8 @@ return view.extend({
 					'style': 'font-size:12px',
 					'readonly': 'readonly',
 					'wrap': 'off',
-					'rows': loglines.length + 1
-				}, [ loglines.join('\n') ]),
+					'rows': loglines.rows
+				}, [ loglines.value ]),
 				E('div', {'style': 'padding-bottom: 20px'}, [scrollUpButton])
 			])
 		]);


### PR DESCRIPTION
Implements #5568. See attached video. I have by design not implemented any "follow tail" logic for the log as I was unsure how it should interact with the "Scroll to tail" and "Scroll to head" buttons that are already there (should it follow the tail even if the user hasn't clicked "Scroll to tail" yet?), but any suggestion how and if we should handle that is welcome.

I was a bit unsure if PKG_RELEASE should be incremented for modules; luci-mod-status hasn't received any since 938e54df17d6a48fc8d84fe5893ff67ffe4a3e6e even though the diff since that commit is quite big.

https://github.com/openwrt/luci/assets/7290072/815a0dea-fa35-4146-bba0-b0cfa2fdb87b

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/64, 23.05.3, Firefox) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: e.g. openwrt/luci#5568
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
