### PR TITLE
Dropbear: Enable SSH from WAN firewall rule

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
@@ -24,6 +24,7 @@ return view.extend({
 		o.rmempty = false;
 
 		o = s.option(form.Flag, 'rfc1918_filter', _('Ignore private IPs on public interface'), _('Prevent access from private (RFC1918) IPs on an interface if it has an public IP address'));
+		o.rmempty = false;
 
 		if (httpsFirewallRule && httpsFirewallRule.enabled !== '1') {
 			o = s.option(form.Flag, '_wan_https_firewall_rule', _('Allow HTTP and HTTPS from WAN'),
@@ -37,6 +38,18 @@ return view.extend({
 				}
 			};
 		}
+
+		o = s.option(form.DynamicList, 'listen_http', _('HTTP listeners (address:port)'), _('Bind to specific interface:port (by specifying interface address)'));
+		o.datatype = 'list(ipaddrport(1))';
+		o.rmempty = false;
+
+		o = s.option(form.DynamicList, 'listen_https', _('HTTPS listener (address:port)'), _('Bind to specific interface:port (by specifying interface address)'));
+		o.datatype = 'list(ipaddrport(1))';
+		o.rmempty = false;
+
+		o = s.option(form.Flag, 'enabled', _('Enabled'), _('If LuCI use another web server then you can disable the uhttpd.'));
+		o.default = true;
+		o.rmempty = false;
 
 		return m.render();
 	}

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
@@ -23,6 +23,8 @@ return view.extend({
 		o = s.option(form.Flag, 'redirect_https', _('Redirect to HTTPS'), _('Enable automatic redirection of <abbr title="Hypertext Transfer Protocol">HTTP</abbr> requests to <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> port.'));
 		o.rmempty = false;
 
+		o = s.option(form.Flag, 'rfc1918_filter', _('Ignore private IPs on public interface'), _('Prevent access from private (RFC1918) IPs on an interface if it has an public IP address'));
+
 		if (httpsFirewallRule && httpsFirewallRule.enabled !== '1') {
 			o = s.option(form.Flag, '_wan_https_firewall_rule', _('Allow HTTP and HTTPS from WAN'),
 				_('Enable firewall rule to allow access to the 80 and 443 ports')

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
@@ -1,9 +1,18 @@
 'use strict';
 'require view';
 'require form';
+'require uci';
 
 return view.extend({
+	load: function() {
+		return Promise.all([
+			uci.load('firewall')
+		]);
+	},
+
 	render: function() {
+		var httpsFirewallRule = uci.get('firewall', 'wan_https_allow');
+
 		var m, s, o;
 
 		m = new form.Map('uhttpd', _('HTTP(S) Access'), _('uHTTPd offers <abbr title="Hypertext Transfer Protocol">HTTP</abbr> or <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> network access.'));
@@ -13,6 +22,19 @@ return view.extend({
 
 		o = s.option(form.Flag, 'redirect_https', _('Redirect to HTTPS'), _('Enable automatic redirection of <abbr title="Hypertext Transfer Protocol">HTTP</abbr> requests to <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> port.'));
 		o.rmempty = false;
+
+		if (httpsFirewallRule && httpsFirewallRule.enabled !== '1') {
+			o = s.option(form.Flag, '_wan_https_firewall_rule', _('Allow HTTP and HTTPS from WAN'),
+				_('Enable firewall rule to allow access to the 80 and 443 ports')
+			);
+			o.depends('enabled', '');
+			o.depends('enabled', '1');
+			o.write = function(section_id, value) {
+				if (value === '1') {
+					uci.set('firewall', 'wan_https_allow', 'enabled', '1');
+				}
+			};
+		}
 
 		return m.render();
 	}


### PR DESCRIPTION
A draft implementation of an easy way to enable the [Allow SSH from WAN](https://github.com/openwrt/openwrt/pull/15562) rule from UI. 

The whole idea is to make a Luci GUI wizard to enable WAN access https://github.com/openwrt/luci/issues/7137

![Luci Dropbear enable WAN screenshot](https://github.com/openwrt/luci/assets/415502/a5fb005f-b144-4f70-aebd-1da10c5165b8)

The key idea is to have a firewall rule pre-defined and the GUI should only enable it.
This is a simplest implementation. It will work only for 22 port.
We may extend it later but it already covers the typical usage.

What is missing: we should show precautions for a users that this is not safe at all.


And same for the uhttpd:

![luci uhttpd enable WAN screenshot](https://github.com/openwrt/luci/assets/415502/1a84b078-be13-4779-b499-b92161caa876)

Here it may be not enough to just open an access. A user may want to switch IP address of uhttpd. Additionally the rfc1918 filter should be disabled. So I copied them from luci-app-uhttpd.

This needs somehow to be managed in graceful way.
