### PR TITLE
luci-base: fix regression add by button-row class

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2974,7 +2974,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 
 			if (!this.getPreviousModalMap())
 				prevNode.parentNode
-					.querySelector('div.right > button')
+					.querySelector('div.button-row > button')
 					.firstChild.data = _('Dismiss');
 		}
 		else {
@@ -3207,8 +3207,8 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 						.appendChild(E('span', title ? ' » ' + title : ''));
 
 					mapNode.parentNode
-						.querySelector('div.right > button')
-						.firstChild.data = _('Back');
+						.querySelector('div.button-row > button')
+						.firstChild.data = _('Dismiss');
 
 					mapNode.classList.add('hidden');
 					mapNode.parentNode.insertBefore(nodes, mapNode.nextElementSibling);

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2672,7 +2672,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 			dom.append(tdEl.lastElementChild,
 				E('button', {
 					'title': _('Edit'),
-					'class': 'cbi-button cbi-button-edit',
+					'class': 'btn cbi-button cbi-button-edit',
 					'click': evFn
 				}, [ _('Edit') ])
 			);
@@ -2682,7 +2682,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 			dom.append(tdEl.lastElementChild,
 				E('button', {
 					'title': more_label,
-					'class': 'cbi-button cbi-button-edit',
+					'class': 'btn cbi-button cbi-button-edit',
 					'click': ui.createHandlerFn(this, 'renderMoreOptionsModal', section_id)
 				}, [ more_label ])
 			);
@@ -2694,7 +2694,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 			dom.append(tdEl.lastElementChild,
 				E('button', {
 					'title': btn_title || _('Delete'),
-					'class': 'cbi-button cbi-button-remove',
+					'class': 'btn cbi-button cbi-button-remove',
 					'click': ui.createHandlerFn(this, 'handleRemove', section_id),
 					'disabled': this.map.readonly || null
 				}, [ btn_title || _('Delete') ])

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4210,7 +4210,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 			UI.prototype.showModal(_('Uploading file…'), [
 				E('p', _('Please select the file to upload.')),
 				E('div', { 'class': 'button-row' }, [
-					E('div', {
+					E('button', {
 						'class': 'btn cbi-button',
 						'click': function() {
 							UI.prototype.hideModal();
@@ -4240,13 +4240,13 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 							upload.focus();
 						}
 					}),
-					E('div', {
+					E('button', {
 						'class': 'btn cbi-button',
 						'click': function(ev) {
 							ev.target.previousElementSibling.click();
 						}
 					}, [ _('Browse…') ]),
-					E('div', {
+					E('button', {
 						'class': 'btn cbi-button-action important',
 						'disabled': true,
 						'click': function(ev) {
@@ -4479,7 +4479,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					list,
 				]),
 				E('div', { 'class': 'button-row' }, [
-					E('div', {
+					E('button', {
 						'class': 'btn cbi-button',
 						'click': UI.prototype.hideModal
 					}, [ _('Close') ]), ' ',
@@ -4493,7 +4493,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						},
 						click: L.bind(function(ev, mode) { this.apply(mode == '0') }, this)
 					}).render(), ' ',
-					E('div', {
+					E('button', {
 						'class': 'btn cbi-button cbi-button-reset',
 						'click': L.bind(this.revert, this)
 					}, [ _('Revert') ])
@@ -4732,15 +4732,15 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						E('h4', _('Connectivity change')),
 						E('p', _('Changes have been made to the existing connection via "%h". This could inhibit access to this device. Any IP change requires <strong>connecting to the new IP</strong> within %d seconds to retain the changes.').format(affected, L.env.apply_rollback)),
 						E('div', { 'class': 'button-row' }, [
-							E('div', {
+							E('button', {
 								'class': 'btn cbi-button',
 								'click': rejectFn,
 							}, [ _('Cancel') ]), ' ',
-							E('div', {
+							E('button', {
 								'class': 'btn cbi-button-action important',
 								'click': resolveFn.bind(null, true)
 							}, [ _('Apply, reverting in case of connectivity loss') ]), ' ',
-							E('div', {
+							E('button', {
 								'class': 'btn cbi-button-negative important',
 								'click': resolveFn.bind(null, false)
 							}, [ _('Apply unchecked') ])

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -176,7 +176,7 @@ function iface_updown(up, id, ev, force) {
 				ui.showModal(_('Confirm disconnect'), [
 					E('p', _('You appear to be currently connected to the device via the "%h" interface. Do you really want to shut down the interface?').format(id)),
 					E('div', { 'class': 'button-row' }, [
-						E('div', {
+						E('button', {
 							'class': 'btn cbi-button cbi-button-neutral',
 							'click': function(ev) {
 								btns[1].classList.remove('spinning');
@@ -187,7 +187,7 @@ function iface_updown(up, id, ev, force) {
 							}
 						}, _('Cancel')),
 						' ',
-						E('div', {
+						E('button', {
 							'class': 'btn cbi-button cbi-button-negative important',
 							'click': function(ev) {
 								dsc.setAttribute('disconnect', '');


### PR DESCRIPTION
This should fix the regression that was introduced by https://github.com/openwrt/luci/pull/7153

- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] \( Preferred ) Mention: @jow-
- [x] Description: (describe the changes proposed in this PR)
