### PR TITLE
luci-base: Do not error out if getDevices returns null

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
@@ -17,6 +17,15 @@ function getGroups() {
     });
 }
 
+function getDevices(network) {
+    if (network.isBridge()) {
+        var devices = network.getDevices();
+        return devices ? devices : [];
+    } else {
+        return L.toArray(network.getDevice());
+    }
+}
+
 var CBIZoneSelect = form.ListValue.extend({
 	__name__: 'CBI.ZoneSelect',
 
@@ -105,7 +114,7 @@ var CBIZoneSelect = form.ListValue.extend({
 					'class': 'ifacebadge' + (network.getName() == this.network ? ' ifacebadge-active' : '')
 				}, network.getName() + ': ');
 
-				var devices = network.isBridge() ? network.getDevices() : L.toArray(network.getDevice());
+				var devices = getDevices(network);
 
 				for (var k = 0; k < devices.length; k++) {
 					span.appendChild(E('img', {
@@ -246,7 +255,7 @@ var CBIZoneForwards = form.DummyValue.extend({
 				'class': 'ifacebadge' + (network.getName() == this.network ? ' ifacebadge-active' : '')
 			}, network.getName() + ': ');
 
-			var subdevs = network.isBridge() ? network.getDevices() : L.toArray(network.getDevice());
+			var subdevs = getDevices(network);
 
 			for (var k = 0; k < subdevs.length && subdevs[k]; k++) {
 				span.appendChild(E('img', {
@@ -339,7 +348,7 @@ var CBINetworkSelect = form.ListValue.extend({
 
 	renderIfaceBadge: function(network) {
 		var span = E('span', { 'class': 'ifacebadge' }, network.getName() + ': '),
-		    devices = network.isBridge() ? network.getDevices() : L.toArray(network.getDevice());
+		    devices = getDevices(network);
 
 		for (var j = 0; j < devices.length && devices[j]; j++) {
 			span.appendChild(E('img', {


### PR DESCRIPTION
This is potentially either a fix or a workaround for Batman-adv interfaces that are not bound to a device but linked to an wireless device.

Probably it is cleaner to make a `batadv_vlan.js` that returns an empty list or return the empty list if the js file looked up is missing.
