### PR TITLE
luci-mod-system: flash.js: fix mtdname on download

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -172,7 +172,7 @@ return view.extend({
 	handleBlock: function(hostname, ev) {
 		var mtdblock = dom.parent(ev.target, '.cbi-section').querySelector('[data-name="mtdselect"] select');
 		var mtdnumber = mtdblock.value;
-		var mtdname = mtdblock.selectedOptions[0].text;
+		var mtdname = mtdblock.selectedOptions[0].text.replace(/([^a-zA-Z0-9]+)/g, '-');
 		var form = E('form', {
 			'method': 'post',
 			'action': L.env.cgi_base + '/cgi-download',


### PR DESCRIPTION
The previous change did not work as intended for
partitions with `_` in the name. I.e `0:qsee_1`.
It would output an error `Invalid characters in filename`.

So fix this by matching and replacing any
character except for `a-z` and `0-9` with `-`.

Example `0:qsee_1` = `0-qsee-1`.

Tested on WAX620 with partition name `0:qsee_1`.

Signed-off-by: Kristian Skramstad <kristian+github@83.no>