### PR TITLE
luci-app-acme: replace deprecated use_staging with staging

### DIFF
--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -464,7 +464,7 @@ return view.extend({
 		o.modalonly = true;
 
 
-		o = s.taboption('advanced', form.Flag, 'use_staging', _('Use staging server'),
+		o = s.taboption('advanced', form.Flag, 'staging', _('Use staging server'),
 			_(
 				'Get certificate from the Letsencrypt staging server ' +
 				'(use for testing; the certificate won\'t be valid).'
@@ -507,7 +507,7 @@ return view.extend({
 
 		o = s.taboption('advanced', form.Flag, "use_acme_server",
 			_("Custom ACME CA"), _("Use a custom CA instead of Let's Encrypt."));
-		o.depends("use_staging", "0");
+		o.depends("staging", "0");
 		o.default = false;
 		o.modalonly = true;
 

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -505,15 +505,9 @@ return view.extend({
 			uci.set('acme', section_id, 'key_type', value);
 		};
 
-		o = s.taboption('advanced', form.Flag, "use_acme_server",
-			_("Custom ACME CA"), _("Use a custom CA instead of Let's Encrypt."));
-		o.depends("staging", "0");
-		o.default = false;
-		o.modalonly = true;
-
 		o = s.taboption('advanced', form.Value, "acme_server", _("ACME server URL"),
-			_("Custom ACME server directory URL."));
-		o.depends("use_acme_server", "1");
+			_('Use a custom CA instead of Let\'s Encrypt.') +	' ' + _('Custom ACME server directory URL.'));
+		o.depends("staging", "0");
 		o.placeholder = "https://api.buypass.com/acme/directory";
 		o.optional = true;
 		o.modalonly = true;


### PR DESCRIPTION
Maintainer: @tohojo

The `use_staging` option was renamed to `staging`.

Also removed `use_acme_server` option since it's ignored by acme. The option is not often used so it's easeir to remove the flag for simplicity.