### PR TITLE
[23.05] luci-app-natmap: change bind port data type from port to portrange

### DIFF
--- a/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
+++ b/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
@@ -91,7 +91,7 @@ return view.extend({
 		o.rmempty = false;
 
 		o = s.option(form.Value, 'port', _('Bind port'));
-		o.datatype = 'port';
+		o.datatype = 'portrange';
 		o.rmempty = false;
 
 		o = s.option(form.Flag, '_forward_mode', _('Forward mode'));


### PR DESCRIPTION
This commit changes the data type of bind port from `port` to `portrange`, supporting [sequential allocation of ports](https://github.com/heiher/natmap/blob/master/README.md?plain=1#L54-L57).

cc @ysc3839 