### PR TITLE
luci-app-attendedsysupgrade: use versioned endpoints

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -399,10 +399,9 @@ return view.extend({
 		let { url, revision, advanced_mode, branch } = data;
 		let { version, target, profile, packages } = firmware;
 		let candidates = [];
-		let request_url = `${url}/api/overview`;
-		if (version.endsWith('SNAPSHOT')) {
-			request_url = `${url}/api/v1/revision/${version}/${target}`;
-		}
+
+		const endpoint = version.endsWith('SNAPSHOT') ? `revision/${version}/${target}` : 'overview';
+		const request_url = `${url}/api/v1/${endpoint}`;
 
 		ui.showModal(_('Searching...'), [
 			E(

--- a/applications/luci-app-attendedsysupgrade/po/ar/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ar/attendedsysupgrade.po
@@ -24,7 +24,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -56,8 +56,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -65,12 +65,12 @@ msgstr ""
 msgid "Configuration"
 msgstr "التكوين"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -138,11 +138,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -192,7 +192,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -216,11 +216,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -248,17 +248,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -283,6 +283,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/bg/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/bg/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Отмени"
 
@@ -55,8 +55,8 @@ msgstr "Клиент"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Затвори"
 
@@ -64,12 +64,12 @@ msgstr "Затвори"
 msgid "Configuration"
 msgstr "Конфигурация"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,6 +282,6 @@ msgstr "Версия"
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/bn_BD/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/bn_BD/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "বাতিল করুন"
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -64,12 +64,12 @@ msgstr ""
 msgid "Configuration"
 msgstr "কনফিগারেশন"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,6 +282,6 @@ msgstr "সংস্করণ"
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/ca/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ca/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Actualització Assistida"
@@ -32,7 +32,7 @@ msgstr "Actualització Assistida"
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Tanca"
 
@@ -64,12 +64,12 @@ msgstr "Tanca"
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,6 +282,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/cs/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/cs/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Pokročilý mód"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Interaktivně provedený přechod na novější verzi systému"
@@ -32,7 +32,7 @@ msgstr "Interaktivně provedený přechod na novější verzi systému"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Konfigurace interaktivního přechodu na novější verzi systému."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Název zařízení / Profilu"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Sestavování firmwaru..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -55,8 +55,8 @@ msgstr "Klient"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Zavřít"
 
@@ -64,13 +64,13 @@ msgstr "Zavřít"
 msgid "Configuration"
 msgstr "Nastavení"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "Nepodařilo se připojit k API na \"%s\". Prosím zkuste to znovu později."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Aktuálně spuštěná verze: %s - %s"
 
@@ -98,7 +98,7 @@ msgstr "Probíhá stahování..."
 msgid "Error building the firmware image"
 msgstr "Během sestavování obrazu firmwaru došlo k chybě"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Připojení k upgradovacímu serveru selhalo"
 
@@ -138,11 +138,11 @@ msgstr "Probíhá instalace..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Uchovat nastavení a současnou konfiguraci"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "K dispozici nová verze firmwaru"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Upgrade není k dispozici"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Balíčky"
 
@@ -194,7 +194,7 @@ msgstr "Přijatá žádost o sestavení"
 msgid "Request Data:"
 msgstr "Žádost o data:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Zaslat žádost o obraz firmwaru"
 
@@ -206,7 +206,7 @@ msgstr "Pozice žádosti ve frontě sestavení %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Vyhledat upgrade firmwaru"
 
@@ -218,11 +218,11 @@ msgstr "Vyhledat nové aktualizace systému při otevření karty"
 msgid "Search on opening"
 msgstr "Vyhledat při otevření"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Hledání dostupné aktualizace systému %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Hledání..."
 
@@ -250,7 +250,7 @@ msgstr "Obraz firmwaru úspěšně vytvořen"
 msgid "Target"
 msgstr "Cíl"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "Služba interaktivního systémového upgradu umožňuje snadné upgradování "
 "základních i vlastních obrazů firmware."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Zařízení běží na nejnovější verzi firmwaru %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -288,7 +288,7 @@ msgstr "Verze"
 msgid "Wrong checksum"
 msgstr "Chybný kontrolní součet"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[instalováno] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/da/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/da/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Avanceret tilstand"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Deltaget i Sysupgrade"
@@ -32,7 +32,7 @@ msgstr "Deltaget i Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Deltaget i en opgradering af systemet Konfiguration."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Board Name / Profile"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Building Firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Annuller"
 
@@ -55,8 +55,8 @@ msgstr "Klient"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Luk"
 
@@ -64,12 +64,12 @@ msgstr "Luk"
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Kunne ikke nå API på \"%s\". Prøv venligst igen senere."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Kører i øjeblikket: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Downloader..."
 msgid "Error building the firmware image"
 msgstr "Fejl ved bygning af firmware image"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Fejl ved tilslutning til opgraderingsserveren"
 
@@ -137,11 +137,11 @@ msgstr "Installerer..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Bevar indstillingerne og den aktuelle konfiguration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Ny firmwareopgradering tilgængelig"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Ingen opgradering tilgængelig"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversigt"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pakker"
 
@@ -193,7 +193,7 @@ msgstr "Modtaget byggeanmodning"
 msgid "Request Data:"
 msgstr "Anmod om data:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Anmod firmware image"
 
@@ -205,7 +205,7 @@ msgstr "Anmodning i byggekø position %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Søg efter firmwareopgradering"
 
@@ -217,11 +217,11 @@ msgstr "Søg efter nye sysupgrades, når du åbner fanen"
 msgid "Search on opening"
 msgstr "Søg ved åbning"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Søger efter en tilgængelig sysupgrade af %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Søger..."
 
@@ -249,7 +249,7 @@ msgstr "Det lykkedes at oprette firmware-image"
 msgid "Target"
 msgstr "Mål"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -257,11 +257,11 @@ msgstr ""
 "Med den assisterede sysupgrade-tjeneste kan du nemt opgradere vanilla- og "
 "brugerdefinerede firmwareimages."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Enheden kører den seneste firmwareversion %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -287,7 +287,7 @@ msgstr "Version"
 msgid "Wrong checksum"
 msgstr "Forkert kontrolsum"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installeret] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/de/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/de/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Erweiterter Modus"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Begleitetes System-Upgrade"
@@ -32,7 +32,7 @@ msgstr "Begleitetes System-Upgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Einstellungen für Begleitetes System-Upgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Board Name / Profil"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Firmware wird erstellt.."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -55,8 +55,8 @@ msgstr "Client"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Schließen"
 
@@ -64,14 +64,14 @@ msgstr "Schließen"
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "Die API unter \"%s\" konnte nicht erreicht werden. Bitte versuchen Sie es "
 "später noch einmal."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Derzeit ausgeführt: %s - %s"
 
@@ -99,7 +99,7 @@ msgstr "Wird heruntergeladen..."
 msgid "Error building the firmware image"
 msgstr "Fehler beim Erstellen des Firmware-Images"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Fehler beim Verbinden mit dem Upgrade-Server"
 
@@ -139,11 +139,11 @@ msgstr "Installation..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Einstellungen beibehalten und die aktuelle Konfiguration sichern"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Neues Firmware-Upgrade verfügbar"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Kein Upgrade verfügbar"
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pakete"
 
@@ -197,7 +197,7 @@ msgstr "Build-Anfrage erhalten"
 msgid "Request Data:"
 msgstr "Daten anfordern:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Firmware-Image anfordern"
 
@@ -209,7 +209,7 @@ msgstr "Anforderung in Build-Warteschlangenposition %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Nach Firmware-Upgrade suchen"
 
@@ -221,11 +221,11 @@ msgstr "Suche beim Öffnen des Tabs nach neuen System-Upgrades"
 msgid "Search on opening"
 msgstr "Suche beim Öffnen"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Suche nach einem verfügbaren Sysupgrade von %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Suche..."
 
@@ -253,7 +253,7 @@ msgstr "Firmware-Image erfolgreich erstellt"
 msgid "Target"
 msgstr "Zielplatform"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -261,11 +261,11 @@ msgstr ""
 "Begleitetes Sysupgrade erlaubt es, Upgrades für Vanilla- und Custom-"
 "Installationen einzuspielen."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Auf dem Gerät läuft die neueste Firmware-Version %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -291,7 +291,7 @@ msgstr "Version"
 msgid "Wrong checksum"
 msgstr "Falsche Prüfsumme"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installiert] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/el/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/el/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Υποβοήθηση Sysupgrade"
@@ -32,7 +32,7 @@ msgstr "Υποβοήθηση Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Ακύρωση"
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -64,12 +64,12 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr "Στόχος"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,6 +282,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/en/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/en/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Advanced Mode"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Attended Sysupgrade"
@@ -32,7 +32,7 @@ msgstr "Attended Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Attendedsysupgrade Configuration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Board Name / Profile"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Building Firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -55,8 +55,8 @@ msgstr "Client"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Close"
 
@@ -64,12 +64,12 @@ msgstr "Close"
 msgid "Configuration"
 msgstr "Configuration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Could not reach API at \"%s\". Please try again later."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Currently running: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Downloading..."
 msgid "Error building the firmware image"
 msgstr "Error building the firmware image"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Error connecting to upgrade server"
 
@@ -138,11 +138,11 @@ msgstr "Installing..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Keep settings and retain the current configuration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "New firmware upgrade available"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "No upgrade available"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Overview"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Packages"
 
@@ -194,7 +194,7 @@ msgstr "Received build request"
 msgid "Request Data:"
 msgstr "Request Data:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Request firmware image"
 
@@ -206,7 +206,7 @@ msgstr "Request in build queue position %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Search for firmware upgrade"
 
@@ -218,11 +218,11 @@ msgstr "Search for new sysupgrades on opening the tab"
 msgid "Search on opening"
 msgstr "Search on opening"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Searching for an available sysupgrade of %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Searching..."
 
@@ -250,7 +250,7 @@ msgstr "Successfully created firmware image"
 msgid "Target"
 msgstr "Target"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "The attended sysupgrade service allows you to easily upgrade vanilla and "
 "custom firmware images."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "The device is running the latest firmware version %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -289,7 +289,7 @@ msgstr "Version"
 msgid "Wrong checksum"
 msgstr "Wrong checksum"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installed] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/es/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/es/attendedsysupgrade.po
@@ -26,7 +26,7 @@ msgid "Advanced Mode"
 msgstr "Modo avanzado"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Actualización asistida"
@@ -35,7 +35,7 @@ msgstr "Actualización asistida"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Configuración de actualización asistida."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Nombre de Placa / Perfil"
 
@@ -48,7 +48,7 @@ msgid "Building Firmware..."
 msgstr "Compilando firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -58,8 +58,8 @@ msgstr "Cliente"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Cerrar"
 
@@ -67,14 +67,14 @@ msgstr "Cerrar"
 msgid "Configuration"
 msgstr "Configuración"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "No se pudo contactar la API en \"%s\". Por favor, inténtelo de nuevo más "
 "tarde."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Actualmente en ejecución: %s - %s"
 
@@ -102,7 +102,7 @@ msgstr "Descargando..."
 msgid "Error building the firmware image"
 msgstr "Error al compilar la imagen de firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Error al conectarse al servidor de actualizaciones"
 
@@ -142,11 +142,11 @@ msgstr "Instalando..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Mantener los ajustes y conservar la configuración actual"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Nueva actualización de firmware disponible"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "No hay actualización disponible"
 
@@ -162,7 +162,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Paquetes"
 
@@ -198,7 +198,7 @@ msgstr "Solicitud de compilación recibida"
 msgid "Request Data:"
 msgstr "Datos de la solicitud:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Solicitar imagen de firmware"
 
@@ -210,7 +210,7 @@ msgstr "Solicitud en la posición %s de la cola de compilación"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Buscar actualización de firmware"
 
@@ -222,11 +222,11 @@ msgstr "Busque nuevas actualizaciones del sistema al abrir la pestaña"
 msgid "Search on opening"
 msgstr "Buscar al abrir"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Buscando una actualización del sistema disponible de %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Buscando..."
 
@@ -255,7 +255,7 @@ msgstr "Imagen de firmware creada con éxito"
 msgid "Target"
 msgstr "Objetivo"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -263,11 +263,11 @@ msgstr ""
 "El servicio de actualización asistida permite actualizar fácilmente las "
 "imágenes de firmware personalizadas y/o limpias."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "El dispositivo ejecuta la última versión de firmware %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -294,7 +294,7 @@ msgstr "Versión"
 msgid "Wrong checksum"
 msgstr "Suma de comprobación incorrecta"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "%s [instalado]"
 

--- a/applications/luci-app-attendedsysupgrade/po/fa/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/fa/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "حالت پیشرفته"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "در Sysupgrade ثبت شد"
@@ -32,7 +32,7 @@ msgstr "در Sysupgrade ثبت شد"
 msgid "Attendedsysupgrade Configuration."
 msgstr "پیکربندی sysupgrade ثبت شد."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "نام /پروفایل بورد"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "ساختن ثابت‌افزار…"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "لغو"
 
@@ -55,8 +55,8 @@ msgstr "کارخواه"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "بستن"
 
@@ -64,12 +64,12 @@ msgstr "بستن"
 msgid "Configuration"
 msgstr "پیکربندی"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "دسترسی به API در \"%s\" ممکن نیست. لطفا بعدا دوباره امتحان کنید."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "در حال اجرا : %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "در حال دانلود..."
 msgid "Error building the firmware image"
 msgstr "خطا در ساخت تصویر سیستم عامل"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "خطای وصل شدن به کارساز ارتقا"
 
@@ -137,11 +137,11 @@ msgstr "در حال نصب..."
 msgid "Keep settings and retain the current configuration"
 msgstr "تنظیمات را نگه دارید و پیکربندی فعلی را حفظ کنید"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "ارتقاء سیستم عامل جدید در دسترس است"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "هیچ ارتقایی موجود نیست"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr "نمای کلی"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "بسته ها"
 
@@ -193,7 +193,7 @@ msgstr "درخواست ساخت دریافت شد"
 msgid "Request Data:"
 msgstr "درخواست داده ها:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "درخواست تصویر سیستم عامل"
 
@@ -205,7 +205,7 @@ msgstr "درخواست ایجاد در موقعیت صف ساخت %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "جستجو برای ارتقاء سیستم عامل"
 
@@ -217,11 +217,11 @@ msgstr "با باز کردن برگه، سیستم ارتقای جدید را ج
 msgid "Search on opening"
 msgstr "جستجو در باز کردن"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "جستجو برای ارتقاء سیستم موجود %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "درحال جستجو..."
 
@@ -249,7 +249,7 @@ msgstr "تصویر سیستم عامل با موفقیت ایجاد شد"
 msgid "Target"
 msgstr "هدف"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -257,11 +257,11 @@ msgstr ""
 "این سرویس با حضور در سیستم ارتقا اجازه می دهد تا به راحتی وانیل و تصاویر "
 "سیستم عامل سفارشی ارتقا دهید."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "دستگاه جدیدترین نسخه سیستم عامل را اجرا می کند %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -288,7 +288,7 @@ msgstr "نسخه"
 msgid "Wrong checksum"
 msgstr "اشتباه در checksum"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "نصب شده %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/fi/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/fi/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Edistynyt tila"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Järjestelmän valvottu päivitys"
@@ -32,7 +32,7 @@ msgstr "Järjestelmän valvottu päivitys"
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Koostetaan laiteohjelmistoa..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Peruuta"
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Sulje"
 
@@ -64,12 +64,12 @@ msgstr "Sulje"
 msgid "Configuration"
 msgstr "Kokoonpano"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Nyt käynnissä: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Ladataan..."
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr "Asennetaan..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Säilytä asetukset ja nykyinen kokoonpano"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Uusi laiteohjelmistopäivitys saatavilla"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Ei päivityksiä saatavilla"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Paketit"
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr "Pyynnön data:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Pyydä laiteohjelmiston levykuva"
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Etsi laiteohjelmiston päivitystä"
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Etsitään..."
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,7 +282,7 @@ msgstr "Versio"
 msgid "Wrong checksum"
 msgstr "Väärä tarkistussumma"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[asennettu] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/fr/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/fr/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Mode avancé"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Mise à niveau Système"
@@ -32,7 +32,7 @@ msgstr "Mise à niveau Système"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Configuration Mise à niveau du système."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Nom de la Carte / Profil"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Construction du micrologiciel..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -55,8 +55,8 @@ msgstr "Client"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Fermer"
 
@@ -64,12 +64,12 @@ msgstr "Fermer"
 msgid "Configuration"
 msgstr "Configuration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Ne peut pas joindre l’API à \"%s\". Veuillez retenter plus tard."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "En cours d'exécution : %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Téléchargement..."
 msgid "Error building the firmware image"
 msgstr "Erreur de construction de l'image du micrologiciel"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Erreur en connectant le serveur de mise à jour"
 
@@ -137,11 +137,11 @@ msgstr "Installation..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Garder les paramètres et conserver la configuration actuelle"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Nouvelle mise à jour du micrologiciel disponible"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Pas de mise à jour disponible"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Vue d'ensemble"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Paquets"
 
@@ -194,7 +194,7 @@ msgstr "Demande de construction reçue"
 msgid "Request Data:"
 msgstr "Demande de données :"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Demander l'image du micrologiciel"
 
@@ -206,7 +206,7 @@ msgstr "Demande de construction dans la file d'attente position %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Recherche de mise à jour du micrologiciel"
 
@@ -218,11 +218,11 @@ msgstr "Recherche de nouvelles sysupgrades à l'ouverture de l'onglet"
 msgid "Search on opening"
 msgstr "Recherche à l'ouverture"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Recherche d'un sysupgrade disponible de %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Recherche..."
 
@@ -251,7 +251,7 @@ msgstr "L'image du micrologiciel a été créée avec succès"
 msgid "Target"
 msgstr "Cible"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -259,11 +259,11 @@ msgstr ""
 "Le service sysupgrade assisté permet de mettre facilement à niveau les "
 "images de firmware vanilla et personnalisées."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "L’appareil exécute la dernière version du micrologiciel %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -290,7 +290,7 @@ msgstr "Version"
 msgid "Wrong checksum"
 msgstr "Somme de contrôle incorrecte"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installé] %"
 

--- a/applications/luci-app-attendedsysupgrade/po/he/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/he/attendedsysupgrade.po
@@ -24,7 +24,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -56,8 +56,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -65,12 +65,12 @@ msgstr ""
 msgid "Configuration"
 msgstr "הגדרות"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -138,11 +138,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -192,7 +192,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -216,11 +216,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -248,17 +248,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -283,6 +283,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/hi/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/hi/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "रद्द करें"
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -64,12 +64,12 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,6 +282,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/hu/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/hu/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Haladó mód"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Felügyelt rendszerfrissítés"
@@ -32,7 +32,7 @@ msgstr "Felügyelt rendszerfrissítés"
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Mégse"
 
@@ -55,8 +55,8 @@ msgstr "Ügyfél"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Bezár"
 
@@ -64,12 +64,12 @@ msgstr "Bezár"
 msgid "Configuration"
 msgstr "Beállítás"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr "Beállítások jelenlegi állapotának megtartása"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Nincs elérhető frissítés"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,7 +247,7 @@ msgstr ""
 msgid "Target"
 msgstr "Célplatform"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -255,11 +255,11 @@ msgstr ""
 "A felügyelt rendszerfrissítés segítségével könnyen frissíthet alap, illetve "
 "saját készítésű firmware-ket is."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -284,7 +284,7 @@ msgstr "Verzió"
 msgid "Wrong checksum"
 msgstr "Hibás ellenőrzőösszeg"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""
 

--- a/applications/luci-app-attendedsysupgrade/po/it/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/it/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Modalità avanzata"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Sysupgrade assistito"
@@ -32,7 +32,7 @@ msgstr "Sysupgrade assistito"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Configurazione sysupgrade assistita."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Nome piattaforma / Profilo"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Compilazione del firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -55,8 +55,8 @@ msgstr "Client"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Chiudi"
 
@@ -64,12 +64,12 @@ msgstr "Chiudi"
 msgid "Configuration"
 msgstr "Configurazione"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Impossibile raggiungere l'API su \"%s\". Riprova più tardi."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Operazione in corso: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Scaricamento..."
 msgid "Error building the firmware image"
 msgstr "Errore compilando l'immagine del firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Errore di connessione al server di aggiornamento"
 
@@ -137,11 +137,11 @@ msgstr "Installazione..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Mantieni le impostazioni e conserva la configurazione attuale"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Nuovo aggiornamento del firmware disponibile"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Nessun aggiornamento disponibile"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riepilogo"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pacchetti"
 
@@ -193,7 +193,7 @@ msgstr "Richiesta di compilazione ricevuta"
 msgid "Request Data:"
 msgstr "Dati della richiesta:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Richiesta immagine firmware"
 
@@ -205,7 +205,7 @@ msgstr "Richiesta nella posizione %s della coda di compilazione"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Cerca aggiornamenti del firmware"
 
@@ -217,11 +217,11 @@ msgstr "Cerca nuovi sysupgrade all'apertura della scheda"
 msgid "Search on opening"
 msgstr "Cerca all'apertura"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Ricerca di un sysupgrade disponibile per %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Ricerca in corso..."
 
@@ -250,7 +250,7 @@ msgstr "Immagine del firmware creata correttamente"
 msgid "Target"
 msgstr "Destinazione"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "Il servizio sysupgrade assistito consente di aggiornare facilmente le "
 "immagini firmware originali e personalizzate."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Il dispositivo ha già la versione firmware più recente %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -289,7 +289,7 @@ msgstr "Versione"
 msgid "Wrong checksum"
 msgstr "Checksum errato"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installati] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/ja/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ja/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -55,8 +55,8 @@ msgstr "クライアント"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "閉じる"
 
@@ -64,12 +64,12 @@ msgstr "閉じる"
 msgid "Configuration"
 msgstr "設定"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr "ダウンロード中..."
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr "インストール中..."
 msgid "Keep settings and retain the current configuration"
 msgstr "現在の設定を残す"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "パッケージ"
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "ファームウェアの更新を検索"
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "検索中..."
 
@@ -247,17 +247,17 @@ msgstr "ファームウェアイメージの作成に成功"
 msgid "Target"
 msgstr "ターゲット"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,7 +282,7 @@ msgstr "バージョン"
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""
 

--- a/applications/luci-app-attendedsysupgrade/po/ko/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ko/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "고급 모드"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "유인 업그레이드"
@@ -32,7 +32,7 @@ msgstr "유인 업그레이드"
 msgid "Attendedsysupgrade Configuration."
 msgstr "유인 업그레이드(Attended Sysupgrade) 설정입니다."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "보드 이름 / 프로파일"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "펌웨어 빌드 중..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "취소"
 
@@ -55,8 +55,8 @@ msgstr "클라이언트"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "닫기"
 
@@ -64,12 +64,12 @@ msgstr "닫기"
 msgid "Configuration"
 msgstr "설정"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "\"%s\"의 API에 도달할 수 없습니다. 나중에 다시 시도해주세요."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "현재 실행 중인 펌웨어: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "다운로드 중..."
 msgid "Error building the firmware image"
 msgstr "펌웨어 이미지 빌드 실패"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "업그레이드 서버 연결 실패"
 
@@ -137,11 +137,11 @@ msgstr "설치 중..."
 msgid "Keep settings and retain the current configuration"
 msgstr "현재 설정을 유지"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "새로운 펌웨어 업그레이드를 사용할 수 있습니다"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "새로운 업그레이드가 없습니다"
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr "개요"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "패키지"
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr "요청 데이터:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "펌웨어 이미지 요청"
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "펌웨어 업그레이드 검색"
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "%s - %s 로부터 사용 가능한 Sysupgrade를 검색하는 중입니다..."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "검색 중..."
 
@@ -247,7 +247,7 @@ msgstr "펌웨어 이미지 생성 성공"
 msgid "Target"
 msgstr "대상"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -255,11 +255,11 @@ msgstr ""
 "유인 업그레이드 서비스는 순정 또는 커스텀 펌웨어 이미지로 쉽게 업그레이드할 "
 "수 있게 해줍니다."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "최신 펌웨어 버전 실행 중: %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -284,7 +284,7 @@ msgstr "버전"
 msgid "Wrong checksum"
 msgstr "체크섬이 일치하지 않음"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[설치됨] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/lt/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/lt/attendedsysupgrade.po
@@ -26,7 +26,7 @@ msgid "Advanced Mode"
 msgstr "Pažangus režimas"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Prisistatoma „Sysupgrade“"
@@ -35,7 +35,7 @@ msgstr "Prisistatoma „Sysupgrade“"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Prisistatoma „Sysupgrade“ konfigūracija."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Plokštės pavadinimas/profilis"
 
@@ -48,7 +48,7 @@ msgid "Building Firmware..."
 msgstr "Statoma programinė įranga..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Atšaukti"
 
@@ -58,8 +58,8 @@ msgstr "Klientas"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Uždaryti"
 
@@ -67,13 +67,13 @@ msgstr "Uždaryti"
 msgid "Configuration"
 msgstr "Konfigūravimas"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "Negalėjome pasiekti „API“ \"%s\". Prašome pamėginti dar kartą vėlesniu laiku."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Dabar veikia: %s - %s"
 
@@ -101,7 +101,7 @@ msgstr "Atsisiunčiama..."
 msgid "Error building the firmware image"
 msgstr "Klaida statant programinės įrangos laikmeną"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Klaida jungiantis į atnaujinimo serverį"
 
@@ -141,11 +141,11 @@ msgstr "Įdiegiama..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Laikyti nustatymus ir dabartinį konfigūravimą"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Naujas programinės įrangos atnaujinimas pasiekiamas"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Atnaujinimo nerasta"
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Apžiūra"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Paketai"
 
@@ -197,7 +197,7 @@ msgstr "Gauti „statymo“ prašymai"
 msgid "Request Data:"
 msgstr "Prašymo data:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Prašyti programinės įrangos laikmeną"
 
@@ -209,7 +209,7 @@ msgstr "Prašymo „statymo“ eilėje vieta – %s"
 msgid "SHA256"
 msgstr "„SHA256“"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Ieškoti programinės įrangos atnaujinimo"
 
@@ -221,11 +221,11 @@ msgstr "Ieškoti dėl naujo „sysupgrades“ atidarant skirtuką"
 msgid "Search on opening"
 msgstr "Ieškoti atidarant"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Ieškojama dėl pasiekiamo „sysupgrade“ – %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Ieškoma..."
 
@@ -253,7 +253,7 @@ msgstr "Sėkmingai sukurta programinės įrangos laikmena"
 msgid "Target"
 msgstr "Taikinys"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -261,11 +261,11 @@ msgstr ""
 "Prisistatoma „sysupgrade“ tarnybą leidžią lengvai atnaujinti „vanilinį“ ir "
 "atskiras programinių įrangų laikmenas."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Įrenginys veikia ant naujausios programinės įrangos versijos – %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -292,6 +292,6 @@ msgstr "Versija"
 msgid "Wrong checksum"
 msgstr "Neatitinkamas „checksum“"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[įdiegta] %s"

--- a/applications/luci-app-attendedsysupgrade/po/mr/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/mr/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "उपस्थित Sysupgrade"
@@ -32,7 +32,7 @@ msgstr "उपस्थित Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -64,12 +64,12 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""
 

--- a/applications/luci-app-attendedsysupgrade/po/ms/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ms/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Tutup"
 
@@ -64,12 +64,12 @@ msgstr "Tutup"
 msgid "Configuration"
 msgstr "Konfigurasi"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr "Sasaran"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,6 +282,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/nb_NO/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/nb_NO/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Bivånet systemoppgradering"
@@ -32,7 +32,7 @@ msgstr "Bivånet systemoppgradering"
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -55,8 +55,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Lukk"
 
@@ -64,12 +64,12 @@ msgstr "Lukk"
 msgid "Configuration"
 msgstr "Oppsett"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -137,11 +137,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -215,11 +215,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -282,7 +282,7 @@ msgstr "Versjon"
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""
 

--- a/applications/luci-app-attendedsysupgrade/po/nl/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/nl/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Geavanceerde modus"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Bijgewoond Sysupgrade"
@@ -32,7 +32,7 @@ msgstr "Bijgewoond Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Attendedsysupgrade-configuratie."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Bestuursnaam / Profiel"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Firmware bouwen..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -55,8 +55,8 @@ msgstr "Cliënt"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Sluiten"
 
@@ -64,12 +64,12 @@ msgstr "Sluiten"
 msgid "Configuration"
 msgstr "Configuratie"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Kan API niet bereiken op \"%s\". Probeer het later opnieuw."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Momenteel actief: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Downloaden..."
 msgid "Error building the firmware image"
 msgstr "Fout bij het maken van de firmware-image"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Fout bij het verbinden met de upgradeserver"
 
@@ -137,11 +137,11 @@ msgstr "Installeren..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Instellingen behouden en de huidige configuratie behouden"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Nieuwe firmware-upgrade beschikbaar"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Geen upgrade beschikbaar"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Overzicht"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pakketten"
 
@@ -194,7 +194,7 @@ msgstr "Verzoek 'build' ontvangen"
 msgid "Request Data:"
 msgstr "Gegevens opvragen:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Firmware-image aanvragen"
 
@@ -206,7 +206,7 @@ msgstr "Verzoek in bouwwachtrij positie %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Zoeken naar firmware-upgrade"
 
@@ -218,11 +218,11 @@ msgstr "Zoek naar nieuwe sysupgrades bij het openen van het tabblad"
 msgid "Search on opening"
 msgstr "Zoeken bij opening"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Zoeken naar een beschikbare sysupgrade van %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Zoeken..."
 
@@ -250,7 +250,7 @@ msgstr "Firmware-image met succes gemaakt"
 msgid "Target"
 msgstr "Doel"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "De bijgewoonde sysupgrade-service maakt het mogelijk om eenvoudig vanille- "
 "en aangepaste firmware-images te upgraden."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Het apparaat voert de nieuwste firmwareversie %s - %s uit"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -289,7 +289,7 @@ msgstr "Versie"
 msgid "Wrong checksum"
 msgstr "Verkeerde controlesom"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[geïnstalleerd] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/pl/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/pl/attendedsysupgrade.po
@@ -24,7 +24,7 @@ msgid "Advanced Mode"
 msgstr "Tryb zaawansowany"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Aktualizacja interaktywna"
@@ -33,7 +33,7 @@ msgstr "Aktualizacja interaktywna"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Konfiguracja Attendedsysupgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Nazwa płyty / Profil"
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr "Kompilowanie oprogramowania układowego..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -56,8 +56,8 @@ msgstr "Klient"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Zamknij"
 
@@ -65,12 +65,12 @@ msgstr "Zamknij"
 msgid "Configuration"
 msgstr "Konfiguracja"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Nie można połączyć z API \"%s\". Spróbuj później."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Aktualnie uruchomione: %s - %s"
 
@@ -98,7 +98,7 @@ msgstr "Pobieranie..."
 msgid "Error building the firmware image"
 msgstr "Błąd podczas tworzenia obrazu oprogramowania układowego"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Błąd połączenia z serwerem aktualizacji"
 
@@ -138,11 +138,11 @@ msgstr "Instalowanie..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Zachowaj ustawienia i bieżącą konfigurację"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Dostępna jest nowa aktualizacja oprogramowania układowego"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Brak dostępnej aktualizacji"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pakiety"
 
@@ -194,7 +194,7 @@ msgstr "Otrzymano żądanie kompilacji"
 msgid "Request Data:"
 msgstr "Żądanie danych:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Kompiluj żądany obraz"
 
@@ -206,7 +206,7 @@ msgstr "Żądanie w pozycji kolejki kompilacji %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Sprawdź dostępność aktualizacji"
 
@@ -218,11 +218,11 @@ msgstr "Wyszukaj aktualizacje przy otwieraniu karty"
 msgid "Search on opening"
 msgstr "Szukaj po otwarciu"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Wyszukiwanie dostępnej wersji sysupgrade %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
@@ -250,7 +250,7 @@ msgstr "Pomyślnie utworzony obraz oprogramowania układowego"
 msgid "Target"
 msgstr "Cel"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,12 +258,12 @@ msgstr ""
 "Usługa sysupgrade umożliwia łatwą aktualizację oryginalnych i "
 "niestandardowych obrazów oprogramowania układowego."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 "Na urządzeniu działa najnowsza wersja oprogramowania układowego %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -290,7 +290,7 @@ msgstr "Wersja"
 msgid "Wrong checksum"
 msgstr "Błędna suma kontrolna"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[zainstalowano] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/pt/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/pt/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Modo avançado"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Sysupgrade assistido"
@@ -32,7 +32,7 @@ msgstr "Sysupgrade assistido"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Configuração do attendedsysupgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Nome da placa / perfil"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Construindo o firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -55,8 +55,8 @@ msgstr "Cliente"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Fechar"
 
@@ -64,12 +64,12 @@ msgstr "Fechar"
 msgid "Configuration"
 msgstr "Configuração"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Não foi possível alcançar a API em \"%s\". Tente novamente mais tarde."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Atualmente em execução: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Baixando..."
 msgid "Error building the firmware image"
 msgstr "Houve um erro ao construir a imagem do firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Erro ao conectar o servidor de atualização"
 
@@ -137,11 +137,11 @@ msgstr "A instalar..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Manter as definições e manter a configuração atual"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Uma nova atualização do firmware está disponível"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Não há atualização disponível"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pacotes"
 
@@ -194,7 +194,7 @@ msgstr "Solicitação de compilação recebida"
 msgid "Request Data:"
 msgstr "Solicitar dados:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Pedir a imagem de firmware"
 
@@ -206,7 +206,7 @@ msgstr "Solicitação na posição %d de fila de construção"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Procurar pela atualização do firmware"
 
@@ -218,11 +218,11 @@ msgstr "Procurar novos sysupgrades ao abrir a guia"
 msgid "Search on opening"
 msgstr "Pesquisar na abertura"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "A procurar por um sysupgrade disponível de %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Procurando..."
 
@@ -250,7 +250,7 @@ msgstr "A imagem do firmware foi criada com sucesso"
 msgid "Target"
 msgstr "Destino"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "O serviço de sysupgrade atendido permite atualizar facilmente imagens de "
 "firmware padrão e personalizados."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "O aparelho executa a versão mais recente da firmware %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -289,7 +289,7 @@ msgstr "Versão"
 msgid "Wrong checksum"
 msgstr "Checksum errado"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[instalado] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/pt_BR/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/pt_BR/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Modo avançado"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Sysupgrade Assistido"
@@ -32,7 +32,7 @@ msgstr "Sysupgrade Assistido"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Configuração do attendedsysupgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Nome da placa / perfil"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Construindo o firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -55,8 +55,8 @@ msgstr "Cliente"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Fechar"
 
@@ -64,12 +64,12 @@ msgstr "Fechar"
 msgid "Configuration"
 msgstr "Configuração"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Não foi possível alcançar a API em \"%s\". tente novamente mais tarde."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Atualmente em execução: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Baixando..."
 msgid "Error building the firmware image"
 msgstr "Houve um erro ao construir a imagem do firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Erro ao conectar o servidor de atualização"
 
@@ -137,11 +137,11 @@ msgstr "Instalando..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Mantenha as configurações e preserve a configuração atual"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Uma nova atualização do firmware está disponível"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Nenhum upgrade disponível"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão geral"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pacotes"
 
@@ -193,7 +193,7 @@ msgstr "Solicitação de compilação recebida"
 msgid "Request Data:"
 msgstr "Solicitar dados:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Solicitar a imagem do firmware"
 
@@ -205,7 +205,7 @@ msgstr "Pedido posicionado na fila de compilação %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Procurar pela atualização do firmware"
 
@@ -217,11 +217,11 @@ msgstr "Pesquisar por novos sysupgrades ao abrir a aba"
 msgid "Search on opening"
 msgstr "Pesquisar ao abrir"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Procurando pela disponibilidade de um sysupgrade em %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Procurando..."
 
@@ -249,7 +249,7 @@ msgstr "A imagem do firmware foi criada com sucesso"
 msgid "Target"
 msgstr "Destino"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -257,11 +257,11 @@ msgstr ""
 "O serviço autônomo sysupgrade permite facilmente realizar o upgrade de "
 "imagens de firmware vanilla e personalizadas."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "O dispositivo possui a versão mas recente do firmware %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -288,7 +288,7 @@ msgstr "Versão"
 msgid "Wrong checksum"
 msgstr "Checksum incorreto"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[instalado] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/ro/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ro/attendedsysupgrade.po
@@ -24,7 +24,7 @@ msgid "Advanced Mode"
 msgstr "Modul avansat"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "a participat Sysupgrade"
@@ -33,7 +33,7 @@ msgstr "a participat Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr "A participat la configurațiaysupgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Numele Plăcii / Profil"
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr "Se crează firmware-ul..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Anulare"
 
@@ -56,8 +56,8 @@ msgstr "Client"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Închideți"
 
@@ -65,13 +65,13 @@ msgstr "Închideți"
 msgid "Configuration"
 msgstr "Configurație"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "Nu s-a putut accesa API la \"%s\". Vă rugăm să încercați din nou mai târziu."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "În prezent rulează: %s - %s"
 
@@ -99,7 +99,7 @@ msgstr "Descărcare..."
 msgid "Error building the firmware image"
 msgstr "Eroare la crearea imaginii firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Eroare de conectare la serverul de actualizare"
 
@@ -140,11 +140,11 @@ msgstr "Se instalează..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Păstrați setările și păstrați configurația curentă"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Este disponibil un nou upgrade de firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Niciun upgrade disponibil"
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Pachete"
 
@@ -197,7 +197,7 @@ msgstr "Cerere de construcție primită"
 msgid "Request Data:"
 msgstr "Solicitați date:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Solicitați imaginea firmware"
 
@@ -209,7 +209,7 @@ msgstr "Cerere aflată în coada de așteptare în poziția %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Căutați actualizări firmware"
 
@@ -221,11 +221,11 @@ msgstr "Căutați noi sysupgrades la deschiderea filei"
 msgid "Search on opening"
 msgstr "Căutare la deschidere"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Căutarea unui sysupgrade disponibil de %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Căutare..."
 
@@ -253,7 +253,7 @@ msgstr "Imaginea firmware a fost creată cu succes"
 msgid "Target"
 msgstr "Țintă"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -261,11 +261,11 @@ msgstr ""
 "Serviciul sysupgrade permite actualizarea cu ușurință a imaginilor de "
 "firmware vanilie și personalizate."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Dispozitivul rulează cea mai recentă versiune de firmware %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -292,7 +292,7 @@ msgstr "Versiune"
 msgid "Wrong checksum"
 msgstr "Suma de control greșită"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installed] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/ru/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/ru/attendedsysupgrade.po
@@ -24,7 +24,7 @@ msgid "Advanced Mode"
 msgstr "Расширенный режим"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Обновление Системы"
@@ -33,7 +33,7 @@ msgstr "Обновление Системы"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Конфигурация обновления системы."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Имя платформы / Профиль"
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr "Сборка прошивки..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -56,8 +56,8 @@ msgstr "Клиент"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Закрыть"
 
@@ -65,12 +65,12 @@ msgstr "Закрыть"
 msgid "Configuration"
 msgstr "Конфигурация"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "API сервера \"%s\" недоступен. Пожалуйста, попробуйте позднее."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Сейчас работает: %s - %s"
 
@@ -98,7 +98,7 @@ msgstr "Скачивание..."
 msgid "Error building the firmware image"
 msgstr "Ошибка сборки образа прошивки"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Ошибка соединения с сервером обновления"
 
@@ -138,11 +138,11 @@ msgstr "Установка..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Сохранить настройки и оставить текущую конфигурацию"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Новое обновление прошивки доступно"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Нет доступных обновлений"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Пакеты"
 
@@ -194,7 +194,7 @@ msgstr "Получен запрос на сборку"
 msgid "Request Data:"
 msgstr "Данные запроса:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Запросить образ прошивки"
 
@@ -206,7 +206,7 @@ msgstr "Запрос в очереди сборки, позиция %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Поиск обновлений прошивки"
 
@@ -218,11 +218,11 @@ msgstr "Искать новые системные обновления при �
 msgid "Search on opening"
 msgstr "Искать при открытии"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Поиск доступной версии sysupgrade %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Поиск..."
 
@@ -250,7 +250,7 @@ msgstr "Образ прошивки создан успешно"
 msgid "Target"
 msgstr "Приоритет"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "Данная служба позволяет легко обновлять ванильные и пользовательские образы "
 "прошивки."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "На устройстве установлена последняя версия прошивки %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -288,7 +288,7 @@ msgstr "Версия"
 msgid "Wrong checksum"
 msgstr "Неверная контрольная сумма"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[установлено] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/sk/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/sk/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Pokročilý režim"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr "Konfigurácia Attendedsysupgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Názov zariadenia / Profil"
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr "Zostavovanie firmvéru..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Zrušiť"
 
@@ -56,8 +56,8 @@ msgstr "Klient"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Zavrieť"
 
@@ -65,12 +65,12 @@ msgstr "Zavrieť"
 msgid "Configuration"
 msgstr "Konfigurácia"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Nepodarilo sa získať prístup k API na \"%s\". Skúste neskôr prosím."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Aktuálne spustené: %s – %s"
 
@@ -98,7 +98,7 @@ msgstr "Sťahuje sa..."
 msgid "Error building the firmware image"
 msgstr "Chyba pri vytváraní obrazu firmvéru"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Chyba pri pripájaní k aktualizačnému serveru"
 
@@ -138,11 +138,11 @@ msgstr "Inštaluje sa..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Ponechať nastavenia a nestratiť aktuálnu konfiguráciu"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "K dispozícii je nová aktualizácia firmvéru"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Nie je k dispozícii žiadna aktualizácia"
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Balíky"
 
@@ -196,7 +196,7 @@ msgstr "Prijatá žiadosť o zostavenie"
 msgid "Request Data:"
 msgstr "Žiadané dáta:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Vyžiadať obraz firmvéru"
 
@@ -208,7 +208,7 @@ msgstr "Žiadosť vo fronte zostavenia na pozícii %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Vyhľadať aktualizáciu firmvéru"
 
@@ -220,11 +220,11 @@ msgstr "Vyhľadávanie nových aktualizácií systému pri otvorení karty"
 msgid "Search on opening"
 msgstr "Vyhľadať pri otvorení"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Hľadanie dostupnej aktualizácie systému %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Hľadanie..."
 
@@ -252,7 +252,7 @@ msgstr "Obraz firmvéru úspešne vytvorený"
 msgid "Target"
 msgstr "Cieľ"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -260,11 +260,11 @@ msgstr ""
 "Služba Attended sysupgrade umožňuje jednoduchú aktualizáciu základných a "
 "vlastných obrazov firmvéru."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Zariadenie beží na najnovšej verzii firmvéru %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -291,6 +291,6 @@ msgstr "Verzia"
 msgid "Wrong checksum"
 msgstr "Chybný kontrolný súčet"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[nainštalované] %s"

--- a/applications/luci-app-attendedsysupgrade/po/sv/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/sv/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Avancerat läge"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Systemövervakad uppgradering"
@@ -32,7 +32,7 @@ msgstr "Systemövervakad uppgradering"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Konfiguration för systemövervakad uppgradering."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Bygger mjukvara..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -55,8 +55,8 @@ msgstr "Klient"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Stäng"
 
@@ -64,12 +64,12 @@ msgstr "Stäng"
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Kunde inte nå API vid \"%s\". Vänligen försök igen senare."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Kör för närvarande: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Laddar ner..."
 msgid "Error building the firmware image"
 msgstr "Fel vid byggandet av mjukvaruavbildningen"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Fel uppstod vid anslutning till uppgraderingsservern"
 
@@ -138,11 +138,11 @@ msgstr "Installerar..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Behåll nuvarande inställningar och konfiguration"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Ny mjukvaruuppgradering tillgänglig"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Ingen uppgradering tillgänglig"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Överblick"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Paket"
 
@@ -194,7 +194,7 @@ msgstr "Tog emot byggförfrågan"
 msgid "Request Data:"
 msgstr "Förfrågningsdata:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Begär mjukvaruavbildning"
 
@@ -206,7 +206,7 @@ msgstr "Förfrågan i byggköposition %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Sök efter mjukvaruuppgradering"
 
@@ -218,11 +218,11 @@ msgstr "Sök efter nya systemuppgraderingar vid öppnande av fliken"
 msgid "Search on opening"
 msgstr "Sök efter öppning"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Söker efter tillgänglig systemuppgradering av %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Söker..."
 
@@ -250,7 +250,7 @@ msgstr "Skapandet av mjukvaruavbildningen lyckades"
 msgid "Target"
 msgstr "Mål"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -258,11 +258,11 @@ msgstr ""
 "Tjänsten systemövervakad uppgradering tillåter enkel uppgradering av ej "
 "anpassade och anpassade mjukvaruavbildningar."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Enheten kör den senaste mjukvaruversionen %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -289,7 +289,7 @@ msgstr "Version"
 msgid "Wrong checksum"
 msgstr "Fel kontrollsumma"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[installerat] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/templates/attendedsysupgrade.pot
+++ b/applications/luci-app-attendedsysupgrade/po/templates/attendedsysupgrade.pot
@@ -14,7 +14,7 @@ msgid "Advanced Mode"
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr ""
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Attendedsysupgrade Configuration."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr ""
 
@@ -36,7 +36,7 @@ msgid "Building Firmware..."
 msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr ""
 
@@ -46,8 +46,8 @@ msgstr ""
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr ""
 
@@ -55,12 +55,12 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr ""
 
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Error building the firmware image"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr ""
 
@@ -128,11 +128,11 @@ msgstr ""
 msgid "Keep settings and retain the current configuration"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr ""
 
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr ""
 
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Request Data:"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "SHA256"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr ""
 
@@ -206,11 +206,11 @@ msgstr ""
 msgid "Search on opening"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr ""
 
@@ -238,17 +238,17 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -273,6 +273,6 @@ msgstr ""
 msgid "Wrong checksum"
 msgstr ""
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr ""

--- a/applications/luci-app-attendedsysupgrade/po/tr/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/tr/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Gelişmiş Mod"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Katılımlı Sysupgrade"
@@ -32,7 +32,7 @@ msgstr "Katılımlı Sysupgrade"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Attendedsysupgrade Yapılandırması."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Pano İsmi / Profil"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Firmware oluşturuluyor..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "İptal"
 
@@ -55,8 +55,8 @@ msgstr "İstemci"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Kapat"
 
@@ -64,13 +64,13 @@ msgstr "Kapat"
 msgid "Configuration"
 msgstr "Yapılandırma"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "\"%s\" konumunda API'ye ulaşılamadı. Lütfen daha sonra tekrar deneyiniz."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Şu anda çalışıyor: %s - %s"
 
@@ -98,7 +98,7 @@ msgstr "İndiriliyor..."
 msgid "Error building the firmware image"
 msgstr "Firmware imajı oluşturulurken hata oluştu"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Yükseltme sunucusuna bağlanırken hata oluştu"
 
@@ -138,11 +138,11 @@ msgstr "Yükleniyor..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Ayarları ve mevcut yapılandırmayı koruyun"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Yeni yükseltme mevcut"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Yeni yükseltme mevcut değil"
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Paketler"
 
@@ -195,7 +195,7 @@ msgstr "Oluşturma isteği alındı"
 msgid "Request Data:"
 msgstr "İstenilen Veri:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Firmware imajını iste"
 
@@ -207,7 +207,7 @@ msgstr "%s oluşturma kuyruğu konumunda istek"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Yazılım yükseltmesi için arayın"
 
@@ -219,11 +219,11 @@ msgstr "Sekmeyi açarken yeni sysupgrade'leri arayın"
 msgid "Search on opening"
 msgstr "Açılışta ara"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "%s - %s arasında kullanılabilir bir sysupgrade aranıyor"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Aranıyor..."
 
@@ -251,7 +251,7 @@ msgstr "Firmware imajı başarıyla oluşturuldu"
 msgid "Target"
 msgstr "Hedef"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -259,11 +259,11 @@ msgstr ""
 "Katılımlı sysupgrade hizmeti, resmi ve özel yapım firmware imajlarını "
 "kolayca yükseltmenize olanak tanır."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Cihaz en son donanım yazılımı sürümünü %s - %s çalıştırıyor"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -290,7 +290,7 @@ msgstr "Versiyon"
 msgid "Wrong checksum"
 msgstr "Hatalı checksum"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[kurulu] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/uk/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/uk/attendedsysupgrade.po
@@ -24,7 +24,7 @@ msgid "Advanced Mode"
 msgstr "Розширений режим"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Сервісне оновлення системи"
@@ -33,7 +33,7 @@ msgstr "Сервісне оновлення системи"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Конфігурація Attendedsysupgrade."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Назва платформи / Профіль"
 
@@ -46,7 +46,7 @@ msgid "Building Firmware..."
 msgstr "Створення прошивки..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -56,8 +56,8 @@ msgstr "Клієнт"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Закрити"
 
@@ -65,13 +65,13 @@ msgstr "Закрити"
 msgid "Configuration"
 msgstr "Конфігурація"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr ""
 "Не вдалося отримати доступ до API на \"%s\". Будь-ласка спробуйте пізніше."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "В даний час працює: %s - %s"
 
@@ -99,7 +99,7 @@ msgstr "Завантаження..."
 msgid "Error building the firmware image"
 msgstr "Помилка створення образу прошивки"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Помилка підключення до сервера оновлення"
 
@@ -139,11 +139,11 @@ msgstr "Встановлення..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Зберегти налаштування та поточну конфігурацію"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Доступне оновлення прошивки"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Немає доступних оновлень"
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Пакунки"
 
@@ -195,7 +195,7 @@ msgstr "Отримано запит на збірку"
 msgid "Request Data:"
 msgstr "Дані запиту:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Запит образу прошивки"
 
@@ -207,7 +207,7 @@ msgstr "Запит в черзі на збірку, позиція %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Пошук оновлення прошивки"
 
@@ -219,11 +219,11 @@ msgstr "Пошук нових оновлень системи при відкр�
 msgid "Search on opening"
 msgstr "Пошук при відкритті"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Пошук доступного оновлення системи %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Пошук..."
 
@@ -251,7 +251,7 @@ msgstr "Успішно створений образ прошивки"
 msgid "Target"
 msgstr "Ціль"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -259,11 +259,11 @@ msgstr ""
 "Сервіс attended sysupgrade дозволяє легко оновлювати ванільні та "
 "користувацькі образи прошивки."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "На пристрої встановлена остання версія прошивки %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -290,7 +290,7 @@ msgstr "Версія"
 msgid "Wrong checksum"
 msgstr "Неправильна контрольна сума"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[встановлено] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/vi/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/vi/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "Chế độ nâng cao"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "Nâng cấp Sysupgrade được theo dõi"
@@ -32,7 +32,7 @@ msgstr "Nâng cấp Sysupgrade được theo dõi"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Cấu hình nâng cấp hệ thống có hướng dẫn."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "Tên bo mạch / Hồ sơ"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "Đang xây dựng Firmware..."
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "Hủy lệnh"
 
@@ -55,8 +55,8 @@ msgstr "Máy Khách"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "Đóng"
 
@@ -64,12 +64,12 @@ msgstr "Đóng"
 msgid "Configuration"
 msgstr "Cấu hình"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "Không thể kết nối tới API tại \"%s\". Vui lòng thử lại sau."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "Đang chạy: %s - %s"
 
@@ -97,7 +97,7 @@ msgstr "Đang tải xuống..."
 msgid "Error building the firmware image"
 msgstr "Lỗi khi tạo hình ảnh firmware"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "Lỗi kết nối tới máy chủ nâng cấp"
 
@@ -137,11 +137,11 @@ msgstr "Đang cài đặt..."
 msgid "Keep settings and retain the current configuration"
 msgstr "Giữ nguyên cài đặt và giữ nguyên cấu hình hiện tại"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "Có bản nâng cấp firmware mới"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "Không có bản nâng cấp"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Tổng quan"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "Gói"
 
@@ -193,7 +193,7 @@ msgstr "Đã nhận yêu cầu xây dựng"
 msgid "Request Data:"
 msgstr "Dữ liệu yêu cầu:"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "Yêu cầu hình ảnh firmware"
 
@@ -205,7 +205,7 @@ msgstr "Yêu cầu ở vị trí hàng đợi xây dựng %s"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "Tìm kiếm bản nâng cấp firmware"
 
@@ -217,11 +217,11 @@ msgstr "Tìm kiếm sysupgrade mới khi mở tab"
 msgid "Search on opening"
 msgstr "Tìm kiếm khi mở"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "Đang tìm kiếm sysupgrade có sẵn của %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "Đang tìm kiếm..."
 
@@ -249,7 +249,7 @@ msgstr "Tạo hình ảnh firmware thành công"
 msgid "Target"
 msgstr "Mục tiêu"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
@@ -257,11 +257,11 @@ msgstr ""
 "Dịch vụ nâng cấp hệ thống attended cho phép nâng cấp dễ dàng các hình ảnh "
 "firmware gốc và tùy chỉnh."
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "Thiết bị chạy phiên bản firmware mới nhất %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr ""
@@ -288,7 +288,7 @@ msgstr "Phiên bản"
 msgid "Wrong checksum"
 msgstr "Checksum sai"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[đã cài đặt] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/zh_Hans/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/zh_Hans/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "高级模式"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "值守式系统更新"
@@ -32,7 +32,7 @@ msgstr "值守式系统更新"
 msgid "Attendedsysupgrade Configuration."
 msgstr "值守式系统更新配置。"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "主板名称/配置"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "构建固件中…"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "取消"
 
@@ -55,8 +55,8 @@ msgstr "客户端"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "关闭"
 
@@ -64,12 +64,12 @@ msgstr "关闭"
 msgid "Configuration"
 msgstr "配置"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "无法访问位于 “%s” 的 API，请稍后再试。"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "当前版本：%s - %s"
 
@@ -97,7 +97,7 @@ msgstr "下载中…"
 msgid "Error building the firmware image"
 msgstr "构建固件镜像时出错"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "连接至升级服务器时出错"
 
@@ -137,11 +137,11 @@ msgstr "安装中…"
 msgid "Keep settings and retain the current configuration"
 msgstr "保留当前配置"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "有新固件版本可供更新"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "无升级可用"
 
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "软件包"
 
@@ -192,7 +192,7 @@ msgstr "收到构建请求"
 msgid "Request Data:"
 msgstr "请求数据："
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "请求固件镜像"
 
@@ -204,7 +204,7 @@ msgstr "构建队列位置 %s 中的请求"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "搜索固件更新"
 
@@ -216,11 +216,11 @@ msgstr "打开此标签页时搜索新的系统更新"
 msgid "Search on opening"
 msgstr "打开时进行搜索"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "正在搜索 %s - %s 的可用系统更新"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "搜索中…"
 
@@ -248,17 +248,17 @@ msgstr "已成功创建固件镜像"
 msgid "Target"
 msgstr "目标"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr "值守式系统升级服务可让您轻松升级原版和自定义固件镜像。"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "此设备正运行最新的固件版本 %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr "这是通过按需构建新固件的在线服务来实现的。"
@@ -283,7 +283,7 @@ msgstr "版本"
 msgid "Wrong checksum"
 msgstr "错误的校验和"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[已安装] %s"
 

--- a/applications/luci-app-attendedsysupgrade/po/zh_Hant/attendedsysupgrade.po
+++ b/applications/luci-app-attendedsysupgrade/po/zh_Hant/attendedsysupgrade.po
@@ -23,7 +23,7 @@ msgid "Advanced Mode"
 msgstr "進階模式"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js:11
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:603
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:602
 #: applications/luci-app-attendedsysupgrade/root/usr/share/luci/menu.d/luci-app-attendedsysupgrade.json:3
 msgid "Attended Sysupgrade"
 msgstr "參與式系統升級"
@@ -32,7 +32,7 @@ msgstr "參與式系統升級"
 msgid "Attendedsysupgrade Configuration."
 msgstr "Attendedsysupgrade 設定。"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:511
 msgid "Board Name / Profile"
 msgstr "主機板名稱/設定檔"
 
@@ -45,7 +45,7 @@ msgid "Building Firmware..."
 msgstr "組建韌體中…"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:156
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:527
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:526
 msgid "Cancel"
 msgstr "取消"
 
@@ -55,8 +55,8 @@ msgstr "用戶端"
 
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:237
 #: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:374
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:430
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:564
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:429
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:563
 msgid "Close"
 msgstr "關閉"
 
@@ -64,12 +64,12 @@ msgstr "關閉"
 msgid "Configuration"
 msgstr "組態"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:424
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:423
 msgid "Could not reach API at \"%s\". Please try again later."
 msgstr "無法存取位於 「%s」 的 API。請稍後再試。"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:520
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:618
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:519
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:617
 msgid "Currently running: %s - %s"
 msgstr "目前執行中：%s - %s"
 
@@ -97,7 +97,7 @@ msgstr "下載中…"
 msgid "Error building the firmware image"
 msgstr "產生韌體映像檔時發生錯誤"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:420
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:419
 msgid "Error connecting to upgrade server"
 msgstr "連接升級伺服器發生錯誤"
 
@@ -137,11 +137,11 @@ msgstr "安裝中…"
 msgid "Keep settings and retain the current configuration"
 msgstr "保留目前設定"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:517
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:516
 msgid "New firmware upgrade available"
 msgstr "有韌體升級可用"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:555
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:554
 msgid "No upgrade available"
 msgstr "無升級可用"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:513
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:512
 msgid "Packages"
 msgstr "套件"
 
@@ -193,7 +193,7 @@ msgstr "已接收建構要求"
 msgid "Request Data:"
 msgstr "請求資料："
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:549
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:548
 msgid "Request firmware image"
 msgstr "請求韌體映像檔"
 
@@ -205,7 +205,7 @@ msgstr "建置佇列位置 %s 中的請求"
 msgid "SHA256"
 msgstr "SHA256"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:629
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:628
 msgid "Search for firmware upgrade"
 msgstr "搜尋韌體升級"
 
@@ -217,11 +217,11 @@ msgstr "開啟標籤頁時搜尋新的系統升級"
 msgid "Search on opening"
 msgstr "開啟時進行搜尋"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:411
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:410
 msgid "Searching for an available sysupgrade of %s - %s"
 msgstr "正在搜尋 %s - %s 的可用系統升級"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:407
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:406
 msgid "Searching..."
 msgstr "搜尋中…"
 
@@ -249,17 +249,17 @@ msgstr "成功建立韌體映像檔"
 msgid "Target"
 msgstr "目標"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:607
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:606
 msgid ""
 "The attended sysupgrade service allows to easily upgrade vanilla and custom "
 "firmware images."
 msgstr "attended 系統升級服務允許輕鬆升級原始和第三方韌體映像。"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:558
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:557
 msgid "The device runs the latest firmware version %s - %s"
 msgstr "此裝置執行最新的韌體版本 %s - %s"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:613
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:612
 msgid ""
 "This is done by building a new firmware on demand via an online service."
 msgstr "這是透過線上服務依需求建置新的韌體來實現的。"
@@ -284,7 +284,7 @@ msgstr "版本"
 msgid "Wrong checksum"
 msgstr "錯誤的總和檢查碼"
 
-#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:497
+#: applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js:496
 msgid "[installed] %s"
 msgstr "[已安裝] %s"
 


### PR DESCRIPTION
The unversioned endpoint /api/overview has been removed from ASU which breaks the request when searching for an available sysupgrade if the device is on a stable release. In the case where the unversioned endpoint is added back to prevent this regression in 23.05.3 and earlier (so upgrade is once again possible) we should anyway rely on the versioned endpoints as those replace the unversioned ones.

Ref: https://github.com/openwrt/asu/issues/896. See http://sysupgrade.openwrt.org/docs for the current API.

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (architecture, openwrt version, browser) :white_check_mark:
    * x86/64, 23.05.3, Firefox -> upgraded to 23.05.4 successfully
    * x86/64, SNAPSHOT r26870-4a2f712f85, Firefox -> upgraded to SNAPSHOT r26971-66177c081f successfully
- [X] \( Preferred ) Mention: @ the original code author for feedback @aparcar 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
