### PR TITLE
luci-proto-3g/ppp/pppossh: fix default keepalive values

### DIFF
--- a/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
+++ b/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
@@ -128,7 +128,7 @@ return network.registerProtocol('3g', {
 		o.datatype    = 'min(1)';
 
 		o = s.taboption('advanced', form.Value, '_keepalive_failure', _('LCP echo failure threshold'), _('Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures'));
-		o.placeholder = '0';
+		o.placeholder = '5';
 		o.datatype    = 'uinteger';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
@@ -141,7 +141,7 @@ return network.registerProtocol('3g', {
 		};
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
-		o.placeholder = '5';
+		o.placeholder = '1';
 		o.datatype    = 'min(1)';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js
@@ -100,7 +100,7 @@ return network.registerProtocol('ppp', {
 		}
 
 		o = s.taboption('advanced', form.Value, '_keepalive_failure', _('LCP echo failure threshold'), _('Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures'));
-		o.placeholder = '0';
+		o.placeholder = '5';
 		o.datatype    = 'uinteger';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
@@ -113,7 +113,7 @@ return network.registerProtocol('ppp', {
 		};
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
-		o.placeholder = '5';
+		o.placeholder = '1';
 		o.datatype    = 'min(1)';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js
@@ -86,7 +86,7 @@ return network.registerProtocol('pppoa', {
 		}
 
 		o = s.taboption('advanced', form.Value, '_keepalive_failure', _('LCP echo failure threshold'), _('Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures'));
-		o.placeholder = '0';
+		o.placeholder = '5';
 		o.datatype    = 'uinteger';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
@@ -99,7 +99,7 @@ return network.registerProtocol('pppoa', {
 		};
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
-		o.placeholder = '5';
+		o.placeholder = '1';
 		o.datatype    = 'min(1)';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js
@@ -60,7 +60,7 @@ return network.registerProtocol('pppoe', {
 		}
 
 		o = s.taboption('advanced', form.Value, '_keepalive_failure', _('LCP echo failure threshold'), _('Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures'));
-		o.placeholder = '0';
+		o.placeholder = '5';
 		o.datatype    = 'uinteger';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
@@ -73,7 +73,7 @@ return network.registerProtocol('pppoe', {
 		};
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
-		o.placeholder = '5';
+		o.placeholder = '1';
 		o.datatype    = 'min(1)';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js
@@ -73,7 +73,7 @@ return network.registerProtocol('pptp', {
 		}
 
 		o = s.taboption('advanced', form.Value, '_keepalive_failure', _('LCP echo failure threshold'), _('Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures'));
-		o.placeholder = '0';
+		o.placeholder = '5';
 		o.datatype    = 'uinteger';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
@@ -86,7 +86,7 @@ return network.registerProtocol('pptp', {
 		};
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
-		o.placeholder = '5';
+		o.placeholder = '1';
 		o.datatype    = 'min(1)';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;

--- a/protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js
+++ b/protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js
@@ -96,7 +96,7 @@ return network.registerProtocol('pppossh', {
 		}
 
 		o = s.taboption('advanced', form.Value, '_keepalive_failure', _('LCP echo failure threshold'), _('Presume peer to be dead after given amount of LCP echo failures, use 0 to ignore failures'));
-		o.placeholder = '0';
+		o.placeholder = '5';
 		o.datatype    = 'uinteger';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
@@ -109,7 +109,7 @@ return network.registerProtocol('pppossh', {
 		};
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
-		o.placeholder = '5';
+		o.placeholder = '1';
 		o.datatype    = 'min(1)';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;


### PR DESCRIPTION
The default PPP keepalive value in OpenWRT is actually `5 1` not `0 5`. 