### PR TITLE
luci-app-keepalived: Fix option name for script falls. 

### DIFF
--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/script.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/script.js
@@ -86,7 +86,7 @@ return view.extend({
 		o.optional = true;
 		o.datatype = 'uinteger';
 
-		o = s.option(form.Value, 'fail', _('Fail'),
+		o = s.option(form.Value, 'fall', _('Fall'),
 			_('Required number of successes for KO transition'));
 		o.optional = true;
 		o.datatype = 'uinteger';


### PR DESCRIPTION
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile: I didn't find where exactly.
- [X] Tested on: (MT7621, 23.05, Safari, Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: Before the fix, changing the 'fail' parameter for a VRRP script had no effect because keepalived expects 'fall', not 'fail'. After changing it to 'fall', it started working as expected, waiting for the given number of fails before triggering the fail state.
