### PR TITLE
luci-base: Correct how textarea's wrap works

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -511,7 +511,7 @@ var UITextarea = UIElement.extend(/** @lends LuCI.ui.Textarea.prototype */ {
 			'style': style,
 			'cols': this.options.cols,
 			'rows': this.options.rows,
-			'wrap': this.options.wrap ? '' : null
+			'wrap': this.options.wrap ? 'soft' : 'off'
 		}, [ value ]));
 
 		if (this.options.monospace)


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (aarch64_cortex-a53/x86, OpenWrt23.05.3, Chrome/Edge/Vivaldi) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

Currently the wrap flag of textarea doesn't works properly, this PR fix it. [Reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#wrap)