### PR TITLE
luci-proto-openconnect: several updates to sync with latest package

### DIFF
--- a/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
+++ b/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
@@ -95,10 +95,12 @@ return network.registerProtocol('openconnect', {
 		    o;
 
 		o = s.taboption('general', form.ListValue, 'vpn_protocol', _('VPN Protocol'));
-		o.value('anyconnect', 'Cisco AnyConnect SSL VPN');
+		o.value('anyconnect', 'OpenConnect or Cisco AnyConnect SSL VPN');
 		o.value('nc', 'Juniper Network Connect');
-		o.value('gp', 'GlobalProtect SSL VPN');
+		o.value('gp', 'Palo Alto Networks GlobalProtect');
 		o.value('pulse', 'Pulse Connect Secure SSL VPN');
+		o.value('f5', 'F5 BIG-IP SSL VPN');
+		o.value('fortinet', 'Fortinet SSL VPN');
 		o.value('array', 'Array Networks SSL VPN');
 
 		o = s.taboption('general', form.Value, 'uri', _('VPN Server'));

--- a/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
+++ b/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
@@ -62,7 +62,7 @@ function validateCert(priv, section_id, value) {
 
 return network.registerProtocol('openconnect', {
 	getI18n: function() {
-		return _('OpenConnect (CISCO AnyConnect)');
+		return _('OpenConnect');
 	},
 
 	getIfname: function() {

--- a/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
+++ b/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
@@ -101,7 +101,8 @@ return network.registerProtocol('openconnect', {
 		o.value('pulse', 'Pulse Connect Secure SSL VPN');
 		o.value('array', 'Array Networks SSL VPN');
 
-		o = s.taboption('general', form.Value, 'server', _('VPN Server'));
+		o = s.taboption('general', form.Value, 'uri', _('VPN Server'));
+		o.placeholder = 'https://example.com:443/usergroup';
 		o.validate = function(section_id, value) {
 			var m = String(value).match(/^(?:(\w+):\/\/|)(?:\[([0-9a-f:.]{2,45})\]|([^\/:]+))(?::([0-9]{1,5}))?(?:\/.*)?$/i);
 
@@ -109,7 +110,7 @@ return network.registerProtocol('openconnect', {
 				return _('Invalid server URL');
 
 			if (m[1] != null) {
-				if (!m[1].match(/^(?:http|https|socks|socks4|socks5)$/i))
+				if (!m[1].match(/^(?:https|socks|socks4|socks5)$/i))
 					return _('Unsupported protocol');
 			}
 
@@ -138,13 +139,8 @@ return network.registerProtocol('openconnect', {
 			return true;
 		};
 
-		o = s.taboption('general', form.Value, 'port', _('VPN Server port'));
-		o.placeholder = '443';
-		o.datatype    = 'port';
-
 		s.taboption('general', form.Value, 'serverhash', _("VPN Server's certificate SHA1 hash"));
 		s.taboption('general', form.Value, 'authgroup', _('Auth Group'));
-		s.taboption('general', form.Value, 'usergroup', _('User Group'));
 		s.taboption("general", form.Value, "username", _("Username"));
 
 		o = s.taboption('general', form.Value, 'password', _('Password'));


### PR DESCRIPTION
This enables using luci-proto-openconnect to connect using a URI that enables user-groups and camouflage mode in ocserv. It further adds new protocols that are available in openconnect.

 - [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
 - [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
 - [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
 - [ ] Incremented :up: any `PKG_VERSION` in the Makefile
 - [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
 - [x] \( Preferred ) Mention: @nmav 
 - [ ] \( Preferred ) Screenshot or mp4 of changes:
 - [x] Description: (describe the changes proposed in this PR)
