### PR TITLE
luci-proto-modemmanger: fix auth handling

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -76,11 +76,13 @@ return network.registerProtocol('modemmanager', {
 		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
 		o.datatype = 'and(uinteger,minlength(4),maxlength(8))';
 
-		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));
-		o.value('both', _('PAP/CHAP (both)'));
+		o = s.taboption('general', form.DynamicList, 'allowedauth', _('Authentication Type'));
 		o.value('pap', 'PAP');
 		o.value('chap', 'CHAP');
-		o.value('none', _('None'));
+		o.value('mschap', 'MSCHAP');
+		o.value('mschapv2', 'MSCHAPv2');
+		o.value('eap', 'EAP');
+		o.value('', _('None'));
 		o.default = 'none';
 
 		o = s.taboption('general', form.ListValue, 'allowedmode', _('Allowed network technology'),


### PR DESCRIPTION
This has never worked because the option 'auth' is not known to the modemmanger proto handler. The correct uci name is 'allowedauth' and is also a uci list option, so that several options can be selected.

See https://openwrt.org/docs/guide-user/network/wan/wwan/modemmanager#use

- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Description: (describe the changes proposed in this PR)
