### PR TITLE
luci-proto-yggdrasil: show peer latency

### DIFF
--- a/protocols/luci-proto-yggdrasil/Makefile
+++ b/protocols/luci-proto-yggdrasil/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for Yggdrasil Network
 LUCI_DEPENDS:=+yggdrasil
 LUCI_PKGARCH:=all
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.1.1
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>
 
 include ../../luci.mk

--- a/protocols/luci-proto-yggdrasil/htdocs/luci-static/resources/protocol/yggdrasil.js
+++ b/protocols/luci-proto-yggdrasil/htdocs/luci-static/resources/protocol/yggdrasil.js
@@ -98,6 +98,10 @@ function updateActivePeers(ifname) {
 
 				cell = row.insertCell(-1)
 				cell.className = "td"
+				cell.textContent = '%.2f ms'.format(peer.latency_ms / 10**6);
+
+				cell = row.insertCell(-1)
+				cell.className = "td"
 				cell.textContent = '%.2mB'.format(peer.bytes_recvd);
 
 				cell = row.insertCell(-1)
@@ -136,6 +140,7 @@ var cbiActivePeers = form.DummyValue.extend({
 				E('th', {'class': 'th'}, _('Dir')),
 				E('th', {'class': 'th'}, _('IP Address')),
 				E('th', {'class': 'th'}, _('Uptime')),
+				E('th', {'class': 'th'}, _('Latency')),
 				E('th', {'class': 'th'}, _('RX')),
 				E('th', {'class': 'th'}, _('TX')),
 				E('th', {'class': 'th'}, _('Priority')),


### PR DESCRIPTION
Show latency measurement among other peering information. Latency field was added to yggdrasil admin api in v0.5.6.

Depends on: openwrt/packages#24411 (merged)

cc: @wfleurant