### PR TITLE
luci-mod-network: DHCP tabs redesign phase 2

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -302,7 +302,7 @@ return view.extend({
 		    duids = hosts_duids_pools[1],
 		    pools = hosts_duids_pools[2],
 		    networks = hosts_duids_pools[3],
-		    m, s, o, ss, so, dnss;
+		    m, s, o, ss, so, dnss, tagstab;
 
 		var devices  = Object.keys(L.toArray(hosts_duids_pools[4])[0]);
 		var services = Object.keys(L.toArray(hosts_duids_pools[5])[0]);
@@ -397,11 +397,7 @@ return view.extend({
 		s.tab('ipsets', _('IP Sets'));
 		s.tab('relay', _('Relay'));
 		s.tab('pxe_tftp', _('PXE/TFTP'));
-		s.tab('mac', _('MAC'));
-		s.tab('matchtags', _('Match Tags'));
-		s.tab('vc', _('VC'));
-		s.tab('uc', _('UC'));
-		s.tab('settags', _('Set Tags'));
+		s.tab('tagsparent', _('Tags'));
 
 		s.taboption('filteropts', form.Flag, 'domainneeded',
 			_('Domain required'),
@@ -1173,7 +1169,23 @@ return view.extend({
 			_('Forward/reverse DNS'),
 			_('Add static forward and reverse DNS entries for this host.'));
 
-		o = s.taboption('mac', form.SectionValue, '__mac__', form.TableSection, 'mac', null,
+
+
+		o = s.taboption('tagsparent', form.SectionValue, '__tagsparent__', form.TypedSection, '__tagsparent__');
+
+		tagstab = o.subsection;
+
+		tagstab.anonymous = true;
+		tagstab.cfgsections = function() { return [ '__tagsparent__' ] };
+
+		tagstab.tab('mac', _('MAC'));
+		tagstab.tab('matchtags', _('Match Tags'));
+		tagstab.tab('vc', _('VC'));
+		tagstab.tab('uc', _('UC'));
+		tagstab.tab('settags', _('Set Tags'));
+
+
+		o = tagstab.taboption('mac', form.SectionValue, '__mac__', form.TableSection, 'mac', null,
 			_('MAC hardware addresses uniquely identify clients to set tags on them.') + '<br /><br />' +
 			_('Use the <em>Add</em> Button to add a new MAC.'));
 		ss = o.subsection;
@@ -1193,7 +1205,7 @@ return view.extend({
 		so.rmempty = false;
 		so.optional = false;
 
-		o = s.taboption('matchtags', form.SectionValue, '__tags__', form.TableSection, 'tag', null,
+		o = tagstab.taboption('matchtags', form.SectionValue, '__tags__', form.TableSection, 'tag', null,
 			customi18n( _('A {tagcodestring} is an alphanumeric label. dnsmasq applies chosen DHCP options when a specific {tagcodestring} is encountered.')) + '<br />' +
 			customi18n( _('In other words: "This {tagcodestring} gets these {tag_named_ov_string}".')) + '<br />' +
 			customi18n( _('Note: invalid {tag_named_ov_string} combinations may cause dnsmasq to silently crash.')) + '<br /><br />' +
@@ -1236,7 +1248,7 @@ return view.extend({
 		so.rmempty = false;
 		so.optional = true;
 
-		o = s.taboption('vc', form.SectionValue, '__vc__', form.TableSection, 'vendorclass', null,
+		o = tagstab.taboption('vc', form.SectionValue, '__vc__', form.TableSection, 'vendorclass', null,
 			_('Match Vendor Class (VC) strings sent by DHCP clients as a trigger to set tags on them.') + '<br /><br />' +
 			_('Use the <em>Add</em> Button to add a new VC.'));
 		ss = o.subsection;
@@ -1261,7 +1273,7 @@ return view.extend({
 		so.rmempty = false;
 		so.optional = true;
 
-		o = s.taboption('uc', form.SectionValue, '__uc__', form.TableSection, 'userclass', null,
+		o = tagstab.taboption('uc', form.SectionValue, '__uc__', form.TableSection, 'userclass', null,
 			_('Match User Class (UC) strings sent by DHCP clients as a trigger to set tags on them.') + '<br /><br />' +
 			_('Use the <em>Add</em> Button to add a new UC.'));
 		ss = o.subsection;
@@ -1286,7 +1298,7 @@ return view.extend({
 		so.rmempty = false;
 		so.optional = true;
 
-		o = s.taboption('settags', form.SectionValue, '__settags__', form.TableSection, 'match', null,
+		o = tagstab.taboption('settags', form.SectionValue, '__settags__', form.TableSection, 'match', null,
 			customi18n( _('Encountering chosen DHCP {dhcp_option_code}s (or also its {dhcp_value_code}) from clients triggers dnsmasq to set alphanumeric {tagcodestring}s.')) + '<br />' +
 			customi18n( _('In other words: "{tag_match_code_name} these {dhcp_option_code}s to set this {tagcodestring}" or "These {dhcp_option_code}s set this {tagcodestring}".')) + '<br />' +
 			customi18n( _('Internally, these configuration entries are called {tag_match_code_name}.')) + '<br />' +

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -29,6 +29,18 @@ callDHCPLeases = rpc.declare({
 	expect: { '': {} }
 });
 
+var callNetworkDevices = rpc.declare({
+	object: 'luci-rpc',
+	method: 'getNetworkDevices',
+	expect: { '': {} }
+});
+
+var listServices = rpc.declare({
+	object: 'service',
+	method: 'list',
+	expect: { '': {} }
+});
+
 CBILeaseStatus = form.DummyValue.extend({
 	renderWidget: function(section_id, option_id, cfgvalue) {
 		return E([
@@ -278,6 +290,8 @@ return view.extend({
 			callDUIDHints(),
 			getDHCPPools(),
 			network.getNetworks(),
+			callNetworkDevices(),
+			listServices(),
 			uci.load('firewall')
 		]);
 	},
@@ -289,6 +303,9 @@ return view.extend({
 		    pools = hosts_duids_pools[2],
 		    networks = hosts_duids_pools[3],
 		    m, s, o, ss, so, dnss;
+
+		var devices  = Object.keys(L.toArray(hosts_duids_pools[4])[0]);
+		var services = Object.keys(L.toArray(hosts_duids_pools[5])[0]);
 
 		let noi18nstrings = {
 			etc_hosts: '<code>/etc/hosts</code>',
@@ -1188,6 +1205,17 @@ return view.extend({
 		so.rmempty = false;
 		so.optional = false;
 		so.placeholder = 'specialgateways';
+		so.validate = function(section, value) {
+			for (var i = 0, l = devices.length; i < l; i++) {
+				if (devices[i] == value)
+					return _('Tag name %s must not match any active device name').format(value);
+			}
+			for (var i = 0, l = services.length; i < l; i++) {
+				if (services[i] == value)
+					return _('Tag name %s must not match any service name').format(value);
+			}
+			return true;
+		};
 
 		so = ss.option(form.Flag, 'force',
 			_('Force'),

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -367,6 +367,7 @@ return view.extend({
 		s.tab('ipsets', _('IP Sets'));
 		s.tab('relay', _('Relay'));
 		s.tab('pxe_tftp', _('PXE/TFTP'));
+		s.tab('mac', _('MAC'));
 
 		s.taboption('filteropts', form.Flag, 'domainneeded',
 			_('Domain required'),
@@ -1137,6 +1138,26 @@ return view.extend({
 		so = ss.option(form.Flag, 'dns',
 			_('Forward/reverse DNS'),
 			_('Add static forward and reverse DNS entries for this host.'));
+
+		o = s.taboption('mac', form.SectionValue, '__mac__', form.TableSection, 'mac', null,
+			_('MAC hardware addresses uniquely identify clients to set tags on them.') + '<br /><br />' +
+			_('Use the <em>Add</em> Button to add a new MAC.'));
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+		ss.nodescriptions = true;
+		ss.modaltitle = _('Edit MAC');
+		ss.rowcolors = true;
+
+		so = ss.option(form.Value, 'mac', _('MAC match'));
+		so.validate = isValidMAC;
+		so.rmempty = false;
+		so.optional = false;
+
+		so = ss.option(form.Value, 'networkid', _('Set this Tag'));
+		so.rmempty = false;
+		so.optional = false;
 
 		o = s.taboption('leases', CBILeaseStatus, '__status__');
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -293,6 +293,7 @@ return view.extend({
 		let noi18nstrings = {
 			etc_hosts: '<code>/etc/hosts</code>',
 			etc_ethers: '<code>/etc/ethers</code>',
+			exclamationmark_invert: '<code>!</code>',
 			localhost_v6: '<code>::1</code>',
 			loopback_slash_8_v4: '<code>127.0.0.0/8</code>',
 			not_found: '<code>Not found</code>',
@@ -304,6 +305,8 @@ return view.extend({
 			reverse_arpa: '<code>*.IN-ADDR.ARPA,*.IP6.ARPA</code>',
 			servers_file_entry01: '<code>server=1.2.3.4</code>',
 			servers_file_entry02: '<code>server=/domain/1.2.3.4</code>',
+			tagcodestring:'<code>tag</code>',
+			tag_named_ov_string: '<code>option(6):&lt;opt-name&gt;,[&lt;value&gt;[,&lt;value&gt;]]</code>',
 
 		};
 
@@ -368,6 +371,7 @@ return view.extend({
 		s.tab('relay', _('Relay'));
 		s.tab('pxe_tftp', _('PXE/TFTP'));
 		s.tab('mac', _('MAC'));
+		s.tab('matchtags', _('Match Tags'));
 
 		s.taboption('filteropts', form.Flag, 'domainneeded',
 			_('Domain required'),
@@ -1158,6 +1162,38 @@ return view.extend({
 		so = ss.option(form.Value, 'networkid', _('Set this Tag'));
 		so.rmempty = false;
 		so.optional = false;
+
+		o = s.taboption('matchtags', form.SectionValue, '__tags__', form.TableSection, 'tag', null,
+			customi18n( _('A {tagcodestring} is an alphanumeric label. dnsmasq applies chosen DHCP options when a specific {tagcodestring} is encountered.')) + '<br />' +
+			customi18n( _('In other words: "This {tagcodestring} gets these {tag_named_ov_string}".')) + '<br />' +
+			customi18n( _('Note: invalid {tag_named_ov_string} combinations may cause dnsmasq to silently crash.')) + '<br /><br />' +
+			customi18n( _('Prepend a {tagcodestring} with {exclamationmark_invert} to invert their domain of application, e.g. to send options to a host lacking a {tagcodestring}.') ) + '<br /><br />' +
+			customi18n( _('Use the %s Button to add a new {tagcodestring}.').format( _('<em>Add</em>') ) ) );
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+		ss.nodescriptions = true;
+		ss.modaltitle = _('Edit tag');
+		ss.rowcolors = true;
+
+		so = ss.option(form.DynamicList, 'dhcp_option',
+			_('Apply these DHCP Options...'),
+			_('Options to be added for this tag.'));
+		so.rmempty = true;
+		so.optional = true;
+		so.placeholder = '3,192.168.10.1,10.10.10.1';
+
+		so = ss.option(form.Value, 'tag', _('...To this matching Tag'));
+		so.rmempty = false;
+		so.optional = false;
+		so.placeholder = 'specialgateways';
+
+		so = ss.option(form.Flag, 'force',
+			_('Force'),
+			_('Send options to clients that did not request them.'));
+		so.rmempty = false;
+		so.optional = true;
 
 		o = s.taboption('leases', CBILeaseStatus, '__status__');
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -390,6 +390,7 @@ return view.extend({
 		s.tab('mac', _('MAC'));
 		s.tab('matchtags', _('Match Tags'));
 		s.tab('vc', _('VC'));
+		s.tab('uc', _('UC'));
 
 		s.taboption('filteropts', form.Flag, 'domainneeded',
 			_('Domain required'),
@@ -1236,6 +1237,31 @@ return view.extend({
 		ss.rowcolors = true;
 
 		so = ss.option(form.Value, 'vendorclass', _('Match Vendor Class...'));
+		so.rmempty = false;
+		so.optional = false;
+
+		so = ss.option(form.Value, 'networkid', _('...to set this Tag'));
+		so.rmempty = false;
+		so.optional = false;
+
+		so = ss.option(form.Flag, 'force',
+			_('Force'),
+			_('Send options to clients that did not request them.'));
+		so.rmempty = false;
+		so.optional = true;
+
+		o = s.taboption('uc', form.SectionValue, '__uc__', form.TableSection, 'userclass', null,
+			_('Match User Class (UC) strings sent by DHCP clients as a trigger to set tags on them.') + '<br /><br />' +
+			_('Use the <em>Add</em> Button to add a new UC.'));
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+		ss.nodescriptions = true;
+		ss.modaltitle = _('Edit UC');
+		ss.rowcolors = true;
+
+		so = ss.option(form.Value, 'userclass', _('Match User Class...'));
 		so.rmempty = false;
 		so.optional = false;
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -389,6 +389,7 @@ return view.extend({
 		s.tab('pxe_tftp', _('PXE/TFTP'));
 		s.tab('mac', _('MAC'));
 		s.tab('matchtags', _('Match Tags'));
+		s.tab('vc', _('VC'));
 
 		s.taboption('filteropts', form.Flag, 'domainneeded',
 			_('Domain required'),
@@ -1216,6 +1217,31 @@ return view.extend({
 			}
 			return true;
 		};
+
+		so = ss.option(form.Flag, 'force',
+			_('Force'),
+			_('Send options to clients that did not request them.'));
+		so.rmempty = false;
+		so.optional = true;
+
+		o = s.taboption('vc', form.SectionValue, '__vc__', form.TableSection, 'vendorclass', null,
+			_('Match Vendor Class (VC) strings sent by DHCP clients as a trigger to set tags on them.') + '<br /><br />' +
+			_('Use the <em>Add</em> Button to add a new VC.'));
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+		ss.nodescriptions = true;
+		ss.modaltitle = _('Edit VC');
+		ss.rowcolors = true;
+
+		so = ss.option(form.Value, 'vendorclass', _('Match Vendor Class...'));
+		so.rmempty = false;
+		so.optional = false;
+
+		so = ss.option(form.Value, 'networkid', _('...to set this Tag'));
+		so.rmempty = false;
+		so.optional = false;
 
 		so = ss.option(form.Flag, 'force',
 			_('Force'),

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -325,6 +325,16 @@ return view.extend({
 			tagcodestring:'<code>tag</code>',
 			tag_named_ov_string: '<code>option(6):&lt;opt-name&gt;,[&lt;value&gt;[,&lt;value&gt;]]</code>',
 
+			//match tags
+			dhcp_option_code: '<code>option(6)</code>',
+			dhcp_optioncolon_code: '<code>option(6):</code>',
+			dhcp_option_client_arch: '<code>option:client-arch,6</code>',
+			dhcp_value_code: '<code>,value</code>',
+			tag_match_code_name: '<code>match</code>',
+			tag_match_option_syntax: '<code>&lt;option number&gt;|option:&lt;option name&gt;[,&lt;value&gt;]</code>',
+			tag_name_efi_ia32: '<code>efi-ia32</code>',
+			wildcard_code: '<code>*</code>',
+
 		};
 
 		function customi18n(template, values) {
@@ -391,6 +401,7 @@ return view.extend({
 		s.tab('matchtags', _('Match Tags'));
 		s.tab('vc', _('VC'));
 		s.tab('uc', _('UC'));
+		s.tab('settags', _('Set Tags'));
 
 		s.taboption('filteropts', form.Flag, 'domainneeded',
 			_('Domain required'),
@@ -1274,6 +1285,41 @@ return view.extend({
 			_('Send options to clients that did not request them.'));
 		so.rmempty = false;
 		so.optional = true;
+
+		o = s.taboption('settags', form.SectionValue, '__settags__', form.TableSection, 'match', null,
+			customi18n( _('Encountering chosen DHCP {dhcp_option_code}s (or also its {dhcp_value_code}) from clients triggers dnsmasq to set alphanumeric {tagcodestring}s.')) + '<br />' +
+			customi18n( _('In other words: "{tag_match_code_name} these {dhcp_option_code}s to set this {tagcodestring}" or "These {dhcp_option_code}s set this {tagcodestring}".')) + '<br />' +
+			customi18n( _('Internally, these configuration entries are called {tag_match_code_name}.')) + '<br />' +
+			customi18n( _('Matching option syntax: {tag_match_option_syntax}.')) + ' ' +
+			customi18n( _('Prefix named (IPv6) options with {dhcp_optioncolon_code}.')) + ' ' +
+			customi18n( _('Wildcards ({wildcard_code}) allowed.')) + '<br /><br />' +
+			customi18n( _('Match {dhcp_option_client_arch}, Tag {tag_name_efi_ia32}, sets tag {tag_name_efi_ia32}')) + ' ' +
+			_('when number %s appears in the list of architectures sent by the client in option %s.').format('<code>6</code>', '<code>93</code>') + '<br />' +
+			customi18n( _('Use the %s Button to add a new {tag_match_code_name}.').format(_('<em>Add</em>'))) );
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+		ss.nodescriptions = true;
+		ss.modaltitle = _('Edit Match');
+		ss.rowcolors = true;
+
+		so = ss.option(form.Value, 'match', _('Match this client option(+value)...'));
+		so.rmempty = false;
+		so.optional = false;
+		so.placeholder = '61,8c:80:90:01:02:03';
+
+		so = ss.option(form.Value, 'networkid', _('...to Set this Tag'));
+		so.rmempty = false;
+		so.optional = false;
+		so.placeholder = 'myuniqueclientid'
+
+		so = ss.option(form.Flag, 'force',
+			_('Force'),
+			_('Send options to clients that did not request them.'));
+		so.rmempty = false;
+		so.optional = true;
+
 
 		o = s.taboption('leases', CBILeaseStatus, '__status__');
 

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -39,7 +39,8 @@
 		"description": "Grant access to DHCP configuration",
 		"read": {
 			"ubus": {
-				"luci-rpc": [ "getDHCPLeases", "getDUIDHints", "getHostHints" ]
+				"luci-rpc": [ "getDHCPLeases", "getDUIDHints", "getHostHints", "getNetworkDevices" ],
+				"service": [ "list" ],
 			},
 			"uci": [ "dhcp" ]
 		},


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

This is a continuation of the work done in #6705. It implements GUI for dnsmasq based tags. Tags can trigger DHCP options (to be sent in DHCP responses), and vice-versa: DHCP client options and properties e.g. MAC/Vendor/User Class can trigger creation of tags. Recommended for users who know what they are doing, since invalid `option:value` combos can crash dnsmasq.

To describe tags succinctly is a challenge, such that a newcomer understands them more deeply, since they operate in two domains: ingress and egress. I spent a while coming up with the current descriptions. Suggestions welcome, but modifier beware. Syntax and descriptions are terse since you are expected to know what options and values you need.

Note: tags are still called 'networkid' in the dnsmasq.init script, which is *really* old terminology and should be updated. Current dnsmasq manpage and docu details 'tags' as the current terminology with little more than a footnote mentioning networkid any more.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: 23.05.3
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)

https://github.com/openwrt/luci/assets/647633/d939de2a-e577-4d41-b764-3aa74cb894b8


