### PR TITLE
luci-base: refactoring overlay for connectivity change

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4732,22 +4732,21 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 
 					UI.prototype.changes.displayStatus('warning', [
 						E('h4', _('Connectivity change')),
-						E('p', _('"%h" interface changes could inhibit access to this device.').format(affected)),
-						E('p', _('Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(L.env.apply_rollback)),
+						E('p', _('Changes have been made to the existing connection via "%h". This could inhibit access to this device. Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(affected,L.env.apply_rollback)),
 						E('p', _('Choose how to apply changes:')),
-						E('div', { 'class': 'right' }, [
-							E('button', {
-								'class': 'btn',
-								'click': rejectFn,
-							}, [ _('Cancel') ]), ' ',
+						E('div', { 'class': 'center' }, [
 							E('button', {
 								'class': 'btn cbi-button-action important',
 								'click': resolveFn.bind(null, true)
-							}, [ _('Apply, reverting if GUI remains unreachable') ]), ' ',
+							}, [ _('Apply, reverting if unreachable') ]), ' ',
 							E('button', {
 								'class': 'btn cbi-button-negative important',
 								'click': resolveFn.bind(null, false)
-							}, [ _('Apply, committing now') ])
+							}, [ _('Apply, changes now') ]), ' ',
+							E('button', {
+								'class': 'btn',
+								'click': rejectFn,
+							}, [ _('Cancel') ])
 						])
 					]);
 				});


### PR DESCRIPTION
Before with LuCI-Theme bootstrap:
![before](https://github.com/openwrt/luci/assets/553091/a10b477a-1caa-4cd7-be23-a2fb362b9fac)

After with LuCI-Theme bootstrap:
![after](https://github.com/openwrt/luci/assets/553091/282a78d6-eae5-4a7d-88a4-8471901754d6)


- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)