### PR TITLE
luci-base: form.js: decode HTML entities in AbstractElement.stripTags()

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -275,16 +275,18 @@ var CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement.p
 	},
 
 	/**
-	 * Strip any HTML tags from the given input string.
+	 * Strip any HTML tags from the given input string, and decode
+	 * HTML entities.
 	 *
 	 * @param {string} s
 	 * The input string to clean.
 	 *
 	 * @returns {string}
-	 * The cleaned input string with HTML tags removed.
+	 * The cleaned input string with HTML tags removed, and HTML
+	 * entities decoded.
 	 */
 	stripTags: function(s) {
-		if (typeof(s) == 'string' && !s.match(/[<>]/))
+		if (typeof(s) == 'string' && !s.match(/[<>\&]/))
 			return s;
 
 		var x = dom.elem(s) ? s : dom.parse('<div>' + s + '</div>');


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86-64, openwrt-23.05.3, Firefox 129.0 on Android) :white_check_mark:
- [x] Mention: @feckert, @jow-
- [x] Description: This PR fixes a problem with HTML entities which were visible in their encoded form in the mobile view. This happened for example when displaying a GridSection with a Value option containing `&nbsp;` in the title. Without this change only HTML entities in titles that also contains tags are decoded before they are stored in data-title attributes.
