### PR TITLE
luci-app-attendedsysupgrade: enforce correct imagebuilder version

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -476,6 +476,7 @@ return view.extend({
 					request: {
 						profile,
 						version: candidates[0][0],
+						version_code: revision,
 						packages: Object.keys(packages).sort(),
 					},
 				};
@@ -536,6 +537,7 @@ return view.extend({
 												...firmware,
 												packages: mapdata.request.packages,
 												version: mapdata.request.version,
+												version_code: mapdata.request.version_code,
 												profile: mapdata.request.profile
 											};
 											this.pollFn = L.bind(function () {


### PR DESCRIPTION
By passing the version_code parameter, we can error out if the imagebuilder that responded to the request isn't the same, mirroring the current behavior of auc.

![Screenshot_8](https://github.com/openwrt/luci/assets/7290072/fe6134ba-0e92-4a26-8717-f47d18f3c8f4)

This is spawned from a recent issue with the Attended Sysupgrade server as can be seen in later entries of https://forum.openwrt.org/t/auc-sysupgrade-does-not-work-for-me/196782, https://github.com/openwrt/asu/issues/848 and with the probable root cause in https://github.com/openwrt/asu/issues/853. Due to the LuCI app not having this check, the incorrect version of the imagebuilder may be used for a request, and still be returned to the user as a valid request, which (I guess?) in worst case could downgrade a user's systems instead. 

Adding this check mirrors the behaviour that `auc` currently has, see image below. The relevant code path for the Attended Sysupgrade code is at https://github.com/openwrt/asu/blob/main/asu/build.py#L72-L79, which enforces this check on the API.

![Screenshot_7](https://github.com/openwrt/luci/assets/7290072/c065a5ac-864e-4ea6-ae7c-a6986eae2f71)

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/64, SNAPSHOT r26637-05aec66d53, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @aparcar
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
