### PR TITLE
luci-app-attendedsysupgrade: use remote revision for version code

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -432,8 +432,8 @@ return view.extend({
 				]);
 				return;
 			}
+			const remote_revision = response.json().revision;
 			if (version.endsWith('SNAPSHOT')) {
-				const remote_revision = response.json().revision;
 				if (
 					get_revision_count(revision) < get_revision_count(remote_revision)
 				) {
@@ -476,7 +476,7 @@ return view.extend({
 					request: {
 						profile,
 						version: candidates[0][0],
-						version_code: revision,
+						version_code: remote_revision,
 						packages: Object.keys(packages).sort(),
 					},
 				};


### PR DESCRIPTION
With 8860ca069c04e3dbd3f107f1526f2901f1085902 the check against the version_code parameter was implemented but was incorrectly set to the current revision instead of the latest available remote revision.

This resulted in not being able to upgrade due to the version_code parameter never matched the newer remote revision on the sysupgrade server.

To clarify the problem, r26637-05aec66d53 is the current running revision, and r26679-70088a7e4c is the latest remote revision (which we want to upgrade to) at time of writing this.

See https://github.com/openwrt/luci/pull/7163#issuecomment-2176678529

Without fix:

![Screenshot_15](https://github.com/openwrt/luci/assets/7290072/4f142d9b-9b75-4926-83ac-94a8bde3ef19)

With fix:

![Screenshot_12](https://github.com/openwrt/luci/assets/7290072/73ac37b2-8551-4b13-8dc2-f0fda46a8454)
![Screenshot_13](https://github.com/openwrt/luci/assets/7290072/02f95be8-1485-4a26-b25a-88aeddeaed18)

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/64, SNAPSHOT r26637-05aec66d53, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @aparcar
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
