### PR TITLE
luci-proto-ipv6: Update dslite.js to include DS-Lite common AFTR addresses for Japan market

### DIFF
--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js
@@ -41,6 +41,8 @@ return network.registerProtocol('dslite', {
 		o = s.taboption('general', form.Value, 'peeraddr', _('DS-Lite AFTR address'));
 		o.rmempty  = false;
 		o.datatype = 'or(hostname,ip6addr("nomask"))';
+		o.value("gw.transix.jp", _("Transix (Japan only)"));
+		o.value("dgw.xpass.jp", _("Cross Pass (Japan only)"));
 
 		o = s.taboption('general', form.Value, 'ip6addr', _('Local IPv6 address'), _('Leave empty to use the current WAN address'));
 		o.datatype = 'ip6addr("nomask")';


### PR DESCRIPTION
luci-proto-ipv6: Update dslite.js to include DS-Lite common AFTR addresses for Japan market

Include in DS-Lite General Settings common AFTR addresses for Japan market to make it easier to configure OpenWrt in Japan and help people to save money on hardware.

Details: add gw.transix.jp and dgw.xpass.jp as AFTR choices.
Rational: Japanese ISP do not advertise these addresses and promote buying "compatible" Japanese manufactured routers which just hardcode these addresses anyway. This change will save a lot of pain for people figuring out how to configure OpenWrt router with DS-Lite interface.

[A link to the forum discussion](https://forum.openwrt.org/t/provide-auto-provisioning-of-aftr-for-ds-lite-for-both-rfc6334-and-japanese-market/195654
)

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (arm, openwrt 23.05.3, browser: chrome
- [x] Description: (describe the changes proposed in this PR)
