### PR TITLE
[RFC] luci-app-lxc: remove bypassing GPG validation

### DIFF
--- a/applications/luci-app-lxc/luasrc/controller/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/controller/lxc.lua
@@ -55,11 +55,10 @@ end
 
 function lxc_get_downloadable()
 	local target = lxc_get_arch_target(url)
-	local ssl_status = lxc_get_ssl_status()
 	local templates = {}
 
-	local f = io.popen('sh /usr/share/lxc/templates/lxc-download --list %s --server %s 2>/dev/null'
-		%{ ssl_status, url }, 'r')
+	local f = io.popen('sh /usr/share/lxc/templates/lxc-download --list --server %s 2>/dev/null'
+		%{ url }, 'r')
 	local line
 	for line in f:lines() do
 		local dist, version, dist_target = line:match("^(%S+)%s+(%S+)%s+(%S+)%s+default%s+%S+$")
@@ -80,10 +79,9 @@ function lxc_create(lxc_name, lxc_template)
 		return
 	end
 
-	local ssl_status = lxc_get_ssl_status()
 	local lxc_dist, lxc_release = lxc_template:match("^(.+):(.+)$")
-	luci.sys.call('/usr/bin/lxc-create --quiet --name %s --bdev best --template download -- --dist %s --release %s --arch %s --server %s %s'
-		%{ lxc_name, lxc_dist, lxc_release, lxc_get_arch_target(url), url, ssl_status })
+	luci.sys.call('/usr/bin/lxc-create --quiet --name %s --bdev best --template download -- --dist %s --release %s --arch %s --server %s'
+		%{ lxc_name, lxc_dist, lxc_release, lxc_get_arch_target(url), url })
 
 	while (nx.fs.access(path .. lxc_name .. "/partial")) do
 		nx.nanosleep(1)
@@ -179,14 +177,4 @@ function lxc_get_arch_target(url)
 		end
 	end
 	return target
-end
-
-function lxc_get_ssl_status()
-	local ssl_enabled = uci:get("lxc", "lxc", "ssl_enabled")
-	local ssl_status = "--no-validate"
-
-	if ssl_enabled and ssl_enabled == "1" then
-		ssl_status = ""
-	end
-	return ssl_status
 end

--- a/applications/luci-app-lxc/luasrc/model/cbi/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/model/cbi/lxc.lua
@@ -28,11 +28,6 @@ o1:value("repo.turris.cz/lxc", "repo.turris.cz/lxc (SSL req.)")
 o1.default = "images.linuxcontainers.org"
 o1.rmempty = false
 
-o2 = s:option(Flag, "ssl_enabled", translate("Enable SSL"),
-	translate("Enable optional SSL encryption support. This requires additional packages like 'wget', 'ca-certificates', 'gnupg' and 'gnupg-utils'."))
-o2.default = o2.disabled
-o2.rmempty = false
-
 o3 = s:option(Value, "min_space", translate("Free Space Threshold"),
 	translate("Minimum required free space for LXC Container creation in KB"))
 o3.default = "100000"


### PR DESCRIPTION
Fixes #7098. Ping @xaviergr. 

Since https://github.com/lxc/lxc/commit/58520263041b6864cadad96278848f9b8ce78ee9 which is part of LXC 5.0, not being able to bypass GPG validation anymore has been enforced by upstream in lxc-download. When LXC was bumped to 5.0.1 in https://github.com/openwrt/packages/commit/d957a2293b2a21b1edca1aa92e141bad8292251a this broke passing the --no-validate option to lxc-download, which resulted in getting the output of the --help command line option as the RPC output of lxc-download as it doesn't understand the --no-validate option. This in turn broke the string parsing for compatible distributions and their versions.

To solve this, this commit removes the --no-validate option entirely as it has been removed by upstream.

I've put it as RFC as I don't use LXC myself so don't have a good way of verify that it actually works, but with these changes I can at least download the available templates and create LXC containers properly so I guess it works? The output of the current lxc-download invocation results in the following output:
```
root@labmouse:~# sh /usr/share/lxc/templates/lxc-download --list --no-validate --server images.linuxcontainers.org 2>/dev/null
LXC container image downloader

Special arguments:
[ -h | --help ]: Print this help message and exit
[ -l | --list ]: List all available images and exit

Required arguments:
[ -d | --dist <distribution> ]: The name of the distribution
[ -r | --release <release> ]: Release name/version
[ -a | --arch <architecture> ]: Architecture of the container

Optional arguments:
[ --variant <variant> ]: Variant of the image (default: "default")
[ --server <server> ]: Image server (default: "images.linuxcontainers.org")
[ --flush-cache ]: Flush the local copy (if present)
[ --force-cache ]: Force the use of the local copy even if expired

LXC internal arguments (do not pass manually!):
[ --name <name> ]: The container name
[ --path <path> ]: The path to the container
[ --rootfs <rootfs> ]: The path to the container's rootfs
[ --mapped-uid <map> ]: A uid map (user namespaces)
[ --mapped-gid <map> ]: A gid map (user namespaces)
```

Without the --no-validate option:
```
root@labmouse:~# sh /usr/share/lxc/templates/lxc-download --list --server images.linuxcontainers.org 2>/dev/null
Downloading the image index

---
DIST    RELEASE ARCH    VARIANT BUILD
---
almalinux       8       amd64   default 20240430_23:08
almalinux       8       arm64   default 20240430_23:08
almalinux       9       amd64   default 20240430_23:08
almalinux       9       arm64   default 20240430_23:08
alpine  3.16    amd64   default 20240501_13:00
<... snip here, a huge result of distros and versions... />
```

This bug is present in 23.05 (which I run on my dev machine which had the issue in #7098 but for x86/64) due to https://github.com/openwrt/packages/commit/d957a2293b2a21b1edca1aa92e141bad8292251a being part of master when that was branched so we may need a cherry-pick, unsure tho, you maintainers know best here ;)

Also, a general question: I discovered that the _major bump_ of lxc to v5 was backported to 22.03 in https://github.com/openwrt/packages/commit/29fdb5086dfe24f255238d471b345332dff705c2, is this a common practice to backport major bumps of libraries (which means the API can break completely) or did it just not pass quality checks properly in this case? 

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Tested on: (x86/64, 23.05.3, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @danrl 
- [X] \( Optional ) Closes: e.g. openwrt/luci#7098
- [X] Description: (describe the changes proposed in this PR)
