### PR TITLE
luci-app-firewall: allow src_dport to be empty in port forwardings (DNAT)

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -278,7 +278,7 @@ return view.extend({
 		o = s.taboption('general', form.Value, 'src_dport', _('External port'),
 			_('Match incoming traffic directed at the given destination port or port range on this host'));
 		o.modalonly = true;
-		o.rmempty = false;
+		o.rmempty = true;
 		o.datatype = 'neg(portrange)';
 		o.depends({ proto: 'tcp', '!contains': true });
 		o.depends({ proto: 'udp', '!contains': true });


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86_64, openwrt-23.05, chrome-124) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)

I want to `redirect` some IPs to another IP using DNAT.

https://github.com/openwrt/luci/issues/3629

The following configurations in `/etc/config/firewall` works well for me:

```
config redirect
  option name 'Hijack-CF-1'
  option src 'lan'
  option src_dip '104.21.0.0/16'
  option dest_ip '104.18.95.126'
  option target 'DNAT'
  
config redirect
  option name 'Hijack-CF-2'
  option src 'lan'
  option src_dip '172.64.0.0/13'
  option dest_ip '104.18.95.126'
  option target 'DNAT'
```

However, the front end returns error messages because of empty `src_port`, which is not necessary in my case.

![](https://github.com/openwrt/luci/assets/26499123/fcdad597-c017-4b30-bc1f-3b554513fb25)

So I pull this request to allow `src_port` to be set empty so I can click `Save` without any error message form luci directly.

