### PR TITLE
luci-app-dawn: Fix TypeError undef (reading '0')

### DIFF
--- a/applications/luci-app-dawn/htdocs/luci-static/resources/view/dawn/hearing_map.js
+++ b/applications/luci-app-dawn/htdocs/luci-static/resources/view/dawn/hearing_map.js
@@ -90,9 +90,11 @@ return view.extend({
 							ap[1].score
 						]
 					}
+					return undefined;
 				})
 				
 			}).flat();
+			clients = clients.filter(client => client !== undefined);
 
 			cbi_update_table(hearing_map_table, clients, E('em', _('No clients connected.')));
 


### PR DESCRIPTION
Fixes error with hearing map showing:

```
Cannot read properties of undefined (reading '0')
```

Maintainer: Nick Hainke <vincent@systemli.org>