### PR TITLE
luci-proto-modemmanager: add peerdns option

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -239,6 +239,7 @@ function has_peerdns(proto) {
 	case 'pptp':
 	case 'openvpn':
 	case 'sstp':
+	case 'modemmanager':
 		return true;
 	}
 


### PR DESCRIPTION
ModemManager is a layer 3 "protocol", so there should be an option to allow users to ignore operator-supplied DNS(s).

Tested on Banana PI BPI-R4 (MediaTek Filogic 880, MT7988A), current snapshot, Google Chrome 126.0.6478.127.

Question: should I touch the PKG_VERSION of luci-proto-modemmanager since there's no change there?
