### PR TITLE
luci-mod-system: flash.js: add mtdblock name to filename

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -170,15 +170,17 @@ return view.extend({
 	},
 
 	handleBlock: function(hostname, ev) {
-		var mtdblock = dom.parent(ev.target, '.cbi-section').querySelector('[data-name="mtdselect"] select').value;
+		var mtdblock = dom.parent(ev.target, '.cbi-section').querySelector('[data-name="mtdselect"] select');
+		var mtdnumber = mtdblock.value;
+		var mtdname = mtdblock.selectedOptions[0].text;
 		var form = E('form', {
 			'method': 'post',
 			'action': L.env.cgi_base + '/cgi-download',
 			'enctype': 'application/x-www-form-urlencoded'
 		}, [
 			E('input', { 'type': 'hidden', 'name': 'sessionid', 'value': rpc.getSessionID() }),
-			E('input', { 'type': 'hidden', 'name': 'path',      'value': '/dev/mtdblock%d'.format(mtdblock) }),
-			E('input', { 'type': 'hidden', 'name': 'filename',  'value': '%s.mtd%d.bin'.format(hostname, mtdblock) })
+			E('input', { 'type': 'hidden', 'name': 'path',      'value': '/dev/mtdblock%d'.format(mtdnumber) }),
+			E('input', { 'type': 'hidden', 'name': 'filename',  'value': '%s.mtd%d.%s.bin'.format(hostname, mtdnumber, mtdname) })
 		]);
 
 		ev.currentTarget.parentNode.appendChild(form);


### PR DESCRIPTION
When you download a partition, the name is `hostname+mtdX.bin` and that can be confusing if you go back and try to remember what `mtdX` was if you have 10+ partitions.

So let us add the partition name to the filename like: 
```
hostname.mtdX.boot.bin
hostname.mtdX.firmware.bin
```
Note: If there is a better, easier and simpler way to do the same thing, please let me know.

Signed-off-by: Kristian Skramstad <kristian+github@83.no>