### PR TITLE
luci-app-sqm: fix ucitrack trigger

### DIFF
--- a/applications/luci-app-firewall/root/usr/share/ucitrack/luci-app-firewall.json
+++ b/applications/luci-app-firewall/root/usr/share/ucitrack/luci-app-firewall.json
@@ -4,6 +4,7 @@
 	"affects": [
 		"luci-splash",
 		"qos",
-		"miniupnpd"
+		"miniupnpd",
+		"sqm"
 	]
 }

--- a/applications/luci-app-sqm/root/usr/share/ucitrack/luci-app-sqm.json
+++ b/applications/luci-app-sqm/root/usr/share/ucitrack/luci-app-sqm.json
@@ -1,7 +1,4 @@
 {
 	"config": "sqm",
-	"init": "sqm",
-	"affects": [
-		"sqm"
-	]
+	"init": "sqm"
 }


### PR DESCRIPTION
The general logic for ucitrack trigger for SQM before was:

```
firewall affects sqm
```

But currently, it's:

```
sqm affects sqm
```

This is causing ucitrack to go in a "service reload loop", as there is already a PROCD trigger in sqm's init script.

This can be replicated by enabling an SQM service in LuCI or, calling ubus directly:

```
ubus call service event '{"type":"config.change","data":{"package":"sqm"}}'
```

Issue can be seen here:
https://forum.openwrt.org/t/qualcommax-nss-build/148529/2540

![image](https://github.com/openwrt/luci/assets/8892380/4e38dd32-9cbf-4b57-b673-0dfb29a59c58)
