### PR TITLE
luci-app-advanced-reboot: add support for Linksys WHW03 V1

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-r10
+PKG_VERSION:=1.0.1-11
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw03.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw03.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "WHW03 (Velop)",
+	"boardNames": [ "linksys,whw03" ],
+	"partition1MTD": "mmcblk0p14",
+	"partition2MTD": "mmcblk0p16",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: WHW03, openwrt snapshot, firefox :white_check_mark:
- [x] \( Preferred ) Mention: @stangri
- [x] \( Preferred ) Screenshot or mp4 of changes
- [x] Description: add support for Linksys WHW03 V1

![image](https://github.com/openwrt/luci/assets/3977813/931b087c-f835-4a05-8128-f801b73fe61b)

```
root@OpenWrt:~# ubus call system board
{
	"kernel": "6.6.30",
	"hostname": "OpenWrt",
	"system": "ARMv7 Processor rev 5 (v7l)",
	"model": "Linksys WHW03 (Velop)",
	"board_name": "linksys,whw03",
	"rootfs_type": "squashfs",
	"release": {
		"distribution": "OpenWrt",
		"version": "SNAPSHOT",
		"revision": "r26207-ce4da3cf41",
		"target": "ipq40xx/generic",
		"description": "OpenWrt SNAPSHOT r26207-ce4da3cf41"
	}
}

root@OpenWrt:~# cat /tmp/sysinfo/board_name
linksys,whw03

root@OpenWrt:~# fw_printenv
altkern=48022
auto_recovery=yes
baudrate=115200
boot_part_ready=3
boot_ver=0.0.22
bootargs=console=ttyMSM0,115200n8
bootcmd=if test $boot_part = 1; then run bootpart1; else run bootpart2; fi
bootdelay=2
bootpart1=set bootargs $partbootargs && mmc read $loadaddr $prikern 4000 && bootm $loadaddr
bootpart2=set bootargs $partbootargs2 && && mmc read $loadaddr $altkern  4000 && bootm $loadaddr
ethact=eth0
fileaddr=90000000
flash_type=1
flashimg=tftp $fileaddr $image && mmc write $fileaddr $prikern $imgsize
flashimg2=tftp $fileaddr $image && mmc write $fileaddr $altkern $imgsize
image=nodes.img
imgsize=44000
ipaddr=192.168.1.11
loadaddr=84000000
machid=8010006
partbootargs=init=/sbin/init rootfstype=ext4 root=/dev/mmcblk0p15  rootwait console=ttyMSM0,115200n8
partbootargs2=init=/sbin/init rootfstype=ext4 root=/dev/mmcblk0p17 rootwait console=ttyMSM0,115200n8
prikern=4022
stderr=serial
stdin=serial
stdout=serial
boot_part=1

root@OpenWrt:~# gdisk /dev/mmcblk0
GPT fdisk (gdisk) version 1.0.10

Partition table scan:
  MBR: protective
  BSD: not present
  APM: not present
  GPT: present

Found valid GPT with protective MBR; using GPT.

Command (? for help): p
Disk /dev/mmcblk0: 7634944 sectors, 3.6 GiB
Sector size (logical/physical): 512/512 bytes
Disk identifier (GUID): 98101B32-BBE2-4BF2-A06E-2BB33D000C20
Partition table holds up to 20 entries
Main partition table begins at sector 2 and ends at sector 6
First usable sector is 34, last usable sector is 7634910
Partitions will be aligned on 2-sector boundaries
Total free space is 0 sectors (0 bytes)

Number  Start (sector)    End (sector)  Size       Code  Name
   1              34            1057   512.0 KiB   A012  0:SBL1
   2            1058            2081   512.0 KiB   FFFF  0:BOOTCONFIG
   3            2082            3105   512.0 KiB   A016  0:QSEE
   4            3106            4129   512.0 KiB   FFFF  0:QSEE_1
   5            4130            4641   256.0 KiB   A01B  0:CDT
   6            4642            5153   256.0 KiB   FFFF  0:CDT_1
   7            5154            5665   256.0 KiB   FFFF  0:BOOTCONFIG1
   8            5666            7713   1024.0 KiB  A015  0:APPSBL
   9            7714            9761   1024.0 KiB  FFFF  0:APPSBL_1
  10            9762           10273   256.0 KiB   FFFF  0:ART
  11           10274           12321   1024.0 KiB  FFFF  u_env
  12           12322           14369   1024.0 KiB  FFFF  s_env
  13           14370           16417   1024.0 KiB  FFFF  devinfo
  14           16418          294945   136.0 MiB   FFFF  kernel
  15           32802          294945   128.0 MiB   FFFF  rootfs
  16          294946          573473   136.0 MiB   FFFF  alt_kernel
  17          311330          573473   128.0 MiB   FFFF  alt_rootfs
  18          573474          574497   512.0 KiB   FFFF  sysdiag
  19          574498         7634910   3.4 GiB     FFFF  syscfg

Command (? for help): q

root@OpenWrt:~# hexdump -C /dev/mmcblk0p14 | head -n 24
00000000  d0 0d fe ed 00 35 a4 18  00 00 00 38 00 35 a0 2c  |.....5.....8.5.,|
00000010  00 00 00 28 00 00 00 11  00 00 00 10 00 00 00 00  |...(............|
00000020  00 00 00 6c 00 35 9f f4  00 00 00 00 00 00 00 00  |...l.5..........|
00000030  00 00 00 00 00 00 00 00  00 00 00 01 00 00 00 00  |................|
00000040  00 00 00 03 00 00 00 04  00 00 00 5c 66 39 56 e8  |...........\f9V.|
00000050  00 00 00 03 00 00 00 27  00 00 00 00 41 52 4d 20  |.......'....ARM |
00000060  4f 70 65 6e 57 72 74 20  46 49 54 20 28 46 6c 61  |OpenWrt FIT (Fla|
00000070  74 74 65 6e 65 64 20 49  6d 61 67 65 20 54 72 65  |ttened Image Tre|
00000080  65 29 00 00 00 00 00 03  00 00 00 04 00 00 00 0c  |e)..............|
00000090  00 00 00 01 00 00 00 01  69 6d 61 67 65 73 00 00  |........images..|
000000a0  00 00 00 01 6b 65 72 6e  65 6c 2d 31 00 00 00 00  |....kernel-1....|
000000b0  00 00 00 03 00 00 00 19  00 00 00 00 41 52 4d 20  |............ARM |
000000c0  4f 70 65 6e 57 72 74 20  4c 69 6e 75 78 2d 36 2e  |OpenWrt Linux-6.|  <--
000000d0  36 2e 33 30 00 00 00 00  00 00 00 03 00 35 55 68  |6.30.........5Uh|
000000e0  00 00 00 1b 00 00 a0 e1  00 00 a0 e1 00 00 a0 e1  |................|
000000f0  00 00 a0 e1 00 00 a0 e1  00 00 a0 e1 00 00 a0 e1  |................|
00000100  00 00 a0 e1 05 00 00 ea  18 28 6f 01 00 00 00 00  |.........(o.....|
00000110  68 55 35 00 01 02 03 04  45 45 45 45 70 65 00 00  |hU5.....EEEEpe..|
00000120  00 90 0f e1 ce 0d 00 eb  01 70 a0 e1 02 80 a0 e1  |.........p......|
00000130  00 20 0f e1 03 00 12 e3  01 00 00 1a 17 00 a0 e3  |. ..............|
00000140  56 34 12 ef 00 00 0f e1  1a 00 20 e2 1f 00 10 e3  |V4........ .....|
00000150  1f 00 c0 e3 d3 00 80 e3  04 00 00 1a 01 0c 80 e3  |................|
00000160  0c e0 8f e2 00 f0 6f e1  0e f3 2e e1 6e 00 60 e1  |......o.....n.`.|
00000170  00 f0 21 e1 09 f0 6f e1  00 00 00 00 00 00 00 00  |..!...o.........|

```
