### PR TITLE
luci-mod-status: display log_file in status if defined

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -7,12 +7,11 @@
 return view.extend({
 	retrieveLog: async function() {
 		return Promise.all([
-			L.resolveDefault(fs.stat('/sbin/logread'), null),
-			L.resolveDefault(fs.stat('/usr/sbin/logread'), null)
+			L.resolveDefault(fs.stat('/usr/libexec/syslog-wrapper'), null)
 		]).then(function(stat) {
-			var logger = stat[0] ? stat[0].path : stat[1] ? stat[1].path : null;
+			var logger = stat[0].path;
 
-			return fs.exec_direct(logger, [ '-e', '^' ]).then(logdata => {
+			return fs.exec_direct(logger).then(logdata => {
 				const loglines = logdata.trim().split(/\n/);
 				return { value: loglines.join('\n'), rows: loglines.length + 1 };
 			}).catch(function(err) {

--- a/modules/luci-mod-status/root/usr/libexec/syslog-wrapper
+++ b/modules/luci-mod-status/root/usr/libexec/syslog-wrapper
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+main() {
+	local log_file
+
+	log_file="$(uci_get system @system[0] log_file "")"
+	if [ -f "$log_file" ]; then
+		cat "$log_file"
+		return
+	fi
+
+	if [ -f /sbin/logread ]; then
+		/sbin/logread -e ^
+	else
+		/usr/sbin/logread -e ^
+	fi
+}
+
+main

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -32,10 +32,7 @@
 			"cgi-io": [ "exec" ],
 			"file": {
 				"/bin/dmesg -r": [ "exec" ],
-				"/sbin/logread": [ "stat" ],
-				"/sbin/logread -e ^": [ "exec" ],
-				"/usr/sbin/logread": [ "stat" ],
-				"/usr/sbin/logread -e ^": [ "exec" ]
+				"/usr/libexec/syslog-wrapper": [ "exec" ]
 			},
 			"ubus": {
 				"file": [ "stat" ]


### PR DESCRIPTION
Commit includes wrapper syslog in /usr/libexec. If a log file is configured, the output of this file is displayed. Otherwise the output of logread is displayed.