### PR TITLE
ACL: Add system read for luci-mod-network needed for timezone in wire…

### DIFF
--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -17,7 +17,7 @@
 				"iwinfo": [ "assoclist", "countrylist", "freqlist", "txpowerlist" ],
 				"luci": [ "getSwconfigFeatures", "getSwconfigPortState" ]
 			},
-			"uci": [ "dhcp", "firewall", "network", "wireless" ]
+			"uci": [ "dhcp", "firewall", "network", "wireless", "system" ]
 		},
 		"write": {
 			"cgi-io": [ "exec" ],


### PR DESCRIPTION
https://github.com/openwrt/luci/blob/master/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js#L739 needs system access in order to get timezone.