### PR TITLE
treewide: add new css class button-row

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -886,7 +886,7 @@ function handleConfig(ev)
 			}, '%h'.format(conf[file])));
 		});
 
-		body.push(E('div', { 'class': 'right' }, [
+		body.push(E('div', { 'class': 'button-row' }, [
 			E('div', {
 				'class': 'btn cbi-button-neutral',
 				'click': ui.hideModal
@@ -1012,7 +1012,7 @@ function handleOpkg(ev)
 			if (res.code !== 0)
 				dlg.appendChild(E('p', _('The <em>opkg %h</em> command failed with code <code>%d</code>.').format(cmd, (res.code & 0xff) || -1)));
 
-			dlg.appendChild(E('div', { 'class': 'right' },
+			dlg.appendChild(E('div', { 'class': 'button-row' },
 				E('div', {
 					'class': 'btn',
 					'click': L.bind(function(res) {

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -3220,11 +3220,11 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 						nodes,
 						E('div', { 'class': 'right' }, [
 							E('button', {
-								'class': 'cbi-button',
+								'class': 'btn cbi-button',
 								'click': ui.createHandlerFn(this, 'handleModalCancel', m)
 							}, [ _('Dismiss') ]), ' ',
 							E('button', {
-								'class': 'cbi-button cbi-button-positive important',
+								'class': 'btn cbi-button cbi-button-positive important',
 								'click': ui.createHandlerFn(this, 'handleModalSave', m),
 								'disabled': m.readonly || null
 							}, [ _('Save') ])

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -3218,7 +3218,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 				else {
 					ui.showModal(title, [
 						nodes,
-						E('div', { 'class': 'right' }, [
+						E('div', { 'class': 'button-row' }, [
 							E('button', {
 								'class': 'btn cbi-button',
 								'click': ui.createHandlerFn(this, 'handleModalCancel', m)

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4730,9 +4730,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 
 					UI.prototype.changes.displayStatus('warning', [
 						E('h4', _('Connectivity change')),
-						E('p', _('"%h" interface changes could inhibit access to this device.').format(affected)),
-						E('p', _('Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(L.env.apply_rollback)),
-						E('p', _('Choose how to apply changes:')),
+						E('p', _('Changes have been made to the existing connection via "%h". This could inhibit access to this device. Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(affected, L.env.apply_rollback)),
 						E('div', { 'class': 'right' }, [
 							E('div', {
 								'class': 'btn cbi-button',
@@ -4741,11 +4739,11 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							E('div', {
 								'class': 'btn cbi-button-action important',
 								'click': resolveFn.bind(null, true)
-							}, [ _('Apply, reverting if GUI remains unreachable') ]), ' ',
+							}, [ _('Apply, reverting in case of connectivity loss') ]), ' ',
 							E('div', {
 								'class': 'btn cbi-button-negative important',
 								'click': resolveFn.bind(null, false)
-							}, [ _('Apply, committing now') ])
+							}, [ _('Apply unchecked') ])
 						])
 					]);
 				});

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4735,7 +4735,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						E('p', _('Choose how to apply changes:')),
 						E('div', { 'class': 'right' }, [
 							E('button', {
-								'class': 'btn',
+								'class': 'btn cbi-button',
 								'click': rejectFn,
 							}, [ _('Cancel') ]), ' ',
 							E('button', {

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4734,15 +4734,15 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						E('p', _('Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(L.env.apply_rollback)),
 						E('p', _('Choose how to apply changes:')),
 						E('div', { 'class': 'right' }, [
-							E('button', {
+							E('div', {
 								'class': 'btn cbi-button',
 								'click': rejectFn,
 							}, [ _('Cancel') ]), ' ',
-							E('button', {
+							E('div', {
 								'class': 'btn cbi-button-action important',
 								'click': resolveFn.bind(null, true)
 							}, [ _('Apply, reverting if GUI remains unreachable') ]), ' ',
-							E('button', {
+							E('div', {
 								'class': 'btn cbi-button-negative important',
 								'click': resolveFn.bind(null, false)
 							}, [ _('Apply, committing now') ])

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4480,26 +4480,29 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							E('var', {}, E('ins', '&#160;')), ' ', _('Option changed') ]),
 						E('div', { 'class': 'uci-change-legend-label' }, [
 							E('var', {}, E('del', '&#160;')), ' ', _('Option removed') ])]),
-					E('br'), list,
-					E('div', { 'class': 'right' }, [
-						E('div', {
-							'class': 'btn cbi-button',
-							'click': UI.prototype.hideModal
-						}, [ _('Close') ]), ' ',
-						new UIComboButton('0', {
-							0: [ _('Save & Apply') ],
-							1: [ _('Apply unchecked') ]
-						}, {
-							classes: {
-								0: 'btn cbi-button cbi-button-positive important',
-								1: 'btn cbi-button cbi-button-negative important'
-							},
-							click: L.bind(function(ev, mode) { this.apply(mode == '0') }, this)
-						}).render(), ' ',
-						E('div', {
-							'class': 'btn cbi-button cbi-button-reset',
-							'click': L.bind(this.revert, this)
-						}, [ _('Revert') ])])])
+					E('br'),
+					list,
+				]),
+				E('div', { 'class': 'right' }, [
+					E('div', {
+						'class': 'btn cbi-button',
+						'click': UI.prototype.hideModal
+					}, [ _('Close') ]), ' ',
+					new UIComboButton('0', {
+						0: [ _('Save & Apply') ],
+						1: [ _('Apply unchecked') ]
+					}, {
+						classes: {
+							0: 'btn cbi-button cbi-button-positive important',
+							1: 'btn cbi-button cbi-button-negative important'
+						},
+						click: L.bind(function(ev, mode) { this.apply(mode == '0') }, this)
+					}).render(), ' ',
+					E('div', {
+						'class': 'btn cbi-button cbi-button-reset',
+						'click': L.bind(this.revert, this)
+					}, [ _('Revert') ])
+				])
 			]);
 
 			for (var config in this.changes) {

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4234,7 +4234,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 								upload.focus();
 							}
 						}),
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button',
 							'click': function(ev) {
 								ev.target.previousElementSibling.click();
@@ -4242,7 +4242,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						}, [ _('Browse…') ])
 					]),
 					E('div', { 'class': 'right', 'style': 'flex:1' }, [
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button',
 							'click': function() {
 								UI.prototype.hideModal();
@@ -4250,7 +4250,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							}
 						}, [ _('Cancel') ]),
 						' ',
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button-action important',
 							'disabled': true,
 							'click': function(ev) {

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4235,7 +4235,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							}
 						}),
 						E('button', {
-							'class': 'btn',
+							'class': 'btn cbi-button',
 							'click': function(ev) {
 								ev.target.previousElementSibling.click();
 							}
@@ -4243,7 +4243,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					]),
 					E('div', { 'class': 'right', 'style': 'flex:1' }, [
 						E('button', {
-							'class': 'btn',
+							'class': 'btn cbi-button',
 							'click': function() {
 								UI.prototype.hideModal();
 								rejectFn(new Error(_('Upload has been cancelled')));

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4210,6 +4210,13 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 			UI.prototype.showModal(_('Uploading file…'), [
 				E('p', _('Please select the file to upload.')),
 				E('div', { 'class': 'right' }, [
+					E('div', {
+						'class': 'btn cbi-button',
+						'click': function() {
+							UI.prototype.hideModal();
+							rejectFn(new Error(_('Upload has been cancelled')));
+						}
+					}, [ _('Cancel') ]),
 					E('input', {
 						type: 'file',
 						style: 'display:none',
@@ -4239,14 +4246,6 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							ev.target.previousElementSibling.click();
 						}
 					}, [ _('Browse…') ]),
-					E('div', {
-						'class': 'btn cbi-button',
-						'click': function() {
-							UI.prototype.hideModal();
-							rejectFn(new Error(_('Upload has been cancelled')));
-						}
-					}, [ _('Cancel') ]),
-					' ',
 					E('div', {
 						'class': 'btn cbi-button-action important',
 						'disabled': true,

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4482,7 +4482,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							E('var', {}, E('del', '&#160;')), ' ', _('Option removed') ])]),
 					E('br'), list,
 					E('div', { 'class': 'right' }, [
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button',
 							'click': UI.prototype.hideModal
 						}, [ _('Close') ]), ' ',
@@ -4496,7 +4496,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							},
 							click: L.bind(function(ev, mode) { this.apply(mode == '0') }, this)
 						}).render(), ' ',
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button cbi-button-reset',
 							'click': L.bind(this.revert, this)
 						}, [ _('Revert') ])])])

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4483,7 +4483,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					E('br'), list,
 					E('div', { 'class': 'right' }, [
 						E('button', {
-							'class': 'btn',
+							'class': 'btn cbi-button',
 							'click': UI.prototype.hideModal
 						}, [ _('Close') ]), ' ',
 						new UIComboButton('0', {
@@ -4497,7 +4497,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							click: L.bind(function(ev, mode) { this.apply(mode == '0') }, this)
 						}).render(), ' ',
 						E('button', {
-							'class': 'cbi-button cbi-button-reset',
+							'class': 'btn cbi-button cbi-button-reset',
 							'click': L.bind(this.revert, this)
 						}, [ _('Revert') ])])])
 			]);

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3626,7 +3626,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	/** @private */
 	cancelModal: function(ev) {
 		if (ev.key == 'Escape') {
-			var btn = modalDiv.querySelector('.right > button, .right > .btn');
+			var btn = modalDiv.querySelector('.right > button, .right > .btn, .button-row > .btn');
 
 			if (btn)
 				btn.click();
@@ -4209,7 +4209,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 		return new Promise(function(resolveFn, rejectFn) {
 			UI.prototype.showModal(_('Uploading file…'), [
 				E('p', _('Please select the file to upload.')),
-				E('div', { 'class': 'right' }, [
+				E('div', { 'class': 'button-row' }, [
 					E('div', {
 						'class': 'btn cbi-button',
 						'click': function() {
@@ -4478,7 +4478,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					E('br'),
 					list,
 				]),
-				E('div', { 'class': 'right' }, [
+				E('div', { 'class': 'button-row' }, [
 					E('div', {
 						'class': 'btn cbi-button',
 						'click': UI.prototype.hideModal
@@ -4731,7 +4731,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					UI.prototype.changes.displayStatus('warning', [
 						E('h4', _('Connectivity change')),
 						E('p', _('Changes have been made to the existing connection via "%h". This could inhibit access to this device. Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(affected, L.env.apply_rollback)),
-						E('div', { 'class': 'right' }, [
+						E('div', { 'class': 'button-row' }, [
 							E('div', {
 								'class': 'btn cbi-button',
 								'click': rejectFn,

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -175,7 +175,7 @@ function iface_updown(up, id, ev, force) {
 
 				ui.showModal(_('Confirm disconnect'), [
 					E('p', _('You appear to be currently connected to the device via the "%h" interface. Do you really want to shut down the interface?').format(id)),
-					E('div', { 'class': 'right' }, [
+					E('div', { 'class': 'button-row' }, [
 						E('div', {
 							'class': 'btn cbi-button cbi-button-neutral',
 							'click': function(ev) {

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -176,7 +176,7 @@ function iface_updown(up, id, ev, force) {
 				ui.showModal(_('Confirm disconnect'), [
 					E('p', _('You appear to be currently connected to the device via the "%h" interface. Do you really want to shut down the interface?').format(id)),
 					E('div', { 'class': 'right' }, [
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button cbi-button-neutral',
 							'click': function(ev) {
 								btns[1].classList.remove('spinning');
@@ -187,7 +187,7 @@ function iface_updown(up, id, ev, force) {
 							}
 						}, _('Cancel')),
 						' ',
-						E('button', {
+						E('div', {
 							'class': 'btn cbi-button cbi-button-negative important',
 							'click': function(ev) {
 								dsc.setAttribute('disconnect', '');

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -177,7 +177,7 @@ function iface_updown(up, id, ev, force) {
 					E('p', _('You appear to be currently connected to the device via the "%h" interface. Do you really want to shut down the interface?').format(id)),
 					E('div', { 'class': 'right' }, [
 						E('button', {
-							'class': 'cbi-button cbi-button-neutral',
+							'class': 'btn cbi-button cbi-button-neutral',
 							'click': function(ev) {
 								btns[1].classList.remove('spinning');
 								btns[1].disabled = false;
@@ -188,7 +188,7 @@ function iface_updown(up, id, ev, force) {
 						}, _('Cancel')),
 						' ',
 						E('button', {
-							'class': 'cbi-button cbi-button-negative important',
+							'class': 'btn cbi-button cbi-button-negative important',
 							'click': function(ev) {
 								dsc.setAttribute('disconnect', '');
 								dom.content(dsc, E('em', _('Interface is shutting down...')));

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1394,6 +1394,19 @@ footer ul.breadcrumb {
 	width: 100%;
 }
 
+.modal > .button-row {
+	display: flex;
+	justify-content: space-between;
+}
+
+.modal > .button-row > button:not(:last-of-type) {
+	margin-right: .5em;
+}
+
+.modal > .button-row > button:first-of-type {
+	margin-right: auto;
+}
+
 body.modal-overlay-active {
 	overflow: hidden;
 	height: 100vh;

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1749,6 +1749,19 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 	max-height: none;
 }
 
+.modal .button-row {
+	display: flex;
+	justify-content: space-between;
+}
+
+.modal .button-row > :not(:last-child) {
+	margin-right: .5em;
+}
+
+.modal .button-row > :first-child {
+	margin-right: auto;
+}
+
 body.modal-overlay-active {
 	overflow: hidden;
 	height: 100vh;

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -275,6 +275,18 @@ body.modal-overlay-active #modal_overlay {
 
 .modal .cbi-section > legend:first-child { font-size: 120%; }
 
+.modal .button-row {
+	display: flex;
+	justify-content: space-between;
+}
+
+.modal .button-row > :not(:last-child) {
+	margin-right: .5em;
+}
+
+.modal .button-row > :first-child {
+	margin-right: auto;
+}
 
 /*
  * table layout

--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -242,6 +242,19 @@ hr {
 	overflow: auto;
 }
 
+.modal .button-row {
+	display: flex;
+	justify-content: space-between;
+}
+
+.modal .button-row > :not(:last-child) {
+	margin-right: .5em;
+}
+
+.modal .button-row > :first-child {
+	margin-right: auto;
+}
+
 body.modal-overlay-active {
 	overflow: hidden;
 }


### PR DESCRIPTION
Base on the discussion with @systemcrash @jow- on PR https://github.com/openwrt/luci/pull/7152, I have added the suggested css class `button-row`.

New view for the connectivity change that I originally wanted to change.
![after](https://github.com/openwrt/luci/assets/553091/9c38b491-20af-4c59-945e-a0cbd8ce0279)

I have tested the changes for the themes `luci-theme-material` and `luci-theme-bootstrap`.
* Interface stop
* OPKG update/feeds
* Upload

When comparing the `Save & Apply` I noticed a problem that looks right with `luci-theme-material` but not so right with `luci-theme-bootstrap`.

**luci-theme-bootstrap (NOK):**
![bootstrap](https://github.com/openwrt/luci/assets/553091/45bca8aa-2321-445e-a02b-f94ba92ee390)

**luci-theme-material (OK):**
![material](https://github.com/openwrt/luci/assets/553091/43b1a3ea-66c5-441d-9325-70cd15bee87e)

I think the problem is with the CSS! Unfortunately I have no idea how to solve this.

- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
