### PR TITLE
luci-proto-xfrm: update description for now-optional tunlink parameter

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -7007,6 +7007,10 @@ msgstr ""
 "خياري. مفتاح مشفر باستخدام Base64. يضيف طبقة إضافية من تشفير المفتاح "
 "المتماثل لمقاومة ما بعد الكم."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "خياري. إنشاء مسارات لعناوين IP المسموح بها لهذا النظير."
@@ -8274,10 +8278,6 @@ msgstr "مطلوب. المسار إلى ملف تكوين .yml لهذه الوا
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "مطلوب. المفتاح العام لنظير WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "مطلوب. الواجهة الأساسية."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10793,6 +10793,10 @@ msgstr "غير قادر على التحقق من رمز التحقق"
 msgid "Unconfigure"
 msgstr "إلغاء التكوين"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "الواجهة الأساسية"
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12342,6 +12346,9 @@ msgstr "{example_nx} يعيد {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "إرجع >>"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "مطلوب. الواجهة الأساسية."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP / CHAP (كلاهما)"

--- a/modules/luci-base/po/ast/base.po
+++ b/modules/luci-base/po/ast/base.po
@@ -6707,6 +6707,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7937,10 +7941,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10260,6 +10260,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -6776,6 +6776,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8011,10 +8015,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10341,6 +10341,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -6714,6 +6714,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7947,10 +7951,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10271,6 +10271,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -6839,6 +6839,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8073,10 +8077,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10432,6 +10432,10 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
 msgstr "Desconfigura"
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -6890,6 +6890,10 @@ msgstr ""
 "Volitelné. Předsdílený klíč v kódování Base64. Přidává další vrstvu "
 "symetrické kryptografie pro post-kvantovou odolnost."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 #, fuzzy
 msgid "Optional. Create routes for Allowed IPs for this peer."
@@ -8142,10 +8146,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10554,6 +10554,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -7019,6 +7019,10 @@ msgstr ""
 "Valgfrit. Base64-kodet preshared nøgle. Tilføjer et ekstra lag af symmetrisk "
 "nøgle-kryptografi til post-kvantum-modstandsdygtighed."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Valgfrit. Opret ruter til tilladte IP'er for denne peer."
@@ -8292,10 +8296,6 @@ msgstr "Påkrævet. Sti til .yml-konfigurationsfilen for dette interface."
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Påkrævet. Offentlig nøgle til WireGuard-peeren."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Påkrævet. Underliggende interface."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10879,6 +10879,10 @@ msgstr "PIN-koden kunne ikke bekræftes"
 msgid "Unconfigure"
 msgstr "Afkonfigurer"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Underliggende interface."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12437,6 +12441,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Tilbage"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Påkrævet. Underliggende interface."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (begge)"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -7176,6 +7176,10 @@ msgstr ""
 "Optional. Base64-kodierter, vorhab ausgetauschter Schlüssel um eine weitere "
 "Ebene an symmetrischer Verschlüsselung für erhöhte Sicherheit hinzuzufügen."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Optional. Routen für erlaubte IP-Adressen erzeugen."
@@ -8477,10 +8481,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Benötigt. Öffentlicher Schlüssel des WireGuard Verbindungspartners."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Benötigt. Zugrundeliegende Schnittstelle."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11131,6 +11131,10 @@ msgstr "PIN kann nicht verifiziert werden"
 msgid "Unconfigure"
 msgstr "Dekonfigurieren"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Zugrundeliegende Schnittstelle."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12703,6 +12707,9 @@ msgstr "{example_nx} gibt {nxdomain} zurück."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zurück"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Benötigt. Zugrundeliegende Schnittstelle."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (beide)"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -6818,6 +6818,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8053,10 +8057,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10400,6 +10400,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -6719,6 +6719,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7951,10 +7955,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10275,6 +10275,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -7188,6 +7188,10 @@ msgstr ""
 "adicional de criptografía de clave simétrica para la resistencia post-"
 "cuántica."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opcional. Crear rutas para IPs permitidas para este par."
@@ -8495,10 +8499,6 @@ msgstr "Requerido. Ruta al archivo de configuración .yml para esta interfaz."
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Requerido. Clave pública del par de WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Requerido. Interfaz subyacente."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11153,6 +11153,10 @@ msgstr "No se puede verificar el PIN"
 msgid "Unconfigure"
 msgstr "Desconfigurar"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Interfaz subyacente."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 #, fuzzy
 msgid "Unet"
@@ -12739,6 +12743,9 @@ msgstr "{example_nx} devuelve {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Requerido. Interfaz subyacente."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (ambos)"

--- a/modules/luci-base/po/fa/base.po
+++ b/modules/luci-base/po/fa/base.po
@@ -6713,6 +6713,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7943,10 +7947,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10267,6 +10267,10 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
 msgstr "ناپیکربندی"
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -6877,6 +6877,10 @@ msgstr ""
 "Valinnainen. Base64-koodattu esijaettu avain. Lisää ylimääräisen symmetrisen "
 "avaimen salauksen tason kvanttiresistenssiä varten."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Valinnainen. Luo reitit sallituille IP-reitit tälle vertaiskoneelle."
@@ -8128,10 +8132,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10586,6 +10586,10 @@ msgstr "PIN-koodia ei voi vahvistaa"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/fil/base.po
+++ b/modules/luci-base/po/fil/base.po
@@ -6722,6 +6722,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7952,10 +7956,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10275,6 +10275,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -7060,6 +7060,10 @@ msgstr ""
 "supplémentaire de cryptographie à clé symétrique pour la résistance post-"
 "quantique."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Facultatif. Créer des itinéraires pour les IP autorisés pour ce pair."
@@ -8343,10 +8347,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Obligatoire. Clé publique de l’homologue WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Obligatoire. Interface sous-jacente."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10962,6 +10962,10 @@ msgstr "Incapable de vérifier PIN"
 msgid "Unconfigure"
 msgstr "Annuler la configuration"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Interface sous-jacente."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12529,6 +12533,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Retour"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Obligatoire. Interface sous-jacente."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (les deux)"

--- a/modules/luci-base/po/ga/base.po
+++ b/modules/luci-base/po/ga/base.po
@@ -322,8 +322,8 @@ msgstr "<abbr title=\"Dé-óid Astaithe Solais\">LED</abbr> Ainm"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1018
 msgid "<abbr title=\"Neighbour Discovery Protocol\">NDP</abbr>-Proxy"
 msgstr ""
-"<abbr title=\"Prótacal Fionnachtana Comharsanachta\""
-">NDP</abbr>-Seachfhreastalaí"
+"<abbr title=\"Prótacal Fionnachtana Comharsanachta\">NDP</abbr>-"
+"Seachfhreastalaí"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:963
 msgid "<abbr title=\"Prefix Delegation\">PD</abbr> minimum length"
@@ -1083,8 +1083,8 @@ msgid ""
 "Announce NAT64 prefix in <abbr title=\"Router Advertisement\">RA</abbr> "
 "messages."
 msgstr ""
-"Fógairt réimír NAT64 i dteachtaireachtaí <abbr title=\"Router Advertisement\""
-">RA</abbr>."
+"Fógairt réimír NAT64 i dteachtaireachtaí <abbr title=\"Router "
+"Advertisement\">RA</abbr>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:977
 msgid "Announce this device as IPv6 DNS server."
@@ -1720,8 +1720,8 @@ msgid ""
 "Certificate constraint substring - e.g. /CN=wifi.mycompany.com<br />See "
 "`logread -f` during handshake for actual values"
 msgstr ""
-"Fotheaghrán sriantachta deimhnithe - e.g. /CN=wifi.mycompany.com<br />Féach `"
-"logread -f` le linn chroitheadh láimhe le haghaidh luachanna iarbhír"
+"Fotheaghrán sriantachta deimhnithe - e.g. /CN=wifi.mycompany.com<br />Féach "
+"`logread -f` le linn chroitheadh láimhe le haghaidh luachanna iarbhír"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1725
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1783
@@ -2105,8 +2105,8 @@ msgstr ""
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:382
 msgid "Consider the slave up when any ARP IP target is reachable (any, 0)"
 msgstr ""
-"Smaoinigh ar an sclábhaí suas nuair a bhíonn aon sprioc IP ARP inrochtana ("
-"aon, 0)"
+"Smaoinigh ar an sclábhaí suas nuair a bhíonn aon sprioc IP ARP inrochtana "
+"(aon, 0)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:18
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:370
@@ -2426,8 +2426,9 @@ msgid ""
 "\"<code>6,192.168.2.1,192.168.2.2</code>\" which advertises different DNS "
 "servers to clients."
 msgstr ""
-"Sainmhínigh roghanna breise DHCP, mar shampla \"<code>6,192.168.2.1,192.168.2"
-".2</code>\" a fhógraíonn freastalaithe DNS éagsúla do chliaint."
+"Sainmhínigh roghanna breise DHCP, mar shampla "
+"\"<code>6,192.168.2.1,192.168.2.2</code>\" a fhógraíonn freastalaithe DNS "
+"éagsúla do chliaint."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:516
 msgid ""
@@ -2778,9 +2779,9 @@ msgid ""
 "Protocol\">DHCP</abbr> server and <abbr title=\"Domain Name System\">DNS</"
 "abbr> forwarder."
 msgstr ""
-"Is freastalaí éadrom <abbr title=\"Prótacal Cumraíochta Óstáin Dinimiciúla\""
-">DHCP</abbr> agus seoltóir <abbr title=\"Córas Ainm Fearainn\">DNS</abbr> é "
-"Dnsmasq."
+"Is freastalaí éadrom <abbr title=\"Prótacal Cumraíochta Óstáin "
+"Dinimiciúla\">DHCP</abbr> agus seoltóir <abbr title=\"Córas Ainm "
+"Fearainn\">DNS</abbr> é Dnsmasq."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:672
 msgid "Do not cache negative replies, e.g. for non-existent domains."
@@ -2824,8 +2825,8 @@ msgid ""
 "Do not send any <abbr title=\"Router Advertisement, ICMPv6 Type 134\">RA</"
 "abbr> messages on this interface."
 msgstr ""
-"Ná seol aon teachtaireacht <abbr title=\"Fógrán Ródaire, ICMPv6 Cineál 134\""
-">RA</abbr> ar an gcomhéadan seo."
+"Ná seol aon teachtaireacht <abbr title=\"Fógrán Ródaire, ICMPv6 Cineál "
+"134\">RA</abbr> ar an gcomhéadan seo."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2829
 msgid "Do you really want to delete \"%s\" ?"
@@ -3128,7 +3129,8 @@ msgstr "Cumasaigh <abbr title=\"Prótacal Crann a Chuimsíonn\">STP</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:853
 msgid "Enable <abbr title=\"Stateless Address Auto Config\">SLAAC</abbr>"
-msgstr "Cumasaigh <abbr title=\"Uathchumraíocht Seoltaí Gan Stát\">SLAAC</abbr>"
+msgstr ""
+"Cumasaigh <abbr title=\"Uathchumraíocht Seoltaí Gan Stát\">SLAAC</abbr>"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:174
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:372
@@ -3475,8 +3477,8 @@ msgid ""
 "for <abbr title=\"Real-time Block List\">RBL</abbr> services."
 msgstr ""
 "Díolmhaithe {loopback_slash_8_v4} agus {localhost_v6} ó sheiceálacha "
-"athcheangail, m.sh. le haghaidh seirbhísí <abbr title=\"Blocliosta Fíor-ama\""
-">RBL</abbr>."
+"athcheangail, m.sh. le haghaidh seirbhísí <abbr title=\"Blocliosta Fíor-"
+"ama\">RBL</abbr>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:410
 msgid "Existing device"
@@ -3658,8 +3660,8 @@ msgid ""
 "File listing upstream resolvers, optionally domain-specific, e.g. "
 "{servers_file_entry01}, {servers_file_entry02}."
 msgstr ""
-"Comhad a liostaíonn réitigh suas srutha, roghnach go sonrach le fearann, "
-"m.sh. {servers_file_entry01}, {servers_file_entry02}."
+"Comhad a liostaíonn réitigh suas srutha, roghnach go sonrach le fearann, m."
+"sh. {servers_file_entry01}, {servers_file_entry02}."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
 msgid "File not accessible"
@@ -3969,8 +3971,8 @@ msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
 msgstr ""
-"Tuilleadh eolais faoi chomhéadain WireGuard agus piaraí ag <a "
-"href='http://wireguard.com'>wireguard.com</a>."
+"Tuilleadh eolais faoi chomhéadain WireGuard agus piaraí ag <a href='http://"
+"wireguard.com'>wireguard.com</a>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:184
@@ -4076,7 +4078,8 @@ msgstr "Cruthaigh eochair réamhroinnte"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:675
 msgid "Generates a configuration suitable for import on a WireGuard peer"
-msgstr "Gineann sé cumraíocht atá oiriúnach le hallmhairiú ar phiaraí WireGuard"
+msgstr ""
+"Gineann sé cumraíocht atá oiriúnach le hallmhairiú ar phiaraí WireGuard"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:809
 msgid "Generating QR code…"
@@ -4830,11 +4833,11 @@ msgid ""
 "datarates of the <abbr title=\"Random Access Memory\">RAM</abbr>."
 msgstr ""
 "Mura leor do chuimhne fhisiciúil, is féidir sonraí nár úsáideadh a mhalartú "
-"go sealadach go gléas babhtála a mbeidh méid níos mó de <abbr title=\"Cuimhne"
-" Rochtana Randamach\">RAM</abbr> inúsáidte mar thoradh air. Tabhair faoi "
-"deara gur próiseas an-mhall é sonraí a mhalartú mar ní féidir rochtain a "
-"fháil ar an ngléas babhtála leis na rátaí arda sonraí den <abbr title="
-"\"Cuimhne Rochtana Randamach\">RAM</abbr>."
+"go sealadach go gléas babhtála a mbeidh méid níos mó de <abbr "
+"title=\"Cuimhne Rochtana Randamach\">RAM</abbr> inúsáidte mar thoradh air. "
+"Tabhair faoi deara gur próiseas an-mhall é sonraí a mhalartú mar ní féidir "
+"rochtain a fháil ar an ngléas babhtála leis na rátaí arda sonraí den <abbr "
+"title=\"Cuimhne Rochtana Randamach\">RAM</abbr>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1057
 msgid "Ignore"
@@ -6845,8 +6848,8 @@ msgid ""
 "Note: this setting is for local services on the device only (not for "
 "forwarding)."
 msgstr ""
-"Nóta: tá an socrú seo le haghaidh seirbhísí áitiúla ar an bhfeiste amháin ("
-"ní le haghaidh seoladh)."
+"Nóta: tá an socrú seo le haghaidh seirbhísí áitiúla ar an bhfeiste amháin "
+"(ní le haghaidh seoladh)."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:516
 msgid ""
@@ -6957,7 +6960,8 @@ msgstr "Níl aon luach ag réimse riachtanacha amháin nó níos mó!"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:818
 msgid "Only DHCP Clients with this tag are sent this boot option."
-msgstr "Ní sheoltar ach Cliaint DHCP leis an gcliant seo an rogha tosaithe seo."
+msgstr ""
+"Ní sheoltar ach Cliaint DHCP leis an gcliant seo an rogha tosaithe seo."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:577
 msgid "Only accept replies via"
@@ -7001,8 +7005,8 @@ msgid ""
 "Protocol\">NDP</abbr> proxying."
 msgstr ""
 "Oibriú i <em>mód sealaíochta</em> má tá máistir-chomhéadan sainithe "
-"cumraithe agus gníomhach, nó díchumasaigh seachfhreastalaí <abbr title="
-"\"Prótacal Fionnachtana Comharsanachta\">NDP</abbr>."
+"cumraithe agus gníomhach, nó díchumasaigh seachfhreastalaí <abbr "
+"title=\"Prótacal Fionnachtana Comharsanachta\">NDP</abbr>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:768
 msgid ""
@@ -7113,6 +7117,10 @@ msgid ""
 msgstr ""
 "Roghnach. Eochair réamhchomhroinnte Base64. Cuireann sé ciseal breise de "
 "chripteagrafaíocht eochair siméadrach le haghaidh friotaíocht iar-chúantach."
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
@@ -8398,10 +8406,6 @@ msgstr "Riachtanach. Conair chuig an gcomhad cumraithe.yml don chomhéadan seo."
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Riachtanach. Eochair phoiblí an phiaraí WireGuard."
 
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Riachtanach. Comhéadan bunúsach."
-
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
 msgstr "Riachtanach. ID comhéadan XFRM le húsáid le haghaidh SA."
@@ -9298,8 +9302,8 @@ msgid ""
 "Specifies the logical interface name of the parent (or master) interface "
 "this route belongs to"
 msgstr ""
-"Sonraíonn ainm comhéadain loighciúil an chomhéadain tuismitheora (nó máistir)"
-" leis an mbealach seo"
+"Sonraíonn ainm comhéadain loighciúil an chomhéadain tuismitheora (nó "
+"máistir) leis an mbealach seo"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:259
 msgid ""
@@ -9562,8 +9566,8 @@ msgid ""
 "inherits the value of the inner header) or an hexadecimal value <code>00.."
 "FF</code> (optional)."
 msgstr ""
-"Sonraigh Aicme Tráchta. Is féidir é a bheith ina <code>oidhreacht</code> ("
-"gheibheann an ceanntásc seachtrach luach an cheanntáisc istigh le "
+"Sonraigh Aicme Tráchta. Is féidir é a bheith ina <code>oidhreacht</code> "
+"(gheibheann an ceanntásc seachtrach luach an cheanntáisc istigh le "
 "hoidhreacht) nó luach heicsidheachúil <code>00..FF</code> (roghnach)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:64
@@ -10033,16 +10037,16 @@ msgid ""
 "The IPv6 interface identifier (address suffix) as hexadecimal number (max. "
 "16 chars)."
 msgstr ""
-"An aitheantóir comhéadain IPv6 (iarmhír seoladh) mar uimhir heicseachadach ("
-"uasmhéid. 16 chars)."
+"An aitheantóir comhéadain IPv6 (iarmhír seoladh) mar uimhir heicseachadach "
+"(uasmhéid. 16 chars)."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:53
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:59
 msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
-"De ghnáth críochnaíonn an réimír IPv6 a shanntar don soláthraí le "
-"<code>::</code>"
+"De ghnáth críochnaíonn an réimír IPv6 a shanntar don soláthraí le <code>::</"
+"code>"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js:7
 msgid "The LED blinks with the configured on/off frequency"
@@ -10077,7 +10081,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:640
 msgid "The MTU must not exceed the parent device MTU of %d bytes"
-msgstr "Ní chóir go mbeadh an MTU níos mó ná an MTU tuismitheoireachta %d bytes"
+msgstr ""
+"Ní chóir go mbeadh an MTU níos mó ná an MTU tuismitheoireachta %d bytes"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:950
 msgid "The VLAN ID must be unique"
@@ -10146,8 +10151,8 @@ msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
 msgstr ""
-"Comhad gléis na cuimhne nó na críochdheighilte (<abbr title=\"mar shampla\">m"
-".sh.</abbr> <code>/dev/sda1</code>)"
+"Comhad gléis na cuimhne nó na críochdheighilte (<abbr title=\"mar "
+"shampla\">m.sh.</abbr> <code>/dev/sda1</code>)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:504
 msgid "The device name \"%s\" is already taken"
@@ -10226,8 +10231,8 @@ msgid ""
 msgstr ""
 "Ligeann an socrú pionós hop rogha batman-adv a mhodhnú maidir le bealaí "
 "multihop vs bealaí gearra. Cuirtear an luach i bhfeidhm ar TQ gach OGM a "
-"chuirtear ar aghaidh, agus ar an gcaoi sin iomadaítear costas hop breise ("
-"caithfear an pacáiste a fháil agus a aththarchur a chosnaíonn am aeir)"
+"chuirtear ar aghaidh, agus ar an gcaoi sin iomadaítear costas hop breise "
+"(caithfear an pacáiste a fháil agus a aththarchur a chosnaíonn am aeir)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:799
 msgid "The hostname of the boot server"
@@ -10337,11 +10342,11 @@ msgid ""
 msgstr ""
 "Is féidir na poirt líonra ar an ngléas seo a chomhcheangal le roinnt <abbr "
 "title=\"Líonra Logánta Fíorúil\">VLAN</abbr>anna inar féidir le ríomhairí "
-"cumarsáid dhíreach a dhéanamh lena chéile. Is minic a úsáidtear <abbr title="
-"\"Líonra Logánta Fíorúil\">VLAN</abbr>s chun deighleoga éagsúla den líonra a "
-"scaradh. Go minic tá calafort Uplink amháin ann de réir réamhshocraithe le "
-"haghaidh nasc leis an gcéad líonra eile níos mó ar nós an t-idirlíon agus "
-"calafoirt eile do líonra áitiúil."
+"cumarsáid dhíreach a dhéanamh lena chéile. Is minic a úsáidtear <abbr "
+"title=\"Líonra Logánta Fíorúil\">VLAN</abbr>s chun deighleoga éagsúla den "
+"líonra a scaradh. Go minic tá calafort Uplink amháin ann de réir "
+"réamhshocraithe le haghaidh nasc leis an gcéad líonra eile níos mó ar nós an "
+"t-idirlíon agus calafoirt eile do líonra áitiúil."
 
 #: protocols/luci-proto-yggdrasil/htdocs/luci-static/resources/protocol/yggdrasil.js:230
 msgid "The private key for your Yggdrasil node"
@@ -10738,9 +10743,9 @@ msgid ""
 "import\" href=\"#\">configuration import</a></strong> instead."
 msgstr ""
 "Chun an comhéadan áitiúil WireGuard a chumrú go hiomlán ó chomhad "
-"cumraíochta reatha (m.sh. soláthraíodh an soláthraí), úsáid <strong><a class"
-"=\"full-import\" href=\"#\">iompórtáil cumraíochta</a></strong> ina ionad "
-"sin."
+"cumraíochta reatha (m.sh. soláthraíodh an soláthraí), úsáid <strong><a "
+"class=\"full-import\" href=\"#\">iompórtáil cumraíochta</a></strong> ina "
+"ionad sin."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:402
 msgid ""
@@ -11014,6 +11019,10 @@ msgstr "Ní féidir PIN a fhíorú"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
 msgstr "Díchumraigh"
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
@@ -11587,8 +11596,8 @@ msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
 msgstr ""
-"Éilíonn criptiú WPA go ndéanfar wpa_supplicant (do mhodh cliant) nó hostapd ("
-"le haghaidh modh AP agus ad-hoc) a shuiteáil."
+"Éilíonn criptiú WPA go ndéanfar wpa_supplicant (do mhodh cliant) nó hostapd "
+"(le haghaidh modh AP agus ad-hoc) a shuiteáil."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:153
 msgid "WPS status"
@@ -12587,3 +12596,6 @@ msgstr "Tugann {example_nx} ar ais {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "“Ar ais"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Riachtanach. Comhéadan bunúsach."

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -6737,6 +6737,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7968,10 +7972,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10298,6 +10298,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -6715,6 +6715,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7945,10 +7949,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10268,6 +10268,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -269,8 +269,9 @@ msgid ""
 "802.11v: Wireless Network Management (WNM) Sleep Mode (extended sleep mode "
 "for stations)."
 msgstr ""
-"<abbr title=\"Vezeték nélküli hálózat kezelő (Wireless Network Management)\""
-">WNM</abbr> alvó üzemmód (meghosszabbított alvó üzemmód adóállomásokhoz)."
+"<abbr title=\"Vezeték nélküli hálózat kezelő (Wireless Network "
+"Management)\">WNM</abbr> alvó üzemmód (meghosszabbított alvó üzemmód "
+"adóállomásokhoz)."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1681
 msgid ""
@@ -532,8 +533,8 @@ msgstr ""
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:358
 msgid "ARP"
 msgstr ""
-"<abbr title=\"Címfeloldási protokoll (Address Resolution Protocol)\""
-">ARP</abbr>"
+"<abbr title=\"Címfeloldási protokoll (Address Resolution Protocol)\">ARP</"
+"abbr>"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:371
 msgid "ARP IP Targets"
@@ -573,11 +574,11 @@ msgstr ""
 "abbr>, <abbr title=\"Internet protokoll 4-es verziója\">IPv4</abbr> és <abbr "
 "title=\"Internet protokoll 6-os verziója\">IPv6</abbr> (még a 802.1Q is) "
 "<abbr title=\"Közeghozzáférés-vezérlő (Media Access Control)\">MAC</abbr>-"
-"címes csoport-küldött csomagok továbbítása egyedi-küldéssel az <abbr title="
-"\"Adóállomás (STAtion)\">STA</abbr> MAC-címére.<br />Megjegyzés: ez nem a 802"
-".11v-ben leírt <abbr title=\"Irányított csoport-küldési szolgáltatás ("
-"Directed Multicast Service)\">DMS</abbr>, valamint a vevő állomás "
-"megszegheti a csoport-küldési elvárást."
+"címes csoport-küldött csomagok továbbítása egyedi-küldéssel az <abbr "
+"title=\"Adóállomás (STAtion)\">STA</abbr> MAC-címére.<br />Megjegyzés: ez "
+"nem a 802.11v-ben leírt <abbr title=\"Irányított csoport-küldési "
+"szolgáltatás (Directed Multicast Service)\">DMS</abbr>, valamint a vevő "
+"állomás megszegheti a csoport-küldési elvárást."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1654
 msgid "ATM (Asynchronous Transfer Mode)"
@@ -603,14 +604,14 @@ msgid ""
 "Linux network interfaces which can be used in conjunction with DHCP or PPP "
 "to dial into the provider network."
 msgstr ""
-"Az <abbr title=\"Aszinkron (azaz időosztásos multiplex) átviteli mód ("
-"Asynchronous Transfer Mode)\">ATM</abbr> hidak az <abbr title=\"ATM "
+"Az <abbr title=\"Aszinkron (azaz időosztásos multiplex) átviteli mód "
+"(Asynchronous Transfer Mode)\">ATM</abbr> hidak az <abbr title=\"ATM "
 "adaptációs réteg, 5-ös típus (ATM Adaptation Layer 5)\">AAL5</abbr> "
 "kapcsolatokba ágyazott ethernetet mutatják virtuális Linux hálózati "
-"csatolókként, amely <abbr title=\"Dinamikus állomáskonfiguráló protokoll ("
-"Dynamic Host Configuration Protocol)\">DHCP</abbr>-vel vagy <abbr title"
-"=\"Pont-pont protokoll (Point-to-Point Protocol)\">PPP</abbr>-vel együtt "
-"használható a szolgáltatói hálózatba történő betárcsázáshoz."
+"csatolókként, amely <abbr title=\"Dinamikus állomáskonfiguráló protokoll "
+"(Dynamic Host Configuration Protocol)\">DHCP</abbr>-vel vagy <abbr "
+"title=\"Pont-pont protokoll (Point-to-Point Protocol)\">PPP</abbr>-vel "
+"együtt használható a szolgáltatói hálózatba történő betárcsázáshoz."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1714
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js:62
@@ -867,7 +868,8 @@ msgstr "Cím"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:571
 msgid "Address families of \"Relay from\" and \"Relay to address\" must match."
-msgstr "Az „Átjátszás innen” és „Átjátszás címre” címcsaládoknak egyeznie kell."
+msgstr ""
+"Az „Átjátszás innen” és „Átjátszás címre” címcsaládoknak egyeznie kell."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:21
 msgctxt "nft meta nfproto"
@@ -967,7 +969,8 @@ msgstr "Összes kiszolgáló"
 msgid ""
 "Allocate IP addresses sequentially, starting from the lowest available "
 "address."
-msgstr "IP-címek kiosztása sorrendben, kezdve a legalacsonyabb elérhető címtől."
+msgstr ""
+"IP-címek kiosztása sorrendben, kezdve a legalacsonyabb elérhető címtől."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:624
 msgid "Allocate IPs sequentially"
@@ -1081,8 +1084,8 @@ msgid ""
 "option does not comply with IEEE 802.11n-2009!"
 msgstr ""
 "Mindig a 40 MHz-es csatornákat használja, akkor is ha a másodlagos csatorna "
-"átfedi. <br />Ennek a lehetőségnek a használata nem felel meg az IEEE 802."
-"11n-2009 előírásainak!"
+"átfedi. <br />Ennek a lehetőségnek a használata nem felel meg az IEEE "
+"802.11n-2009 előírásainak!"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:740
 msgid "Amount of Duplicate Address Detection probes to send"
@@ -1445,14 +1448,14 @@ msgid ""
 "the other end. Per default fragmentation is enabled and inactive if the "
 "packet fits but it is possible to deactivate the fragmentation entirely."
 msgstr ""
-"A <abbr title=\\\"BATMAN-fejlett - „Mobil eseti hálózatok jobb megközelítése”"
-" átvitel megvalósítása kernel modulban (Better Approach to Mobile Ad-hoc "
-"Networking)-advanced\\\">BATMAN-adv</abbr> beépített 2. rétegű tördeléssel "
-"rendelkezik a hálózaton keresztül áramló egyedi-küldésű adatok számára, "
-"amely lehetővé teszi a batman-adv futtatását olyan csatolókon, amik nem "
-"teszik lehetővé a szabványos 1500 bájtos Ethernet-csomagméretnél nagyobb "
-"<abbr title=\\\"Legnagyobb átviteli egység (Maximum Transmission Unit)\\\""
-">MTU</abbr>-t. Ha a tördezés engedélyezve van, a batman-adv automatikusan "
+"A <abbr title=\\\"BATMAN-fejlett - „Mobil eseti hálózatok jobb "
+"megközelítése” átvitel megvalósítása kernel modulban (Better Approach to "
+"Mobile Ad-hoc Networking)-advanced\\\">BATMAN-adv</abbr> beépített 2. rétegű "
+"tördeléssel rendelkezik a hálózaton keresztül áramló egyedi-küldésű adatok "
+"számára, amely lehetővé teszi a batman-adv futtatását olyan csatolókon, amik "
+"nem teszik lehetővé a szabványos 1500 bájtos Ethernet-csomagméretnél nagyobb "
+"<abbr title=\\\"Legnagyobb átviteli egység (Maximum Transmission Unit)\\"
+"\">MTU</abbr>-t. Ha a tördezés engedélyezve van, a batman-adv automatikusan "
 "feldarabolja a túlméretezett csomagokat, és a másik végén "
 "töredezettségmentesíti azokat. <br />Alapértelmezés szerint a tördelés "
 "engedélyezett és tétlen ha a csomag illeszkedik, de lehetséges a tördelés "
@@ -1763,9 +1766,10 @@ msgid ""
 "Certificate constraint(s) against DNS SAN values (if available)<br />or "
 "Subject CN (exact match)"
 msgstr ""
-"Tanúsítványkényszer <abbr title=\"Tartománynév rendszer (Domain Name System)"
-"\">DNS</abbr> <abbr title=\"Tárgy alternatív neve (Subject Alternative Name)"
-"\">SAN</abbr> (ha elérhető) vagy tárgy CN értékkel (pontos egyezés)."
+"Tanúsítványkényszer <abbr title=\"Tartománynév rendszer (Domain Name "
+"System)\">DNS</abbr> <abbr title=\"Tárgy alternatív neve (Subject "
+"Alternative Name)\">SAN</abbr> (ha elérhető) vagy tárgy CN értékkel (pontos "
+"egyezés)."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1728
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1786
@@ -1773,9 +1777,10 @@ msgid ""
 "Certificate constraint(s) against DNS SAN values (if available)<br />or "
 "Subject CN (suffix match)"
 msgstr ""
-"Tanúsítványkényszer <abbr title=\"Tartománynév rendszer (Domain Name System)"
-"\">DNS</abbr> <abbr title=\"Tárgy alternatív neve (Subject Alternative Name)"
-"\">SAN</abbr> (ha elérhető) vagy tárgy CN értékkel (utótag egyezés)."
+"Tanúsítványkényszer <abbr title=\"Tartománynév rendszer (Domain Name "
+"System)\">DNS</abbr> <abbr title=\"Tárgy alternatív neve (Subject "
+"Alternative Name)\">SAN</abbr> (ha elérhető) vagy tárgy CN értékkel (utótag "
+"egyezés)."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1722
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1780
@@ -1980,8 +1985,8 @@ msgid ""
 msgstr ""
 "Bonyolulttá teszi a kulcs újratelepítési támadásokat ügyféloldalon a kulcsok "
 "telepítéséhez használt <abbr title=\"Bővíthető hitelesítési protokoll a "
-"helyi hálózaton keresztül (Extensible Authentication Protocol Over LAN)\""
-">EAPOL</abbr>-kulcskeretek újraküldésének letiltásával. Ez a megoldás "
+"helyi hálózaton keresztül (Extensible Authentication Protocol Over "
+"LAN)\">EAPOL</abbr>-kulcskeretek újraküldésének letiltásával. Ez a megoldás "
 "átjárhatósági problémákat és a kulcsegyeztetés robusztusságának csökkenését "
 "okozhatja, különösen nagy forgalmú környezetekben."
 
@@ -2027,8 +2032,8 @@ msgid ""
 "offered."
 msgstr ""
 "Az adatátviteli alapsebességet állítja a lefedett cellasűrűség alapján:<br /"
-"> „Normál” - 6, 12, 24 Mb/s, örökölt 802.11b esetén 5,5 és 11 Mb/s.<br "
-"/>„Magas” - 12, 24 Mb/s, örökölt 802.11b esetén 11 Mb/s.<br />„Nagyon magas” "
+"> „Normál” - 6, 12, 24 Mb/s, örökölt 802.11b esetén 5,5 és 11 Mb/s.<br /"
+">„Magas” - 12, 24 Mb/s, örökölt 802.11b esetén 11 Mb/s.<br />„Nagyon magas” "
 "- 24 Mb/s.<br />A támogatott értékeknél alacsonyabb minimális alapsebesség "
 "beállítása nem ajánlott."
 
@@ -2134,8 +2139,8 @@ msgstr ""
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:382
 msgid "Consider the slave up when any ARP IP target is reachable (any, 0)"
 msgstr ""
-"Fontolja meg a segéd funkciót, amikor bármelyik ARP cél-IP elérhető ("
-"bármelyik, 0)"
+"Fontolja meg a segéd funkciót, amikor bármelyik ARP cél-IP elérhető "
+"(bármelyik, 0)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:18
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:370
@@ -2250,8 +2255,8 @@ msgid ""
 "Customizes the behaviour of the device <abbr title=\"Light Emitting "
 "Diode\">LED</abbr>s if possible."
 msgstr ""
-"Az eszközbe épített <abbr title=\"Fénykibocsátó dióda (Light Emitting Diode)"
-"\">LED</abbr>-ek működésének testreszabása."
+"Az eszközbe épített <abbr title=\"Fénykibocsátó dióda (Light Emitting "
+"Diode)\">LED</abbr>-ek működésének testreszabása."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:740
 msgid "DAD transmits"
@@ -2458,9 +2463,9 @@ msgid ""
 msgstr ""
 "További <abbr title=\"Dinamikus állomáskonfiguráló protokoll (Dynamic Host "
 "Configuration Protocol)\">DHCP</abbr> lehetőségek meghatározása, például: "
-"<code>6,192.168.2.1,192.168.2.2</code>, ami különböző <abbr title="
-"\"Tartománynév rendszer (Domain Name System)\">DNS</abbr>-kiszolgálókat "
-"hirdet az ügyfelek részére."
+"<code>6,192.168.2.1,192.168.2.2</code>, ami különböző <abbr "
+"title=\"Tartománynév rendszer (Domain Name System)\">DNS</abbr>-"
+"kiszolgálókat hirdet az ügyfelek részére."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:516
 msgid ""
@@ -2741,7 +2746,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:466
 msgid "Discard upstream responses containing {rfc_1918_link} addresses."
-msgstr "Az {rfc_1918_link} címet tartalmazó külső (upstream) válaszok elvetése."
+msgstr ""
+"Az {rfc_1918_link} címet tartalmazó külső (upstream) válaszok elvetése."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:716
@@ -2845,8 +2851,8 @@ msgid ""
 "Do not proxy any <abbr title=\"Neighbour Discovery Protocol\">NDP</abbr> "
 "packets."
 msgstr ""
-"Ne használjon proxy-t az <abbr title=\"Szomszéd felderítő protokoll ("
-"Neighbor Discovery Protocol)\">NDP</abbr> csomagokhoz."
+"Ne használjon proxy-t az <abbr title=\"Szomszéd felderítő protokoll "
+"(Neighbor Discovery Protocol)\">NDP</abbr> csomagokhoz."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:32
 msgid "Do not send a Release when restarting"
@@ -2862,8 +2868,8 @@ msgid ""
 "abbr> messages on this interface."
 msgstr ""
 "Ne küldjön <abbr title=\"Útválasztó hirdetése (Router Advertisement)\">RA</"
-"abbr> (<abbr title=\"Internet felügyeleti-üzenet protokoll 6-os verziója ("
-"Internet Control Message Protocol version 6)\">ICMPv6</abbr> 134-es típus) "
+"abbr> (<abbr title=\"Internet felügyeleti-üzenet protokoll 6-os verziója "
+"(Internet Control Message Protocol version 6)\">ICMPv6</abbr> 134-es típus) "
 "üzenetet ezen a csatolón."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2829
@@ -3015,9 +3021,9 @@ msgid ""
 "Dropbear offers <abbr title=\"Secure Shell\">SSH</abbr> network shell access "
 "and an integrated <abbr title=\"Secure Copy\">SCP</abbr> server"
 msgstr ""
-"A Dropbear hálózati <abbr title=\"Biztonságos rendszerhéj (Secure Shell)\""
-">SSH</abbr> parancsértelmező hozzáférést és integrált <abbr title="
-"\"Biztonságos másolási protokoll (Secure Copy Protocol)\">SCP</abbr>-"
+"A Dropbear hálózati <abbr title=\"Biztonságos rendszerhéj (Secure "
+"Shell)\">SSH</abbr> parancsértelmező hozzáférést és integrált <abbr "
+"title=\"Biztonságos másolási protokoll (Secure Copy Protocol)\">SCP</abbr>-"
 "kiszolgálót biztosít."
 
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:14
@@ -3278,16 +3284,16 @@ msgid ""
 msgstr ""
 "Engedélyezi a <abbr title=\"Hiperszöveg (sokközponttú, nem lineáris, "
 "interaktív) átviteli protokoll (HyperText Transfer Protocol)\">HTTP</abbr> "
-"kérések automatikus átirányítását <abbr title=\"Biztonságos hiperszöveg ("
-"sokközponttú, nem lineáris, interaktív) átviteli protokoll (HyperText "
+"kérések automatikus átirányítását <abbr title=\"Biztonságos hiperszöveg "
+"(sokközponttú, nem lineáris, interaktív) átviteli protokoll (HyperText "
 "Transfer Protocol Secure)\">HTTPS</abbr>-re."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1093
 msgid ""
 "Enable downstream delegation of IPv6 prefixes available on this interface"
 msgstr ""
-"Ezen a csatolón elérhető <abbr title=\"Internet protokoll 6-os verziója\""
-">IPv6</abbr>-előtagok belső használatának engedélyezése."
+"Ezen a csatolón elérhető <abbr title=\"Internet protokoll 6-os "
+"verziója\">IPv6</abbr>-előtagok belső használatának engedélyezése."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1866
 msgid "Enable key reinstallation (KRACK) countermeasures"
@@ -3363,8 +3369,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:765
 msgid "Enable the built-in single-instance TFTP server."
 msgstr ""
-"Beépített egypéldányos <abbr title=\"Egyszerű állományátviteli protokoll ("
-"Trivial File Transfer Protocol)\">TFTP</abbr>-kiszolgáló engedélyezése."
+"Beépített egypéldányos <abbr title=\"Egyszerű állományátviteli protokoll "
+"(Trivial File Transfer Protocol)\">TFTP</abbr>-kiszolgáló engedélyezése."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Enable this network"
@@ -3430,8 +3436,8 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:572
 msgid "Enables the Spanning Tree Protocol on this bridge"
 msgstr ""
-"Engedélyezi az <abbr title=\"Feszítőfa protokoll (Spanning Tree Protocol)\""
-">STP</abbr>-t ezen a hídon."
+"Engedélyezi az <abbr title=\"Feszítőfa protokoll (Spanning Tree "
+"Protocol)\">STP</abbr>-t ezen a hídon."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:62
@@ -3737,9 +3743,8 @@ msgid ""
 "File listing upstream resolvers, optionally domain-specific, e.g. "
 "{servers_file_entry01}, {servers_file_entry02}."
 msgstr ""
-"Fájl a külső feloldások listájával, elhagyható tartomány-"
-"specifikussággal.<br />Például: {servers_file_entry01}, "
-"{servers_file_entry02}."
+"Fájl a külső feloldások listájával, elhagyható tartomány-specifikussággal."
+"<br />Például: {servers_file_entry01}, {servers_file_entry02}."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2684
 msgid "File not accessible"
@@ -3981,10 +3986,11 @@ msgid ""
 "messages received on the designated master interface to downstream "
 "interfaces."
 msgstr ""
-"Továbbítsa az <abbr title=\"Útválasztó hirdetése (Router Advertisement)\""
-">RA</abbr> (<abbr title=\"Internet felügyeleti-üzenet protokoll 6-os "
-"verziója (Internet Control Message Protocol version 6)\">ICMPv6</abbr> 134-"
-"es típus) üzeneteket a kijelölt mester csatoló és a belső csatolók között."
+"Továbbítsa az <abbr title=\"Útválasztó hirdetése (Router "
+"Advertisement)\">RA</abbr> (<abbr title=\"Internet felügyeleti-üzenet "
+"protokoll 6-os verziója (Internet Control Message Protocol version "
+"6)\">ICMPv6</abbr> 134-es típus) üzeneteket a kijelölt mester csatoló és a "
+"belső csatolók között."
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:164
 msgid "Forward DHCP traffic"
@@ -5678,8 +5684,8 @@ msgid ""
 msgstr ""
 "Az R0KH-k listája ugyanabban a mobilitási tartományban.<br />Formátum: <abbr "
 "title=\"Közeghozzáférés-vezérlő (Media Access Control)\">MAC</abbr>-cím, "
-"<abbr title=\"Hálózati hozzáférési kiszolgáló (Network Access Server)\\\""
-">NAS</abbr>-azonosító, 128 bites kulcs hexadecimális karakterláncként.<br /"
+"<abbr title=\"Hálózati hozzáférési kiszolgáló (Network Access Server)\\"
+"\">NAS</abbr>-azonosító, 128 bites kulcs hexadecimális karakterláncként.<br /"
 ">Ezt a listát használják az R0KH-azonosító (NAS-azonosító) cél MAC-címre "
 "történő leképezéséhez, ha <abbr title=\"Páros mesterkulcs (Pairwise Master "
 "Key)\">PMK</abbr>-R1 kulcsot kér attól az R0KH-tól, amelyet az állomás "
@@ -7231,6 +7237,10 @@ msgstr ""
 "Base64-kódolású előre megosztott kulcs, ami még egy réteg szimmetrikus "
 "kulcsú titkosítást biztosít kvantumszámítógépes támadások ellen (elhagyható)."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8546,13 +8556,13 @@ msgstr "Kötelező. A csatoló .yml beállítási fájljának elérési útja."
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Kötelező. WireGuard partner nyilvános kulcsa."
 
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Kötelező. Mögöttes csatoló."
-
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
 msgstr "Kötelező. Az SA-hoz használandó XFRM csatoló azonosítója."
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Required. Underlying interface."
+msgstr "Kötelező. Mögöttes csatoló."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1472
 msgid ""
@@ -11129,6 +11139,10 @@ msgstr "Nem lehet ellenőrizni a PIN-t"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/id/base.po
+++ b/modules/luci-base/po/id/base.po
@@ -6707,6 +6707,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7937,10 +7941,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10260,6 +10260,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -7135,6 +7135,10 @@ msgstr ""
 "livello di crittografia a chiave simmetrica per la resistenza post-"
 "quantistica."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Facoltativo. Crea instradamenti per gli IP consentiti per questo peer."
@@ -8425,10 +8429,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Necessario. Chiave pubblica del peer WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Necessario. Interfaccia sottostante."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11063,6 +11063,10 @@ msgstr "Impossibile verificare il PIN"
 msgid "Unconfigure"
 msgstr "Deconfigura"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Interfaccia sottostante."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12637,6 +12641,9 @@ msgstr "{example_nx} restituisce {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Indietro"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Necessario. Interfaccia sottostante."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (entrambi)"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -6922,6 +6922,10 @@ msgstr ""
 "Base64でエンコードされた事前共有キーです。ポスト量子レジスタンスのため、対称"
 "鍵暗号の追加層を追加します（オプション）。"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "このピアの許可されたIPのルートを作成します（オプション）。"
@@ -8178,10 +8182,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10640,6 +10640,10 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
 msgstr "設定解除"
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -6793,6 +6793,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8036,10 +8040,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10416,6 +10416,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/lt/base.po
+++ b/modules/luci-base/po/lt/base.po
@@ -7247,6 +7247,10 @@ msgstr ""
 "papildomą simetrinio rakto kriptografijos sluoksnį, kad būtų užtikrintas "
 "atsparumas pokvantinio atsparumo."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8550,10 +8554,6 @@ msgstr "Reikalingas. Kelias į šios sąsajos „.yml“ konfigūracijos failą.
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Reikalaujama. „WireGuard“ lygiarangio viešasis raktas."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Reikalingas/privalomas. Pagrindinė sąsaja."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11209,6 +11209,10 @@ msgstr "Nepavyko patvirtinti „PIN-kodo“"
 msgid "Unconfigure"
 msgstr "Atkonfigūruoti"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Pagrindinė sąsaja."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "„Unet“"
@@ -12790,6 +12794,9 @@ msgstr "„{example_nx}“ grąžina „{nxdomain}“."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "🡐 Atgal"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Reikalingas/privalomas. Pagrindinė sąsaja."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "„PAP/CHAP“ (abu)"

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -6713,6 +6713,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7944,10 +7948,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10267,6 +10267,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -6738,6 +6738,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7970,10 +7974,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10310,6 +10310,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -6794,6 +6794,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8030,10 +8034,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10400,6 +10400,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -7025,6 +7025,10 @@ msgstr ""
 "Optioneel. Base64-gecodeerde vooraf gedeelde sleutel. Voegt een extra laag "
 "cryptografie met symmetrische sleutels toe voor post-kwantumweerstand."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Optioneel. Maak routes voor Toegestane IP's voor deze peer."
@@ -8303,10 +8307,6 @@ msgstr "Vereist. Pad naar het .yml-configuratiebestand voor deze interface."
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Vereist. Openbare sleutel van de WireGuard peer."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Vereist. Onderliggende interface."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10915,6 +10915,10 @@ msgstr "Kan pincode niet verifiëren"
 msgid "Unconfigure"
 msgstr "Deconfigureer"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Onderliggende interface."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12479,6 +12483,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Terug"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Vereist. Onderliggende interface."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (beide)"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -7128,6 +7128,10 @@ msgstr ""
 "dodatkową warstwę symetrycznej kryptografii klucza dla uzyskania odporności "
 "postkwantowej."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opcjonalny. Tworzenie tras dozwolonych adresów IP dla tego peera."
@@ -8414,10 +8418,6 @@ msgstr "Wymagane. Ścieżka do pliku konfiguracyjnego .yml dla tego interfejsu."
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Wymagane. Klucz publiczny peera WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Wymagane. Podstawowy interfejs."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11026,6 +11026,10 @@ msgstr "Nie można zweryfikować kodu PIN"
 msgid "Unconfigure"
 msgstr "Dekonfiguruj"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Podstawowy interfejs."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12598,6 +12602,9 @@ msgstr "{example_nx} zwraca {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Wstecz"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Wymagane. Podstawowy interfejs."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (oba)"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -7050,6 +7050,10 @@ msgstr ""
 "Opcional. Adiciona uma camada extra de cifragem simétrica para resistência "
 "pós quântica."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opcional. Cria rotas para endereços IP Autorizados para este parceiro."
@@ -8331,10 +8335,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Obrigatório. Chave pública do par WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Obrigatório. Interface subjacente."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10936,6 +10936,10 @@ msgstr "Não foi possível verificar o PIN"
 msgid "Unconfigure"
 msgstr "Desconfigurar"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Interface subjacente."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12502,6 +12506,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Obrigatório. Interface subjacente."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (ambos)"

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -7098,6 +7098,10 @@ msgstr ""
 "Opcional. Chave pré-compartilhada codificada com base64. Adiciona uma camada "
 "adicional de criptografia da chave simétrica para resistência pós-quântica."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opcional. Cria rotas para endereços IP Autorizados para este parceiro."
@@ -8381,10 +8385,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Obrigatório. Chave pública do par WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Obrigatório. Interface subjacente."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11002,6 +11002,10 @@ msgstr "Não foi possível verificar o PIN"
 msgid "Unconfigure"
 msgstr "Desconfigurar"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Interface subjacente."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12568,6 +12572,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Obrigatório. Interface subjacente."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (ambos)"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -7040,6 +7040,10 @@ msgstr ""
 "suplimentar de criptografie cu cheie simetrică pentru rezistență post-"
 "cuantice."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Opțional. Creează rute pentru IP-uri permise pentru acest peer."
@@ -8323,10 +8327,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Este necesar. Cheia publică a omologului WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Este necesar. Interfața de bază."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10941,6 +10941,10 @@ msgstr "Nu se poate verifica PIN-ul"
 msgid "Unconfigure"
 msgstr "Neconfigurați"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Interfața de bază."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12506,6 +12510,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Înapoi"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Este necesar. Interfața de bază."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (ambele)"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -7145,6 +7145,10 @@ msgstr ""
 "Необязательно. Base64-шифрованный общий ключ. Добавляет дополнительный слой "
 "криптографии с симметричным ключом для постквантовой устойчивости."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8431,10 +8435,6 @@ msgstr "Обязательно. Путь к файлу конфигурации 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Обязательно. Публичный ключ WireGuard узла."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Обязательно. Основной интерфейс."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -11043,6 +11043,10 @@ msgstr "Не удается проверить PIN-код"
 msgid "Unconfigure"
 msgstr "Сброс"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Основной интерфейс."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12617,6 +12621,9 @@ msgstr "{example_nx} возвращает {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Обязательно. Основной интерфейс."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (оба)"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -6884,6 +6884,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8130,10 +8134,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10531,6 +10531,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -6751,6 +6751,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7983,10 +7987,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10311,6 +10311,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -6704,6 +6704,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7934,10 +7938,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10257,6 +10257,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -7103,6 +7103,10 @@ msgstr ""
 "İsteğe bağlı. Base64 kodlu önceden paylaşılmış anahtar. Kuantum sonrası "
 "direnç için ek bir simetrik anahtar şifreleme katmanı ekler."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "İsteğe bağlı. Bu eş için İzin Verilen IP'ler için yollar oluşturun."
@@ -8377,10 +8381,6 @@ msgstr "Gerekli. Bu arabirim için .yml yapılandırma dosyasının yolu."
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Gerekli. WireGuard eşinin ortak anahtarı."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Gerekli. Temel arayüz."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10981,6 +10981,10 @@ msgstr "PIN doğrulanamadı"
 msgid "Unconfigure"
 msgstr "Yapılandırmayı kaldır"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Temel arayüz."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12548,6 +12552,9 @@ msgstr "{example_nx}, {nxdomain} değerini döndürür."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Geri"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Gerekli. Temel arayüz."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (her ikisi de)"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -7041,6 +7041,10 @@ msgstr ""
 "Додавання додатково рівня шифрування із симетричним ключем для пост-"
 "квантової стійкості."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "Необов'язково. Створити для цього вузла маршрути для дозволених IP."
@@ -8314,10 +8318,6 @@ msgstr ""
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Необхідно. Основний інтерфейс."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10884,6 +10884,10 @@ msgstr ""
 msgid "Unconfigure"
 msgstr "Скасувати налаштування"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Основний інтерфейс."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -12428,6 +12432,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Необхідно. Основний інтерфейс."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (обидва)"

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -6713,6 +6713,10 @@ msgid ""
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -7943,10 +7947,6 @@ msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
-msgstr ""
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
 msgstr ""
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
@@ -10267,6 +10267,10 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
+msgstr ""
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -6994,6 +6994,10 @@ msgstr ""
 "Không bắt buộc. Khóa mã hóa Base64 được chia sẻ từ trước. Thêm vào một lớp "
 "mã hóa khóa đối xứng bổ sung cho tính kháng sau khi được lượng tử."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr ""
@@ -8270,10 +8274,6 @@ msgstr "Bắt buộc. Đường dẫn đến tệp cấu hình .yml cho giao di�
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "Bắt buộc. Khóa công khai của đối tác WireGuard."
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "Bắt buộc. Giao diện cơ bản."
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10834,6 +10834,10 @@ msgstr "Không thể xác minh PIN"
 msgid "Unconfigure"
 msgstr "Hủy cấu hình"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "Giao diện cơ bản."
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12387,6 +12391,9 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Quay lại"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "Bắt buộc. Giao diện cơ bản."
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (cả hai)"

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -294,12 +294,14 @@ msgstr "; 无效的 MAC："
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1015
 msgid "<abbr title=\"Basic Service Set Identifier\">BSSID</abbr>"
-msgstr "<abbr title=\"Basic Service Set Identifier（基本服务集标识符）\">BSSID</abbr>"
+msgstr ""
+"<abbr title=\"Basic Service Set Identifier（基本服务集标识符）\">BSSID</abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1004
 msgid "<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
-msgstr "<abbr title=\"Extended Service Set Identifier（扩展服务集标识符）\""
-">ESSID</abbr>"
+msgstr ""
+"<abbr title=\"Extended Service Set Identifier（扩展服务集标识符）\">ESSID</"
+"abbr>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:736
 msgid "<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Netmask"
@@ -396,9 +398,9 @@ msgid ""
 "internet connection in the mesh) or having the gateway support turned off "
 "entirely (which is the default setting)."
 msgstr ""
-"batman-adv 节点可以运行于在服务器模式 (与Mesh 共享其 Internet 连接) "
-"或客户端模式 (在 Mesh 中搜索最合适的 Internet 连接) 或完全关闭网关支持 "
-"(这是默认设置)。"
+"batman-adv 节点可以运行于在服务器模式 (与Mesh 共享其 Internet 连接) 或客户端"
+"模式 (在 Mesh 中搜索最合适的 Internet 连接) 或完全关闭网关支持 (这是默认设"
+"置)。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:424
 msgid "A configuration for the device \"%s\" already exists"
@@ -548,9 +550,9 @@ msgid ""
 "to the STA MAC address. Note: This is not Directed Multicast Service (DMS) "
 "in 802.11v. Note: might break receiver STA multicast expectations."
 msgstr ""
-"带组播目的地 MAC 的ARP、IPv4 和 IPv6（甚至 802.1Q）是对 STA MAC "
-"地址的单播。注意：这不是 802.11v 中的定向多播服务（DMS）。注意："
-"可能会破坏接收端 STA 多播预期。"
+"带组播目的地 MAC 的ARP、IPv4 和 IPv6（甚至 802.1Q）是对 STA MAC 地址的单播。"
+"注意：这不是 802.11v 中的定向多播服务（DMS）。注意：可能会破坏接收端 STA 多播"
+"预期。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1654
 msgid "ATM (Asynchronous Transfer Mode)"
@@ -2822,8 +2824,8 @@ msgid ""
 "good NA proxy on the network and such frames need not be used or in the case "
 "of 802.11, must not be used to prevent attacks."
 msgstr ""
-"丢弃所有非请求邻居通告，例如，如果网络中存在已知的好的 NA "
-"代理，那么不需要使用这些帧；或者在 802.11 的情况下，必须禁止使用以防止攻击。"
+"丢弃所有非请求邻居通告，例如，如果网络中存在已知的好的 NA 代理，那么不需要使"
+"用这些帧；或者在 802.11 的情况下，必须禁止使用以防止攻击。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:710
 msgid "Drop gratuitous ARP"
@@ -4635,8 +4637,9 @@ msgstr "如果选中，则禁用加密"
 msgid ""
 "If empty, all incoming connections will be allowed (default). This does not "
 "affect outgoing peerings, nor link-local peers discovered via multicast."
-msgstr "如果为空，将允许所有传入连接 "
-"(默认设置)。这不会影响传出连接，也不影响通过多播发现的链路本地对等节点。"
+msgstr ""
+"如果为空，将允许所有传入连接 (默认设置)。这不会影响传出连接，也不影响通过多播"
+"发现的链路本地对等节点。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1118
 msgid ""
@@ -5003,8 +5006,8 @@ msgid ""
 "value, an administrator may tune the number of IGMP messages on the subnet; "
 "larger values cause IGMP Queries to be sent less often"
 msgstr ""
-"组播常规查询之间的时间间隔 (以毫秒为单位)。通过更改该值，"
-"管理员可以调整子网中 IGMP 消息的数量。 数值越大，IGMP 查询的发送频率越低"
+"组播常规查询之间的时间间隔 (以毫秒为单位)。通过更改该值，管理员可以调整子网"
+"中 IGMP 消息的数量。 数值越大，IGMP 查询的发送频率越低"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:576
 msgid "Interval in seconds for STP hello packets"
@@ -5420,10 +5423,10 @@ msgid ""
 "R0KH. This is also the list of authorized R1KHs in the MD that can request "
 "PMK-R1 keys."
 msgstr ""
-"同一移动域中的 R1KH 列表。<br />格式: MAC 地址，R1KH-ID (包含冒号的 6 "
-"个八位字节)， 256 位密钥 (十六进制字符串)。<br /> 当从 R0KH 发送 PMK-R1 "
-"键时，此列表用于将 R1KH-ID 映射到目标 MAC 地址。这也是可以请求 PMK-R1 键的 "
-"MD 中授权的 R1KH 的列表。"
+"同一移动域中的 R1KH 列表。<br />格式: MAC 地址，R1KH-ID (包含冒号的 6 个八位"
+"字节)， 256 位密钥 (十六进制字符串)。<br /> 当从 R0KH 发送 PMK-R1 键时，此列"
+"表用于将 R1KH-ID 映射到目标 MAC 地址。这也是可以请求 PMK-R1 键的 MD 中授权的 "
+"R1KH 的列表。"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:82
 msgid "List of SSH key files for auth"
@@ -5654,7 +5657,8 @@ msgstr "正在登录…"
 msgid ""
 "Logical network from which to select the local endpoint if local IPv6 "
 "address is empty and no WAN IPv6 is available (optional)."
-msgstr "如果本地 IPv6 地址为空，且没有广域网 IPv6 可用，则从中选择本地端点的逻辑网络 "
+msgstr ""
+"如果本地 IPv6 地址为空，且没有广域网 IPv6 可用，则从中选择本地端点的逻辑网络 "
 "(可选)。"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:57
@@ -6651,8 +6655,8 @@ msgid ""
 "Note: you may also need a DHCP Proxy (currently unavailable) when specifying "
 "a non-standard Relay To port(<code>addr#port</code>)."
 msgstr ""
-"注意：在为“Relay To”指定非标准端口(<code>addr#port</code>) 时，"
-"您可能还需要使用DHCP代理 (当前不可用)。"
+"注意：在为“Relay To”指定非标准端口(<code>addr#port</code>) 时，您可能还需要使"
+"用DHCP代理 (当前不可用)。"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:142
 msgid "Notes"
@@ -6888,9 +6892,9 @@ msgid ""
 "server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
 "for the interface."
 msgstr ""
-"可选，允许的值：“eui64”、“random”和其他固定值 (例如：“::1”或“::1:2”)。"
-"当从授权服务器获取到 IPv6 前缀（如“a:b:c:d::”），使用后缀（如 “::1”）合成 "
-"IPv6 地址（“a:b:c:d::1”）分配给此接口。"
+"可选，允许的值：“eui64”、“random”和其他固定值 (例如：“::1”或“::1:2”)。当从授"
+"权服务器获取到 IPv6 前缀（如“a:b:c:d::”），使用后缀（如 “::1”）合成 IPv6 地址"
+"（“a:b:c:d::1”）分配给此接口。"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:586
 msgid ""
@@ -6899,6 +6903,10 @@ msgid ""
 msgstr ""
 "可选，Base64 编码的预共享密钥。添加在额外的对称密钥加密层中，用于抵抗未来的量"
 "子计算破解。"
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
@@ -6945,15 +6953,17 @@ msgid ""
 "establishing a connection but allows generating a peer configuration or QR "
 "code if available. It can be removed after the configuration has been "
 "exported."
-msgstr "可选。WireGuard 对端的私钥。 该密钥不是建立连接所必需的，"
-"但允许生成对端配置或 二维码 (如果可用)。 导出配置后可以将其删除。"
+msgstr ""
+"可选。WireGuard 对端的私钥。 该密钥不是建立连接所必需的，但允许生成对端配置"
+"或 二维码 (如果可用)。 导出配置后可以将其删除。"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:667
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
-msgstr "可选。Keep-Alive 消息之间的秒数，默认为 0 (禁用)。如果此设备位于 NAT "
-"之后,建议使用的值为 25。"
+msgstr ""
+"可选。Keep-Alive 消息之间的秒数，默认为 0 (禁用)。如果此设备位于 NAT 之后,建"
+"议使用的值为 25。"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:162
 msgid "Optional. UDP port used for outgoing and incoming packets."
@@ -7583,8 +7593,9 @@ msgstr "禁止客户端间通信"
 msgid ""
 "Prevents one wireless client to talk to another. This setting only affects "
 "packets without any VLAN tag (untagged packets)."
-msgstr "防止一个无线客户端与另一个客户端通信。 此设置仅影响没有任何 VLAN "
-"标记的数据包 (未打标记的数据包)。"
+msgstr ""
+"防止一个无线客户端与另一个客户端通信。 此设置仅影响没有任何 VLAN 标记的数据"
+"包 (未打标记的数据包)。"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:218
 msgid "Primary Slave"
@@ -8144,10 +8155,6 @@ msgstr "必填。 此接口 .yml 配置文件的路径。"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "必需。WireGuard 对端的公钥。"
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "必需。底层接口。"
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -8710,8 +8717,9 @@ msgstr "将接口设置为 NDP 代理外部从属设备。默认为关闭。"
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
-msgstr "不论接口的链路状态如何,总是用应用设置 "
-"(如果勾选,链路状态变更将不再触发热插拔事件处理)。"
+msgstr ""
+"不论接口的链路状态如何,总是用应用设置 (如果勾选,链路状态变更将不再触发热插拔"
+"事件处理)。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:405
 msgid "Set log class/facility for syslog entries."
@@ -9022,8 +9030,9 @@ msgstr "指定该路由所属的父（或主）接口的逻辑接口名"
 msgid ""
 "Specifies the mac-address for the actor in protocol packet exchanges "
 "(LACPDUs). If empty, masters' mac address defaults to system default"
-msgstr "明确协议包交换 actor 的 MAC 地址(LACPDUs)。如果为空，master 的 mac "
-"地址默认为系统默认值"
+msgstr ""
+"明确协议包交换 actor 的 MAC 地址(LACPDUs)。如果为空，master 的 mac 地址默认为"
+"系统默认值"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
@@ -9210,8 +9219,8 @@ msgid ""
 "header inherits the value of the inner header) or an hexadecimal value "
 "<code>00..FF</code> (optional)."
 msgstr ""
-"指定一个 TOS (服务类型)。可以是<code>继承</code> "
-"(外层消息头继承内部消息头的值) 或一个十六进制值<code>00..FF</code> (可选)。"
+"指定一个 TOS (服务类型)。可以是<code>继承</code> (外层消息头继承内部消息头的"
+"值) 或一个十六进制值<code>00..FF</code> (可选)。"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:74
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:74
@@ -9912,9 +9921,8 @@ msgid ""
 "\"leave latency\" of the network. A reduced value results in reduced time to "
 "detect the loss of the last member of a group"
 msgstr ""
-"插入为响应离组消息而发送的特定于组的查询中的最大响应时间 "
-"(以厘秒为单位)。它也是特定于组的查询消息之间的时间量。 "
-"可以调整该值以修改网络的“离开等待时间”。 "
+"插入为响应离组消息而发送的特定于组的查询中的最大响应时间 (以厘秒为单位)。它也"
+"是特定于组的查询消息之间的时间量。 可以调整该值以修改网络的“离开等待时间”。 "
 "减小的值会降低检测组中最后一个成员丢失的时间"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:615
@@ -10311,7 +10319,8 @@ msgid ""
 "To restore configuration files, you can upload a previously generated backup "
 "archive here. To reset the firmware to its initial state, click \"Perform "
 "reset\" (only possible with squashfs images)."
-msgstr "上传备份存档以恢复配置。要将固件恢复到初始状态，请单击“执行重置” (仅 "
+msgstr ""
+"上传备份存档以恢复配置。要将固件恢复到初始状态，请单击“执行重置” (仅 "
 "squashfs 格式的镜像文件有效)。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1644
@@ -10574,6 +10583,10 @@ msgstr "无法验证 PIN"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1417
 msgid "Unconfigure"
 msgstr "取消配置"
+
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "底层接口。"
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
@@ -11125,8 +11138,9 @@ msgstr "WPA 密钥"
 msgid ""
 "WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP "
 "and ad-hoc mode) to be installed."
-msgstr "WPA 加密需要安装 wpa_supplicant (客户端模式) 或安装 hostapd (接入点 AP、"
-"点对点 Ad-Hoc 模式)。"
+msgstr ""
+"WPA 加密需要安装 wpa_supplicant (客户端模式) 或安装 hostapd (接入点 AP、点对"
+"点 Ad-Hoc 模式)。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:153
 msgid "WPS status"
@@ -12094,6 +12108,9 @@ msgstr "{example_nx} 返回 {nxdomain}。"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "必需。底层接口。"
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP（均使用）"

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -6878,6 +6878,10 @@ msgstr ""
 "可選性. Base64編碼的預先共享金鑰. 新增了額外一層對稱金鑰密碼學, 以便針對後量"
 "子攻擊的抵抗力."
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Optional. Bind to a specific interface."
+msgstr ""
+
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:643
 msgid "Optional. Create routes for Allowed IPs for this peer."
 msgstr "可選性. 對已允許的IP對等節點創建路由表."
@@ -8126,10 +8130,6 @@ msgstr "必填。此介面的 .yml 設定檔路徑。"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:572
 msgid "Required. Public key of the WireGuard peer."
 msgstr "必需。WireGuard 對端的公開金鑰。"
-
-#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
-msgid "Required. Underlying interface."
-msgstr "必填。底層介面。"
 
 #: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:39
 msgid "Required. XFRM interface ID to be used for SA."
@@ -10558,6 +10558,10 @@ msgstr "無法驗證 PIN"
 msgid "Unconfigure"
 msgstr "取消配置"
 
+#: protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js:42
+msgid "Underlying interface"
+msgstr "底層介面。"
+
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -12074,6 +12078,9 @@ msgstr "{example_nx} 返回 {nxdomain}."
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 倒退"
+
+#~ msgid "Required. Underlying interface."
+#~ msgstr "必填。底層介面。"
 
 #~ msgid "PAP/CHAP (both)"
 #~ msgstr "PAP/CHAP (並用)"

--- a/protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js
+++ b/protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js
@@ -39,7 +39,7 @@ return network.registerProtocol('xfrm', {
 		o = s.taboption('general', form.Value, 'ifid', _('Interface ID'), _('Required. XFRM interface ID to be used for SA.'));
 		o.datatype = 'integer';
 
-		o = s.taboption('general', widgets.NetworkSelect, 'tunlink', _('Required. Underlying interface.'));
+		o = s.taboption('general', widgets.NetworkSelect, 'tunlink', _('Underlying interface'),_('Optional. Bind to a specific interface.'));
 		o.exclude = s.section;
 		o.nocreate = true;
 


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: [LuCI openwrt-23.05 branch (git-24.086.45142-09d5a38)](https://github.com/openwrt/luci) / [OpenWrt 23.05.4 (r24012-d8dd03c46f)](https://openwrt.org/), with openwrt/openwrt#16046 backport
- [x] Depends on: openwrt/openwrt#16046
- [x] Description: Updates luci description for tunlink parameter which is now optional.
