### PR TITLE
luci-app-tinyproxy: change the `Bind` type to list

### DIFF
--- a/applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua
+++ b/applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua
@@ -44,8 +44,8 @@ o.datatype = "ipaddr"
 o.placeholder = "0.0.0.0"
 
 
-o = s:taboption("general", Value, "Bind", translate("Bind address"),
-	translate("Specifies the address Tinyproxy binds to for outbound forwarded requests"))
+o = s:taboption("general", DynamicList, "Bind", translate("Bind address"),
+	translate("Specifies the addresses Tinyproxy binds to for outbound forwarded requests"))
 
 o.optional = true
 o.datatype = "ipaddr"


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile *(package does not have one?)*
- [x] Tested on: (x86, 64, openwrt-23.05.4, Firefox 124) :white_check_mark:
- [x] Mention: @sbyx, @jow-
- [x] Screenshot or mp4 of changes: ![image](https://github.com/user-attachments/assets/5e401118-9dff-47bb-96eb-3974a8753950)
- [x] Depends on: openwrt/packages#24713
- [x] Description: tinyproxy supports several `Bind` options, that can be used to create a proxy that (1) supports both IPv4 and IPv6 and (2) uses specific addresses (in my case VPN addresses. It is very important to bind to specific addresses to avoid traffic leaks).
