### PR TITLE
luci-app-sqm: remove deprecated ucitrack

### DIFF
--- a/applications/luci-app-sqm/root/usr/share/ucitrack/luci-app-sqm.json
+++ b/applications/luci-app-sqm/root/usr/share/ucitrack/luci-app-sqm.json
@@ -1,4 +1,0 @@
-{
-	"config": "sqm",
-	"init": "sqm"
-}


### PR DESCRIPTION
Package sqm-scripts already uses procd to manage uci config change triggers, so ucitrack is not necessary.