### PR TITLE
luci-proto-nebula: drop maintainership

### DIFF
--- a/protocols/luci-proto-nebula/Makefile
+++ b/protocols/luci-proto-nebula/Makefile
@@ -1,16 +1,25 @@
-# Copyright 2021 Stan Grishin (stangri@melmac.ca)
-# This is free software, licensed under the GNU General Public License v3.
+# Copyright 2021-2024 MOSSDeF, Stan Grishin (stangri@melmac.ca).
+# This is free software, licensed under AGPL-3.0-or-later.
 
 include $(TOPDIR)/rules.mk
 
-PKG_LICENSE:=GPL-3.0-or-later
-PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.8.2-r2
+PKG_NAME:=luci-proto-nebula
+PKG_LICENSE:=AGPL-3.0-or-later
+PKG_MAINTAINER:=
+PKG_VERSION:=1.8.2
+PKG_RELEASE:=2
 
 LUCI_TITLE:=Support for Nebula
 LUCI_DESCRIPTION:=Provides Web UI for Nebula protocol/interface.
 LUCI_DEPENDS:=+nebula +nebula-proto
-LUCI_PKGARCH:=all
+
+define Package/$(PKG_NAME)/config
+# shown in make menuconfig <Help>
+help
+	$(LUCI_TITLE)
+	.
+	Version: $(PKG_VERSION)-$(PKG_RELEASE)
+endef
 
 include ../../luci.mk
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.3
Run tested: n/a

Description:
* update license
* improve package's presence in make menuconfig
* drop maintainership
