### PR TITLE
luci-app-privoxy: fix description for socks5

### DIFF
--- a/applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua
+++ b/applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua
@@ -617,7 +617,8 @@ local fs4	= ns:taboption("forward", DynamicList, "forward_socks4")
 fs4.title	= string.format(HELP, "SOCKS", "Forward SOCKS 4" )
 fs4.description	= translate("Through which SOCKS proxy (and optionally to which parent HTTP proxy) specific requests should be routed.")
 		.. [[<br />]]
-		.. translate("Syntax: target_pattern socks_proxy[:port] http_parent[:port]")
+		.. translate("Syntax:")
+		.. " target_pattern socks_proxy[:port] http_parent[:port]"
 fs4.rmempty	= true
 
 -- forward-socks4a -------------------------------------------------------------
@@ -629,13 +630,16 @@ f4a.rmempty	= true
 -- forward-socks5 --------------------------------------------------------------
 local fs5	= ns:taboption("forward", DynamicList, "forward_socks5")
 fs5.title	= string.format(HELP, "SOCKS", "Forward SOCKS 5" )
-fs5.description = fs4.description
+fs5.description	= translate("Through which SOCKS proxy (and optionally to which parent HTTP proxy) specific requests should be routed.")
+		.. [[<br />]]
+		.. translate("Syntax:")
+		.. " target_pattern [user:pass@]socks_proxy[:port] http_parent[:port]"
 fs5.rmempty	= true
 
 -- forward-socks5t -------------------------------------------------------------
 local f5t	= ns:taboption("forward", DynamicList, "forward_socks5t")
 f5t.title	= string.format(HELP, "SOCKS", "Forward SOCKS 5t" )
-f5t.description = fs4.description
+f5t.description = fs5.description
 f5t.rmempty	= true
 
 -- tab: misc -- ################################################################

--- a/applications/luci-app-privoxy/po/ar/privoxy.po
+++ b/applications/luci-app-privoxy/po/ar/privoxy.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -54,11 +54,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -69,19 +69,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -188,25 +188,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr "عارض ملف السجل"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -255,7 +255,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -278,16 +278,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "الرجاء الضغط على زر [قراءة]"
 
@@ -332,19 +332,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "قراءة / إعادة قراءة ملف السجل"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -369,24 +369,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "بناء الجملة:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -405,7 +403,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -435,11 +433,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -457,7 +455,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -475,6 +473,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -490,11 +489,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -502,7 +501,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -510,10 +509,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -531,7 +530,7 @@ msgstr "الإصدار"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -541,17 +540,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -567,16 +566,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/bg/privoxy.po
+++ b/applications/luci-app-privoxy/po/bg/privoxy.po
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -55,11 +55,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -70,19 +70,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -189,25 +189,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -256,7 +256,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -279,16 +279,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -302,7 +302,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -333,19 +333,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -370,24 +370,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -406,7 +404,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -436,11 +434,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -458,7 +456,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -476,6 +474,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -491,11 +490,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -503,7 +502,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -511,10 +510,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -532,7 +531,7 @@ msgstr "Версия"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -542,17 +541,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -568,16 +567,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/bn_BD/privoxy.po
+++ b/applications/luci-app-privoxy/po/bn_BD/privoxy.po
@@ -15,8 +15,8 @@ msgid ""
 "A URL to be displayed in the error page that users will see if access to an "
 "untrusted page is denied."
 msgstr ""
-"ত্রুটি পৃষ্ঠায় প্রদর্শনের URL যা ব্যবহারকারীরা দেখতে পাবে যদি কোনো অবিশ্বস্"
-"ত পৃষ্ঠায় প্রবেশাধিকার অস্বীকার করা হয়।"
+"ত্রুটি পৃষ্ঠায় প্রদর্শনের URL যা ব্যবহারকারীরা দেখতে পাবে যদি কোনো অবিশ্বস্ত পৃষ্ঠায় "
+"প্রবেশাধিকার অস্বীকার করা হয়।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:226
 msgid ""
@@ -35,8 +35,7 @@ msgstr "প্রবেশাধিকার নিয়ন্ত্রণ"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:337
 msgid "Actions that are applied to all sites and maybe overruled later on."
-msgstr ""
-"সমস্ত সাইটে প্রযোজ্য এবং পরবর্তীকালে হয়তো অকার্যকর করা হয়েছে এমন অ্যাকশন।"
+msgstr "সমস্ত সাইটে প্রযোজ্য এবং পরবর্তীকালে হয়তো অকার্যকর করা হয়েছে এমন অ্যাকশন।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:308
 msgid "An alternative directory where the templates are loaded from."
@@ -46,23 +45,22 @@ msgstr "বিকল্প ডিরেক্টরি যেখান থেক
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Privoxy প্রশাসকের কাছে পৌঁছানোর জন্য ইমেল ঠিকানা।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
 msgstr ""
-"সার্ভার দ্বারা নির্ধারিত না হলে অনুমেয় সার্ভার-সাইড কিপ-লাইভ টাইমআউট "
-"(সেকেন্ডে)।"
+"সার্ভার দ্বারা নির্ধারিত না হলে অনুমেয় সার্ভার-সাইড কিপ-লাইভ টাইমআউট (সেকেন্ডে)।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:151
 msgid "Boot delay"
 msgstr "বুট বিলম্ব"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGI ইউজার ইন্টারফেস"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "সাধারণ লগ ফরম্যাট"
 
@@ -72,23 +70,23 @@ msgid ""
 "proxies. Note that parent proxies can severely decrease your privacy level. "
 "Also specified here are SOCKS proxies."
 msgstr ""
-"একাধিক প্রক্সির চেইনের মাধ্যমে এখানে HTTP অনুরোধের রাউটিং কনফিগার করুন। লক্ষ্"
-"য করুন যে প্যারেন্ট প্রক্সিগুলি আপনার গোপনীয়তার স্তরকে মারাত্মকভাবে হ্রাস "
-"করতে পারে। এছাড়াও এখানে SOCKS প্রক্সি উল্লেখ করুন।"
+"একাধিক প্রক্সির চেইনের মাধ্যমে এখানে HTTP অনুরোধের রাউটিং কনফিগার করুন। লক্ষ্য করুন "
+"যে প্যারেন্ট প্রক্সিগুলি আপনার গোপনীয়তার স্তরকে মারাত্মকভাবে হ্রাস করতে পারে। এছাড়াও "
+"এখানে SOCKS প্রক্সি উল্লেখ করুন।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "GIF ডি-অ্যানিমেশন ডিবাগ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "ফোর্স ফিচার ডিবাগ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "রিডাইরেক্ট ডিবাগ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "রেগুলার এক্সপ্রেশন ফিল্টার ডিবাগ করুন"
 
@@ -123,8 +121,7 @@ msgstr "প্রক্সি প্রমাণীকরণ ফরওয়া�
 msgid ""
 "Enable/Disable autostart of Privoxy on system startup and interface events"
 msgstr ""
-"সিস্টেম স্টার্টআপ এবং ইন্টারফেস ইভেন্টগুলিতে Privoxy এর অটো স্টার্ট "
-"সক্ষম/নিষ্ক্রিয় করুন"
+"সিস্টেম স্টার্টআপ এবং ইন্টারফেস ইভেন্টগুলিতে Privoxy এর অটো স্টার্ট সক্ষম/নিষ্ক্রিয় করুন"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:555
 msgid "Enable/Disable filtering when Privoxy starts."
@@ -139,8 +136,8 @@ msgid ""
 "Enabling this option is NOT recommended if there is no parent proxy that "
 "requires authentication!"
 msgstr ""
-"প্রমাণীকরণের প্রয়োজন নেই এমন কোনও প্যারেন্ট প্রক্সি না থাকলে এই অপশনটি "
-"সক্রিয় না করাই ভাল!"
+"প্রমাণীকরণের প্রয়োজন নেই এমন কোনও প্যারেন্ট প্রক্সি না থাকলে এই অপশনটি সক্রিয় না "
+"করাই ভাল!"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:368
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:404
@@ -148,7 +145,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "কনফিগারেশন ডিরেক্টরিতে ফাইল '%s' পাওয়া যায়নি"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "ফাইল পাওয়া যায়নি বা খালি"
@@ -175,8 +172,8 @@ msgid ""
 "If enabled, Privoxy hides the 'go there anyway' link. The user obviously "
 "should not be able to bypass any blocks."
 msgstr ""
-"যদি সক্রিয় থাকে, Privoxy 'go there anyway' লিঙ্কটি লুকিয়ে রাখে। ব্যবহারকারী"
-"র স্পষ্টতই কোন ব্লক বাইপাস করতে সক্ষম হওয়া উচিত নয়।"
+"যদি সক্রিয় থাকে, Privoxy 'go there anyway' লিঙ্কটি লুকিয়ে রাখে। ব্যবহারকারীর "
+"স্পষ্টতই কোন ব্লক বাইপাস করতে সক্ষম হওয়া উচিত নয়।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:67
 msgid ""
@@ -184,8 +181,8 @@ msgid ""
 "be a good idea to let them know how to reach you, what you block and why you "
 "do that, your policies, etc."
 msgstr ""
-"আপনি যদি নিজে ছাড়াও অন্য ব্যবহারকারীদের জন্য Privoxy পরিচালনা করতে চান, তাহলে"
-" আপনার কাছে পৌঁছানোর উপায়, আপনি কী ব্লক করেন এবং কেন করেন, আপনার নীতিমালা "
+"আপনি যদি নিজে ছাড়াও অন্য ব্যবহারকারীদের জন্য Privoxy পরিচালনা করতে চান, তাহলে "
+"আপনার কাছে পৌঁছানোর উপায়, আপনি কী ব্লক করেন এবং কেন করেন, আপনার নীতিমালা "
 "ইত্যাদি তাদের জানানো উচিৎ।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:215
@@ -204,26 +201,25 @@ msgstr "Privoxy ব্যবহারকারী ম্যানুয়াল
 msgid "Log File Viewer"
 msgstr "লগ ফাইল ভিউয়ার"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "নেটওয়ার্ক থেকে পড়া সমস্ত তথ্য লগ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "নেটওয়ার্কে লেখা সমস্ত ডেটা লগ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "আবেদন কর্ম লগ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
-msgstr ""
-"Privoxy যেতে দেয় এমন অনুরোধগুলোর গন্তব্য লগ করুন।এছাড়াও 'ডিবাগ 1024' দেখুন।"
+msgstr "Privoxy যেতে দেয় এমন অনুরোধগুলোর গন্তব্য লগ করুন।এছাড়াও 'ডিবাগ 1024' দেখুন।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -272,7 +268,7 @@ msgstr "বাধ্যতামূলক ইনপুট: কোন বৈধ I
 msgid "Mandatory Input: No valid Port given!"
 msgstr "বাধ্যতামূলক ইনপুট: কোন বৈধ পোর্ট দেওয়া হয়নি!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "সর্বাধিক সংখ্যক ক্লায়েন্ট সংযোগ যা পরিবেশন করা হবে।"
 
@@ -295,18 +291,17 @@ msgstr "ইনস্টল করা না"
 msgid "No trailing '/', please."
 msgstr "দয়া করে শেষের '/' পরিহার করুন।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "অমারাত্মক ত্রুটি - *আমরা এটি সক্রিয় করার জন্য জোরালো সুপারিশ করেছি *"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
-"সেকেন্ডের সংখ্যা যার পরে একটি সকেট টাইম আউট হয়ে যায় যদি কোন ডেটা না পাওয়া "
-"যায়।"
+"সেকেন্ডের সংখ্যা যার পরে একটি সকেট টাইম আউট হয়ে যায় যদি কোন ডেটা না পাওয়া যায়।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "সেকেন্ডের সংখ্যা যার পরে একটি খোলা সংযোগ আর ব্যবহার করা হবে না।"
@@ -315,14 +310,13 @@ msgstr "সেকেন্ডের সংখ্যা যার পরে এ�
 msgid ""
 "Only when using 'external filters', Privoxy has to create temporary files."
 msgstr ""
-"শুধুমাত্র 'বাহ্যিক ফিল্টার' ব্যবহার করার সময় Privoxy-কে অস্থায়ী ফাইল তৈরি "
-"করতে হয়।"
+"শুধুমাত্র 'বাহ্যিক ফিল্টার' ব্যবহার করার সময় Privoxy-কে অস্থায়ী ফাইল তৈরি করতে হয়।"
 
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:81
 msgid "Please install current version !"
 msgstr "বর্তমান সংস্করণ ইনস্টল করুন!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "দয়া করে [পড়ুন] বোতাম টিপুন"
 
@@ -345,8 +339,8 @@ msgid ""
 "configuration, help and logging. This section of the configuration file "
 "tells Privoxy where to find those other files."
 msgstr ""
-"Privoxy অতিরিক্ত কনফিগারেশন, সাহায্য এবং লগিংয়ের জন্য অন্যান্য ফাইল ব্যবহার "
-"করতে পারে (এবং সাধারণত করে)। কনফিগারেশন ফাইলের এই বিভাগটি Privoxy-কে বলে যে "
+"Privoxy অতিরিক্ত কনফিগারেশন, সাহায্য এবং লগিংয়ের জন্য অন্যান্য ফাইল ব্যবহার করতে "
+"পারে (এবং সাধারণত করে)। কনফিগারেশন ফাইলের এই বিভাগটি Privoxy-কে বলে যে "
 "অন্যান্য ফাইলগুলি কোথায় পাওয়া যাবে।"
 
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:32
@@ -355,23 +349,23 @@ msgid ""
 "enhancing privacy, modifying web page data and HTTP headers, controlling "
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
-"Privoxy হল একটি নন-ক্যাশিং ওয়েব প্রক্সি যার উন্নত ফিল্টারিং ক্ষমতা গোপনীয়তা"
-" বৃদ্ধি, ওয়েব পেজ ডেটা এবং এইচটিটিপি হেডার পরিবর্তন, অ্যাক্সেস নিয়ন্ত্রণ "
-"এবং বিজ্ঞাপন এবং অন্যান্য অপ্রীতিকর ইন্টারনেট আবর্জনা অপসারণ করে থাকে।"
+"Privoxy হল একটি নন-ক্যাশিং ওয়েব প্রক্সি যার উন্নত ফিল্টারিং ক্ষমতা গোপনীয়তা বৃদ্ধি, "
+"ওয়েব পেজ ডেটা এবং এইচটিটিপি হেডার পরিবর্তন, অ্যাক্সেস নিয়ন্ত্রণ এবং বিজ্ঞাপন এবং "
+"অন্যান্য অপ্রীতিকর ইন্টারনেট আবর্জনা অপসারণ করে থাকে।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "লগ ফাইল পড়ুন / পুনরায় পড়ুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "I/O অবস্থা দেখুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "প্রতিটি সংযোগের অবস্থা দেখান"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "হেডার পার্সিং দেখান"
 
@@ -396,25 +390,23 @@ msgstr "শুরু/শেষ করুন"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Privoxy ওয়েব প্রক্সি শুরু/বন্ধ করুন"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "স্টার্টআপ ব্যানার এবং সতর্কতা।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "সিনট্যাক্স:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "সিনট্যাক্স: ক্লায়েন্ট হেডারের নাম স্পেস দ্বারা সীমাবদ্ধ।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "সিনট্যাক্স: target_pattern http_parent [: port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "সিনট্যাক্স: target_pattern socks_proxy [: port] http_parent [: port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -434,13 +426,13 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr "ঠিকানা এবং টিসিপি পোর্ট যেখানে Privoxy ক্লায়েন্টের অনুরোধ শুনবে।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
 msgstr ""
-"বাফার করা কন্টেন্ট সংকুচিত করার সময় zlib লাইব্রেরিতে যে কম্প্রেশন লেভেলটি "
-"পাঠানো হয়।"
+"বাফার করা কন্টেন্ট সংকুচিত করার সময় zlib লাইব্রেরিতে যে কম্প্রেশন লেভেলটি পাঠানো "
+"হয়।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:252
 msgid ""
@@ -457,8 +449,7 @@ msgid ""
 "The filter files contain content modification rules that use regular "
 "expressions."
 msgstr ""
-"ফিল্টার ফাইলগুলিতে কন্টেন্ট পরিবর্তনের নিয়ম রয়েছে যা রেগুলার এক্সপ্রেশন "
-"ব্যবহার করে।"
+"ফিল্টার ফাইলগুলিতে কন্টেন্ট পরিবর্তনের নিয়ম রয়েছে যা রেগুলার এক্সপ্রেশন ব্যবহার করে।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:183
 msgid "The hostname shown on the CGI pages."
@@ -468,63 +459,60 @@ msgstr "CGI পৃষ্ঠাগুলিতে প্রদর্শিত হ
 msgid "The log file to use. File name, relative to log directory."
 msgstr "ব্যবহার করার জন্য লগ ফাইল। ফাইলের নাম, লগ ডিরেক্টরির ভিত্তিতে।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr "যে ক্রমে ক্লায়েন্ট হেডারগুলি ফরওয়ার্ড করার আগে সাজানো হয়।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
 msgstr ""
-"যে স্ট্যাটাস কোড Privoxy +handle-as-empty-document দ্বারা ব্লক করা পেজের জন্"
-"য পাঠায়।"
+"যে স্ট্যাটাস কোড Privoxy +handle-as-empty-document দ্বারা ব্লক করা পেজের জন্য "
+"পাঠায়।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:413
 msgid ""
 "The trust mechanism is an experimental feature for building white-lists and "
 "should be used with care."
 msgstr ""
-"ট্রাস্ট মেকানিজম সাদা তালিকা তৈরির জন্য একটি পরীক্ষামূলক বৈশিষ্ট্য এবং এটি "
-"যত্ন সহকারে ব্যবহার করা উচিত।"
+"ট্রাস্ট মেকানিজম সাদা তালিকা তৈরির জন্য একটি পরীক্ষামূলক বৈশিষ্ট্য এবং এটি যত্ন "
+"সহকারে ব্যবহার করা উচিত।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:238
 msgid ""
 "The value of this option only matters if the experimental trust mechanism "
 "has been activated."
-msgstr ""
-"পরীক্ষামূলক ট্রাস্ট মেকানিজম সক্রিয় করা হলেই এই অপশনের মান গুরুত্বপূর্ণ।"
+msgstr "পরীক্ষামূলক ট্রাস্ট মেকানিজম সক্রিয় করা হলেই এই অপশনের মান গুরুত্বপূর্ণ।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
 msgstr ""
-"এই অপশনটি কেবল ডিবাগিং উদ্দেশ্যেই রয়েছে। এটি কর্মক্ষমতাকে ব্যাপকভাবে হ্রাস "
-"করবে।"
+"এই অপশনটি কেবল ডিবাগিং উদ্দেশ্যেই রয়েছে। এটি কর্মক্ষমতাকে ব্যাপকভাবে হ্রাস করবে।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:574
 msgid ""
 "This option will be removed in future releases as it has been obsoleted by "
 "the more general header taggers."
 msgstr ""
-"এই অপশনটি ভবিষ্যতের রিলিজগুলিতে সরানো হবে কারণ এটি আরও সাধারণ হেডার ট্যাগারদে"
-"র দ্বারা অপ্রচলিত হয়ে গেছে।"
+"এই অপশনটি ভবিষ্যতের রিলিজগুলিতে সরানো হবে কারণ এটি আরও সাধারণ হেডার ট্যাগারদের "
+"দ্বারা অপ্রচলিত হয়ে গেছে।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:85
 msgid ""
 "This tab controls the security-relevant aspects of Privoxy's configuration."
 msgstr ""
-"এই ট্যাবটি Privoxy-এর কনফিগারেশনের নিরাপত্তা-প্রাসঙ্গিক দিকগুলি নিয়ন্ত্রণ "
-"করে।"
+"এই ট্যাবটি Privoxy-এর কনফিগারেশনের নিরাপত্তা-প্রাসঙ্গিক দিকগুলি নিয়ন্ত্রণ করে।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
 msgstr ""
-"যে SOCKS প্রক্সির (এবং সেইসাথে অভিভাবক HTTP প্রক্সি) মাধ্যমে অনুরোধ পাঠানো "
-"হবে।"
+"যে SOCKS প্রক্সির (এবং সেইসাথে অভিভাবক HTTP প্রক্সি) মাধ্যমে অনুরোধ পাঠানো হবে।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:610
 msgid "To which parent HTTP proxy specific requests should be routed."
@@ -536,11 +524,11 @@ msgstr "ব্যবহারকারীর কাস্টমাইজেশ�
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "মান কোন সংখ্যা নয়"
 
@@ -548,7 +536,7 @@ msgstr "মান কোন সংখ্যা নয়"
 msgid "Value not between 0 and 300"
 msgstr "মান 0 এবং 300 এর মধ্যে নয়"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "মান 0 এবং 9 এর মধ্যে নয়"
 
@@ -556,10 +544,10 @@ msgstr "মান 0 এবং 9 এর মধ্যে নয়"
 msgid "Value not between 1 and 4096"
 msgstr "মান 1 এবং 4096 এর মধ্যে নয়"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "মান 0-এর বেশি নয় বা খালি"
 
@@ -577,7 +565,7 @@ msgstr "সংস্করণ"
 msgid "Version Information"
 msgstr "সংস্করণ সংক্রান্ত তথ্য"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "বাধা দেওয়া অনুরোধগুলিকে বৈধ বলে গণ্য করা উচিত কিনা।"
 
@@ -585,22 +573,21 @@ msgstr "বাধা দেওয়া অনুরোধগুলিকে ব
 msgid ""
 "Whether or not Privoxy recognizes special HTTP headers to change toggle "
 "state."
-msgstr ""
-"Privoxy টগল স্টেট পরিবর্তন করার জন্য বিশেষ HTTP হেডার স্বীকৃতি দেয় কি না।"
+msgstr "Privoxy টগল স্টেট পরিবর্তন করার জন্য বিশেষ HTTP হেডার স্বীকৃতি দেয় কি না।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "বাফার করা কন্টেন্ট ডেলিভারির আগে সংকুচিত হয় কিনা।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
-"বহির্গামী সংযোগগুলি যা জীবিত রাখা হয়েছে তা বিভিন্ন ইনকামিং সংযোগের মধ্যে ভা"
-"গ করা উচিত কিনা।"
+"বহির্গামী সংযোগগুলি যা জীবিত রাখা হয়েছে তা বিভিন্ন ইনকামিং সংযোগের মধ্যে ভাগ করা "
+"উচিত কিনা।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "পাইপলাইন করা অনুরোধগুলি পরিবেশন করা উচিত কি না।"
 
@@ -616,18 +603,16 @@ msgstr "ওয়েব-ভিত্তিক অ্যাকশন ফাইল
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "ওয়েব-ভিত্তিক টগল ফিচার ব্যবহার করা যাবে কি না।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr "Privoxy-এর CGI পেজের অনুরোধগুলি ব্লক করা বা পুননির্দেশিত করা যাবে কিনা।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
-msgstr ""
-"CGI ইন্টারফেসের বিচ্ছিন্ন HTTP ক্লায়েন্টদের সাথে সামঞ্জস্যপূর্ণ থাকা উচিত "
-"কিনা।"
+msgstr "CGI ইন্টারফেসের বিচ্ছিন্ন HTTP ক্লায়েন্টদের সাথে সামঞ্জস্যপূর্ণ থাকা উচিত কিনা।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "শুধুমাত্র একটি সার্ভার থ্রেড চালানো হবে কিনা।"
 
@@ -652,3 +637,6 @@ msgstr "বা উচ্চতর"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "আবশ্যক"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "সিনট্যাক্স: target_pattern socks_proxy [: port] http_parent [: port]"

--- a/applications/luci-app-privoxy/po/ca/privoxy.po
+++ b/applications/luci-app-privoxy/po/ca/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Retard d'arrencada"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/cs/privoxy.po
+++ b/applications/luci-app-privoxy/po/cs/privoxy.po
@@ -48,7 +48,7 @@ msgstr "Alternativní adresář, ze kterého jsou načítany šablony."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "E-mailová adresa správce Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -60,11 +60,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Zpoždění bootu"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Uživatelské rozhraní CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Společný formát protokolu"
 
@@ -78,19 +78,19 @@ msgstr ""
 "servery mohou výrazně snížit úroveň soukromí. Zde také můžete zadat SOCKS "
 "proxy servery."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Protokolovat GIF de-animace"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Protokolovat 'force' vlastnosti"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Protokolovat přesměrování"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Protokolovat filtry regulárních výrazů"
 
@@ -150,7 +150,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Soubor '%s' nebyl nalezen v konfiguračním adresáři"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Soubor nebyl nalezen nebo je prázdný"
@@ -206,19 +206,19 @@ msgstr "Umístění uživatelského manuálu Privoxy."
 msgid "Log File Viewer"
 msgstr "Prohlížeč souborů protokolu"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Protokolovat všechna data příchozí ze sítě"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Protokolovat všechna data odchozí do sítě"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Protokolovat aplikované akce"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -226,7 +226,7 @@ msgstr ""
 "Protokolovat cíl každého požadavku, který Privoxy propustí. Vizte také "
 "'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -275,7 +275,7 @@ msgstr "Povinný vstup: Nebyla zadána žádná platná IPv6 adresa!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Povinný vstup: Nebyl zadán žádný platný port!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Maximální počet klientských spojení, které budou obsluhovány."
 
@@ -298,18 +298,18 @@ msgstr "NENÍ nainstalováno"
 msgid "No trailing '/', please."
 msgstr "Nepoužívejte koncové '/', prosím."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Nezávažné chyby -*důrazně doporučujeme toto povolit*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Počet sekund, po kterých vyprší časový limit, pokud nejsou přijata žádná "
 "data."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "Počet sekund, po kterých již nebude otevřené připojení znovu použito."
@@ -324,7 +324,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Nainstalujte prosím aktuální verzi!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Prosím, stiskněte tlačítko [Načíst]"
 
@@ -362,19 +362,19 @@ msgstr ""
 "hlaviček, řídící přístup a odebírající reklamy a ostatní otravné internetové "
 "smetí."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Načíst / znovu načíst soubor protokolu"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Zobrazit stav I/O"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Zobrazit stav každého připojení"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Zobrazit analýzu hlavičky"
 
@@ -399,25 +399,23 @@ msgstr "Spustit / zastavit"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Spustit / zastavit Privoxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Úvodní nápis a upozornění."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Syntaxe:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Syntaxe: Názvy hlaviček klienta odděleny mezerami."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Syntax: target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -438,7 +436,7 @@ msgid ""
 msgstr ""
 "Adresa a port TCP, na kterém bude Privoxy naslouchat požadavkům klientů."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -476,12 +474,12 @@ msgstr ""
 "Soubor protokolu, který má být použit. Název souboru relativní k adresáři "
 "protokolu."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "Pořadí, ve kterém jsou tříděny hlavičky klientů před jejich přeposláním."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -505,7 +503,7 @@ msgstr ""
 "Hodnota této možnosti je důležitá pouze v případě, že byl aktivován "
 "experimentální mechanismus důvěryhodnosti."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -526,6 +524,7 @@ msgid ""
 msgstr "Tato záložka řídí bezpečnostní aspekty konfigurace Privoxy."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -545,11 +544,11 @@ msgstr "Uživatelské úpravy"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Hodnota není číslo"
 
@@ -557,7 +556,7 @@ msgstr "Hodnota není číslo"
 msgid "Value not between 0 and 300"
 msgstr "Hodnota není v rozsahu 0 až 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Hodnota není v rozmezí 0 až 9"
 
@@ -565,10 +564,10 @@ msgstr "Hodnota není v rozmezí 0 až 9"
 msgid "Value not between 1 and 4096"
 msgstr "Hodnota není v rozmezí 1 and 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Hodnota není větší než 0, nebo je prázdná"
 
@@ -586,7 +585,7 @@ msgstr "Verze"
 msgid "Version Information"
 msgstr "Informace o verzi"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Zda mají být zachycené požadavky považovány za platné."
 
@@ -596,11 +595,11 @@ msgid ""
 "state."
 msgstr "Zda má Privoxy rozpoznávat speciální HTTP hlavičky pro změnu stavu."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "Zda je vyrovnávací obsah komprimován před doručením."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -608,7 +607,7 @@ msgstr ""
 "Zda mají být odchozí spojení, která byla zachována, sdílena mezi různými "
 "příchozími spojeními."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Zda odbavovat zařazené (pipelined) požadavky."
 
@@ -625,17 +624,17 @@ msgstr "Zda lze použít webový editor pro úpravu souborů akcí."
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Zda může být použita webová přepínací funkce."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Zda mohou být požadavky na CGI stránky v Privoxy blokovány nebo přesměrovány."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr "Zda má rozhraní CGI zůstat kompatibilní s rozbitými HTTP klienty."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Zda má být spuštěno pouze jedno serverové vlákno."
 
@@ -660,3 +659,6 @@ msgstr "nebo vyšší"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "vyžadováno"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"

--- a/applications/luci-app-privoxy/po/da/privoxy.po
+++ b/applications/luci-app-privoxy/po/da/privoxy.po
@@ -45,7 +45,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -57,11 +57,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -72,19 +72,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -191,25 +191,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -258,7 +258,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -281,16 +281,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -335,19 +335,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -372,24 +372,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -408,7 +406,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -438,11 +436,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -460,7 +458,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -478,6 +476,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -493,11 +492,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -505,7 +504,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -513,10 +512,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -534,7 +533,7 @@ msgstr "Version"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -544,17 +543,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -570,16 +569,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/de/privoxy.po
+++ b/applications/luci-app-privoxy/po/de/privoxy.po
@@ -53,7 +53,7 @@ msgstr "Eine alternatives Verzeichnis, aus dem die Vorlagen geladen werden."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Eine E-Mail-Adresse, um die Privoxy-Administrator zu erreichen."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -65,11 +65,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Systemstart-Verzögerung"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Protokolliert die CGI Benutzer Schnittstelle"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Gemeinsames Protokollformat"
 
@@ -84,19 +84,19 @@ msgstr ""
 "Privatsphäre stark einschränken können. Auch hier angegeben werden SOCKS-"
 "Proxies."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Protokolliert die GIF de-animation"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Protokolliert die 'Force' Eigenschaft"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Protokolliert Weiterleitungen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Protokolliert Filter für reguläre Ausdrücke"
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Datei '%s' nicht im Konfigurationsverzeichnis gefunden"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Datei nicht gefunden oder leer"
@@ -215,19 +215,19 @@ msgstr "Ort des Privoxy Benutzer Handbuches."
 msgid "Log File Viewer"
 msgstr "Protokolldateibetrachter"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Protokolliert alle Daten, die vom Netzwerk gelesen werden"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Protokolliert alle Daten, die auf das Netzwerk geschrieben werden"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Protokiolliert angewendete Aktionen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -235,7 +235,7 @@ msgstr ""
 "Protokolliert das Ziel für jede Anforderung die Privoxy durchlässt. Siehe "
 "auch 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -287,7 +287,7 @@ msgstr "Pflichtfeld: Keine gültige IPv6 Adresse angegeben!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Pflichtfeld: Keine gültige Port Nummer angegeben!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Maximale Anzahl von Client-Verbindungen."
 
@@ -310,20 +310,20 @@ msgstr "NICHT installiert"
 msgid "No trailing '/', please."
 msgstr "Bitte kein '/' am Ende."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 "Protokolliert nicht schwerwiegende Fehler - * Es wird dringend empfohlen, "
 "dieses zu aktivieren *"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Anzahl der Sekunden, nach der eine Socket Timeout erfolgt, wenn keine Daten "
 "empfangen werden."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Installieren Sie bitte die aktuelle Version!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Bitte Protokolldatei einlesen"
 
@@ -380,19 +380,19 @@ msgstr ""
 "Header, kontrolliert den Zugang und das Entfernen von Anzeigen und anderem "
 "abscheulichen Internet Schrott."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Protokolldatei (neu) einlesen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Protokolliert den I/O Status"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Protokolliert jeden Verbindungsstatus"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Protokolliert das 'Header parsing'"
 
@@ -417,25 +417,23 @@ msgstr "Start / Stopp"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Start/Stopp Privoxy WEB Proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Protokolliert Start-Meldungen und Warnungen."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Syntax:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Syntax: Client header Namen getrennt durch Leerzeichen."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Syntax: target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -457,7 +455,7 @@ msgstr ""
 "Die Adresse und das TCP-Port, auf dem Privoxy auf Client-Anforderungen "
 "wartet."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -492,13 +490,13 @@ msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 "Zu verwendende Protokolldatei. Dateiname relativ zum Protokoll-Verzeichnis."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "Die Reihenfolge, in der Client-Header sortiert werden, bevor sie "
 "weitergeleitet werden."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -522,7 +520,7 @@ msgstr ""
 "Der Wert dieser Option ist nur wirksam, wenn der experimentelle Trust-"
 "Mechanismus aktiviert wurde."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -544,6 +542,7 @@ msgstr ""
 "Konfiguration."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -563,11 +562,11 @@ msgstr "Benutzerdefinierte Anpassungen"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Wert ist keine Zahl"
 
@@ -575,7 +574,7 @@ msgstr "Wert ist keine Zahl"
 msgid "Value not between 0 and 300"
 msgstr "Wert nicht zwischen 0 und 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Wert nicht zwischen 0 und 9"
 
@@ -583,10 +582,10 @@ msgstr "Wert nicht zwischen 0 und 9"
 msgid "Value not between 1 and 4096"
 msgstr "Wert nicht zwischen 1 und 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Wert nicht größer 0 oder leer"
 
@@ -604,7 +603,7 @@ msgstr "Version"
 msgid "Version Information"
 msgstr "Versionsinformationen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Ob abgefangen Anfragen als gültig behandelt werden."
 
@@ -616,12 +615,12 @@ msgstr ""
 "Ob Privoxy erkannte spezielle HTTP-Header zur Änderung des Toggle-Status "
 "verwendet.."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 "Ob gepufferte Inhalte vor der Weiterleitung komprimiert werden oder nicht."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -629,7 +628,7 @@ msgstr ""
 "Ob ausgehende Verbindungen, die am Leben gehalten werden, für verschiedenen "
 "eingehenden Verbindungen gemeinsam genutzt werden oder nicht."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Ob Pipeline-Anfragen bedient werden oder nicht."
 
@@ -646,20 +645,20 @@ msgstr "De-/Aktiviert den webbasierte Action-Datei Editor."
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "De-Aktiviert die webbasierte Umschaltfunktion."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Ob Anfragen an Privoxy CGI-Seiten gesperrt oder umgeleitet werden können "
 "oder nicht."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Ob die CGI-Schnittstelle mit broken HTTP-Clients kompatibel bleibt oder "
 "nicht."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Ob nur ein Server-Thread ausgeführt wird."
 
@@ -684,6 +683,9 @@ msgstr "oder höher"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "erforderlich"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #~ msgid "Local Set-up"
 #~ msgstr "Lokale Einstellungen"

--- a/applications/luci-app-privoxy/po/el/privoxy.po
+++ b/applications/luci-app-privoxy/po/el/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/en/privoxy.po
+++ b/applications/luci-app-privoxy/po/en/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr "Version"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/es/privoxy.po
+++ b/applications/luci-app-privoxy/po/es/privoxy.po
@@ -53,7 +53,7 @@ msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 "Una dirección de correo electrónico para llegar al administrador de Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -65,11 +65,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Retraso de arranque"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interfaz de usuario CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Formato de registro común"
 
@@ -84,19 +84,19 @@ msgstr ""
 "disminuir considerablemente su nivel de privacidad. También se especifican "
 "aquí los proxies SOCKS."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Depurar GIF desaminación"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Depurar característica de fuerza"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Depurar redirecciones"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Depurar filtros de expresiones regulares"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "El archivo '%s' no se encuentra dentro del directorio de configuración"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Archivo no encontrado o vacío"
@@ -214,19 +214,19 @@ msgstr "Ubicación del manual de usuario de Privoxy."
 msgid "Log File Viewer"
 msgstr "Visor de Archivo de Registro"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Registrar todos los datos leídos desde la red"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Registrar todos los datos escritos en la red"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Registrar las acciones de aplicación"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -234,7 +234,7 @@ msgstr ""
 "Registrar el destino para cada solicitud que Privoxy dejó pasar. Véase "
 "también 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -288,7 +288,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Entrada obligatoria: ¡No se ha dado un puerto válido!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Número máximo de conexiones de clientes que se atenderán."
 
@@ -311,18 +311,18 @@ msgstr "No instalado"
 msgid "No trailing '/', please."
 msgstr "No hay '/' al final, por favor."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Errores no fatales - *recomendamos encarecidamente activar esto*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Número de segundos después de los cuales se agota un socket si no se reciben "
 "datos."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Por favor, instale la versión actual!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Por favor presione el botón [Leer]"
 
@@ -378,19 +378,19 @@ msgstr ""
 "web y los encabezados HTTP, controlar el acceso y eliminar anuncios y otros "
 "datos basura desagradables de Internet."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Leer / Releer el archivo de registro"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Mostrar estado de E/S"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Mostrar el estado de cada conexión"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Mostrar encabezado analizando"
 
@@ -415,25 +415,23 @@ msgstr "Iniciar / Detener"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Iniciar/Detener Privoxy WEB Proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Banner de inicio y advertencias."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sintaxis:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Sintaxis: Nombres de encabezado de cliente delimitados por espacios."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Sintaxis: target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Sintaxis: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -455,7 +453,7 @@ msgstr ""
 "La dirección y el puerto TCP en el que Privoxy escuchará las solicitudes de "
 "los clientes."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -493,13 +491,13 @@ msgstr ""
 "El archivo de registro a utilizar. Nombre del archivo, relativo al "
 "directorio de registro."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "El orden en que se clasifican los encabezados de los clientes antes de "
 "reenviarlos."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -523,7 +521,7 @@ msgstr ""
 "El valor de esta opción solo importa si se ha activado el mecanismo de "
 "confianza experimental."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -547,6 +545,7 @@ msgstr ""
 "configuración de Privoxy."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -566,11 +565,11 @@ msgstr "Personalizaciones de usuario"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "El valor no es un número"
 
@@ -578,7 +577,7 @@ msgstr "El valor no es un número"
 msgid "Value not between 0 and 300"
 msgstr "Valor no entre 0 y 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Valor no entre 0 y 9"
 
@@ -586,10 +585,10 @@ msgstr "Valor no entre 0 y 9"
 msgid "Value not between 1 and 4096"
 msgstr "Valor no entre 1 y 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Valor no mayor a 0 o vacío"
 
@@ -607,7 +606,7 @@ msgstr "Versión"
 msgid "Version Information"
 msgstr "Información de versión"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Si las solicitudes interceptadas deben tratarse como válidas."
 
@@ -619,12 +618,12 @@ msgstr ""
 "Si Privoxy reconoce o no encabezados HTTP especiales para cambiar el estado "
 "de conmutación."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 "Si el contenido almacenado en búfer se comprime o no antes de la entrega."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -632,7 +631,7 @@ msgstr ""
 "Si las conexiones salientes que se han mantenido vivas deben compartirse "
 "entre diferentes conexiones entrantes."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Si las solicitudes canalizadas deben ser atendidas o no."
 
@@ -649,19 +648,19 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Si se puede usar o no la función de conmutación basada en la web."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Si las solicitudes a las páginas CGI de Privoxy se pueden bloquear o "
 "redirigir."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Si la interfaz CGI debe permanecer compatible con los clientes HTTP rotos."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Ya sea para ejecutar un solo hilo del servidor."
 
@@ -686,3 +685,6 @@ msgstr "o mas alto"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "requerido"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Sintaxis: target_pattern socks_proxy[:port] http_parent[:port]"

--- a/applications/luci-app-privoxy/po/fi/privoxy.po
+++ b/applications/luci-app-privoxy/po/fi/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr "Versio"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/fr/privoxy.po
+++ b/applications/luci-app-privoxy/po/fr/privoxy.po
@@ -49,7 +49,7 @@ msgstr "Dossier alternatif depuis lequel les templates peuvent être chargés."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Une adresse email pour joindre l'administrateur du Privoxy ."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -61,11 +61,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Délai de démarrage"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interface utilisateur CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Format de journal commun"
 
@@ -79,19 +79,19 @@ msgstr ""
 "plusieurs proxy. Notez que les proxy parent peuvent réduire considérablement "
 "votre niveau de confidentialité. Les proxy SOCKS sont également spécifié ici."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Debug GIF désanimé"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Debug forcer la fonctionnalité"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Debug rediriger"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Debug filtres d'expression régulière"
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Pas de fichier '%s' trouvé dans le répertoire Configuration"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Fichier introuvable ou vide"
@@ -209,19 +209,19 @@ msgstr "Emplacement du manuel d'utilisation de Privoxy."
 msgid "Log File Viewer"
 msgstr "Visualiseur de fichier de journa"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Enregistrer toutes les données lues à partir du réseau"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Enregistrer toutes les données écrites à partir du réseau"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Journaliser les actions appliqués"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -229,7 +229,7 @@ msgstr ""
 "Journaliser la destination pour chaque requêtes que Privoxy à laissé passer. "
 "Allez aussi voir 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -280,7 +280,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -303,18 +303,18 @@ msgstr "NON installé"
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Nombre de secondes après lesquelles un socket expire si aucune donnée n’est "
 "reçue."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -328,7 +328,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Veuillez appuyer sur le bouton [Lire]"
 
@@ -359,19 +359,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Lire/Relire le fichier de journal"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -396,24 +396,22 @@ msgstr "Démarrer/Arrêter"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Syntaxe:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -434,7 +432,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -466,11 +464,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -492,7 +490,7 @@ msgstr ""
 "La valeur de cette option ne compte que si le mécanisme expérimental de "
 "confiance a été activé."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -512,6 +510,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -529,11 +528,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -541,7 +540,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -549,10 +548,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -570,7 +569,7 @@ msgstr "Version"
 msgid "Version Information"
 msgstr "Informations de version"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -580,11 +579,11 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -592,7 +591,7 @@ msgstr ""
 "Indique si les connexions sortantes qui ont été maintenues en vie doivent ou "
 "non être partagées entre différentes connexions entrantes."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -608,16 +607,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/he/privoxy.po
+++ b/applications/luci-app-privoxy/po/he/privoxy.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -47,11 +47,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -62,19 +62,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -181,25 +181,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -271,16 +271,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -294,7 +294,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -325,19 +325,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -362,24 +362,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -398,7 +396,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -428,11 +426,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -450,7 +448,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -468,6 +466,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -483,11 +482,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -495,7 +494,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -503,10 +502,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -524,7 +523,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -534,17 +533,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -560,16 +559,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/hi/privoxy.po
+++ b/applications/luci-app-privoxy/po/hi/privoxy.po
@@ -48,7 +48,7 @@ msgstr "एक वैकल्पिक निर्देशिका जहा
 msgid "An email address to reach the Privoxy administrator."
 msgstr "प्रिविक्सी व्यवस्थापक तक पहुंचने के लिए एक ईमेल पता।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -60,11 +60,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "बूट में देरी"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "सीजीआई यूजर इंटरफेस"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "सामान्य लॉग प्रारूप"
 
@@ -78,19 +78,19 @@ msgstr ""
 "कि माता-पिता की निकटता आपके गोपनीयता स्तर को गंभीर रूप से कम कर सकती है। यहाँ भी "
 "निर्दिष्ट SOCKS परदे के पीछे हैं।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "डीबग GIF डे-एनीमेशन"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "डीबग बल सुविधा"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "डिबग पुनर्निर्देश"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "नियमित एक्सप्रेशन फ़िल्टर डीबग करें"
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "कॉन्फ़िगरेशन निर्देशिका के अंदर फ़ाइल '% s' नहीं मिली"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "फ़ाइल नहीं मिली या खाली नहीं है"
@@ -204,25 +204,25 @@ msgstr "प्रिविक्सी यूजर मैनुअल का �
 msgid "Log File Viewer"
 msgstr "लॉग फ़ाइल व्यूअर"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "नेटवर्क से पढ़े गए सभी डेटा को लॉग करें"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "नेटवर्क पर लिखे गए सभी डेटा को लॉग इन करें"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "आवेदन क्रियाओं को लॉग इन करें"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr "प्रत्येक अनुरोध के लिए गंतव्य लॉग इन करें। 'डिबग 1024' भी देखें।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -271,7 +271,7 @@ msgstr "अनिवार्य इनपुट: कोई मान्य IPv6
 msgid "Mandatory Input: No valid Port given!"
 msgstr "अनिवार्य इनपुट: कोई मान्य पोर्ट नहीं दिया गया है!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "अधिकतम ग्राहक कनेक्शन जो परोसे जाएंगे।"
 
@@ -294,16 +294,16 @@ msgstr "स्थापित नहीं है"
 msgid "No trailing '/', please."
 msgstr "कोई अनुगामी '/', कृपया।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "गैर-घातक त्रुटियां - * हमने इसे सक्षम करने की अत्यधिक अनुशंसा की *"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr "यदि कोई डेटा प्राप्त नहीं होता है तो सॉकेट समय के बाद सेकंड की संख्या।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "सेकंड की संख्या जिसके बाद एक खुला कनेक्शन अब पुन: उपयोग नहीं किया जाएगा।"
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "कृपया वर्तमान संस्करण स्थापित करें!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "कृपया [पढ़ें] बटन दबाएं"
 
@@ -355,19 +355,19 @@ msgstr ""
 "नियंत्रित करने और विज्ञापनों और अन्य अप्रिय इंटरनेट कबाड़ को हटाने के लिए उन्नत फ़िल्टरिंग "
 "क्षमताओं के साथ एक गैर-कैशिंग वेब प्रॉक्सी है।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "पढ़ें / लॉग फ़ाइल पुनः चलाएँ"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "I / O स्थिति दिखाएं"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "प्रत्येक कनेक्शन की स्थिति दिखाएं"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "हेडर पार्सिंग दिखाएं"
 
@@ -392,25 +392,23 @@ msgstr "चालू / बंद"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Privoxy WEB प्रॉक्सी शुरू / बंद करें"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "स्टार्टअप बैनर और चेतावनी।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "वाक्य - विन्यास:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "सिंटैक्स: क्लाइंट हेडर नाम रिक्त स्थान द्वारा सीमांकित।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "सिंटैक्स: target_pattern http_parent [:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "सिंटैक्स: target_pattern मोजे_प्रोक्सी [:port] http_parent [:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -430,7 +428,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr "पता और टीसीपी पोर्ट जिस पर प्रिविक्स क्लाइंट अनुरोधों के लिए सुनेंगे।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -461,11 +459,11 @@ msgstr "होस्टनाम सीजीआई पृष्ठों पर
 msgid "The log file to use. File name, relative to log directory."
 msgstr "लॉग फ़ाइल का उपयोग करने के लिए। फ़ाइल नाम, लॉग निर्देशिका के सापेक्ष।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr "जिस क्रम में क्लाइंट हेडर को अग्रेषित करने से पहले क्रमबद्ध किया जाता है।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -486,7 +484,7 @@ msgid ""
 msgstr ""
 "इस विकल्प का मूल्य केवल तभी मायने रखता है जब प्रयोगात्मक ट्रस्ट तंत्र सक्रिय हो गया हो।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -506,6 +504,7 @@ msgid ""
 msgstr "यह टैब प्रिविक्सी के कॉन्फ़िगरेशन के सुरक्षा-प्रासंगिक पहलुओं को नियंत्रित करता है।"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -523,11 +522,11 @@ msgstr "उपयोगकर्ता अनुकूलन"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "मान एक संख्या नहीं है"
 
@@ -535,7 +534,7 @@ msgstr "मान एक संख्या नहीं है"
 msgid "Value not between 0 and 300"
 msgstr "मान 0 और 300 के बीच नहीं"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "मान 0 और 9 के बीच नहीं"
 
@@ -543,10 +542,10 @@ msgstr "मान 0 और 9 के बीच नहीं"
 msgid "Value not between 1 and 4096"
 msgstr "मान 1 और 4096 के बीच नहीं"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "मान 0 या खाली नहीं है"
 
@@ -564,7 +563,7 @@ msgstr "संस्करण"
 msgid "Version Information"
 msgstr "संस्करण जानकारी"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "क्या इंटरसेप्टेड अनुरोधों को वैध माना जाना चाहिए।"
 
@@ -574,11 +573,11 @@ msgid ""
 "state."
 msgstr "Privoxy टॉगल स्थिति को बदलने के लिए विशेष HTTP हेडर को पहचानती है या नहीं।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "डिलीवरी से पहले बफ़र्ड कंटेंट को कंप्रेस किया जाता है या नहीं।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -586,7 +585,7 @@ msgstr ""
 "आउटगोइंग कनेक्शन जिन्हें जीवित रखा गया है या नहीं, उन्हें विभिन्न आवक कनेक्शनों के बीच साझा "
 "किया जाना चाहिए।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "पाइपलाइन किए गए अनुरोधों को सेवा दी जानी चाहिए या नहीं।"
 
@@ -602,17 +601,17 @@ msgstr "वेब-आधारित क्रिया फ़ाइल सं�
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "वेब-आधारित टॉगल सुविधा का उपयोग किया जा सकता है या नहीं।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "क्या प्रिविक्सी के CGI पृष्ठों के अनुरोधों को अवरुद्ध या पुनर्निर्देशित किया जा सकता है।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr "क्या सीजीआई इंटरफ़ेस टूटे हुए HTTP क्लाइंट के साथ संगत रहना चाहिए।"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "केवल एक सर्वर थ्रेड को चलाना है या नहीं।"
 
@@ -637,3 +636,6 @@ msgstr "या ऊँचा"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "अपेक्षित"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "सिंटैक्स: target_pattern मोजे_प्रोक्सी [:port] http_parent [:port]"

--- a/applications/luci-app-privoxy/po/hu/privoxy.po
+++ b/applications/luci-app-privoxy/po/hu/privoxy.po
@@ -49,7 +49,7 @@ msgstr "Egy alternatív könyvtár, ahonnan a sablonok betöltésre kerülnek."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Egy e-mail cím a Privoxy adminisztrátorának eléréséhez."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -61,11 +61,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Rendszerindítási késleltetés"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGI felhasználói felület"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Gyakori naplóformátum"
 
@@ -79,19 +79,19 @@ msgstr ""
 "feledje, hogy a szülőproxyk erősen csökkenthetik az adatvédelmi szintet. Itt "
 "adhatók meg a SOCKS proxyk is."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "GIF-animáció megszüntetésének hibakeresése"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Kényszerítés funkció hibakeresése"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Átirányítások hibakeresése"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Reguláris kifejezés szűrőinek hibakeresése"
 
@@ -152,7 +152,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "A(z) „%s” fájl nem található a beállítási könyvtáron belül"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "A fájl nem található vagy üres"
@@ -210,19 +210,19 @@ msgstr "A Privoxy felhasználói kézikönyvének helye."
 msgid "Log File Viewer"
 msgstr "Naplófájl-megjelenítő"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "A hálózatról olvasott összes adat naplózása"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "A hálózatra írt összes adat naplózása"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Az alkalmazott műveletek naplózása"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -230,7 +230,7 @@ msgstr ""
 "Azon kérések céljainak naplózása, amelyeket a Privoxy átenged. Nézze meg még "
 "az „1024 hibakeresést”."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -281,7 +281,7 @@ msgstr "Kötelező bemenet: nincs érvényes IPv6-cím megadva!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Kötelező bemenet: nincs érvényes port megadva!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Ügyfélkapcsolatok legnagyobb száma, amely ki lesz szolgálva."
 
@@ -304,18 +304,18 @@ msgstr "Nincs telepítve"
 msgid "No trailing '/', please."
 msgstr "Ne használjon záró „/” karakter."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Nem végzetes hibák – *erősen ajánljuk ennek engedélyezését*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Másodpercek száma, amely után egy foglalat túllépi az időkorlátot, ha nem "
 "érkezik adat."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Telepítse a jelenlegi verziót!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Nyomja meg a [Beolvasás] gombot"
 
@@ -371,19 +371,19 @@ msgstr ""
 "módosításához, a hozzáférés szabályozásához, valamint a reklámok és egyéb "
 "kellemetlen internetes szemét eltávolításához."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Naplófájl olvasása vagy újraolvasása"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "I/O állapot megjelenítése"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Minden kapcsolatállapot megjelenítése"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Fejléc feldolgozásának megjelenítése"
 
@@ -408,25 +408,23 @@ msgstr "Indítás vagy leállítás"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Privoxy webes proxy indítása vagy leállítása"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Rendszerindítási reklámcsík és figyelmeztetések."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Elrendezés:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Szintaxis: szóközzel elválasztott ügyfélfejlécnevek."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Szintaxis: cél_minta http_szülő[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Szintaxis: cél_minta socks_proxy[:port] http_szülő[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -447,7 +445,7 @@ msgid ""
 msgstr ""
 "A cím és a TCP port, amelyen a Privoxy figyelni fogja az ügyfélkéréseket."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -483,12 +481,12 @@ msgstr "A CGI-oldalakon megjelenített gépnév."
 msgid "The log file to use. File name, relative to log directory."
 msgstr "A használandó naplófájl. Fájlnév a naplózási könyvtártól relatívan."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "A sorrend, amelyben az ügyfélfejlécek rendezve vannak a továbbításuk előtt."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -512,7 +510,7 @@ msgstr ""
 "Ennek a beállításnak az értéke csak akkor számít, ha a kísérleti "
 "megbízhatóság mechanizmus be lett kapcsolva."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -535,6 +533,7 @@ msgstr ""
 "Ez a lap vezérli a Privoxy beállításának biztonságra vonatkozó szempontjait."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -552,11 +551,11 @@ msgstr "Felhasználói személyre szabások"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Az érték nem szám"
 
@@ -564,7 +563,7 @@ msgstr "Az érték nem szám"
 msgid "Value not between 0 and 300"
 msgstr "Az érték nem 0 és 300 között van"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Az érték nem 0 és 9 között van"
 
@@ -572,10 +571,10 @@ msgstr "Az érték nem 0 és 9 között van"
 msgid "Value not between 1 and 4096"
 msgstr "Az érték nem 1 és 4096 között van"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Az érték nem nagyobb mint 0 vagy üres"
 
@@ -594,7 +593,7 @@ msgstr "Verzió"
 msgid "Version Information"
 msgstr "Verzióinformációk"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Az elfogott kéréseket érvényesnek kell-e tekinteni vagy sem."
 
@@ -606,11 +605,11 @@ msgstr ""
 "A Privoxy ismerje-e fel a különleges HTTP fejléceket az átváltási állapot "
 "megváltoztatásához vagy sem."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "A pufferelt tartalom legyen-e tömörítve kézbesítés előtt vagy sem."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -618,7 +617,7 @@ msgstr ""
 "Az életben tartott kimenő kapcsolatokat meg kell-e osztani a különböző "
 "bejövő kapcsolatok között vagy sem."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "A csővezetéken keresztüli kéréseket ki kell-e szolgálni vagy sem."
 
@@ -634,18 +633,18 @@ msgstr "A webalapú műveletek fájlszerkesztője legyen-e használva vagy sem."
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "A webalapú átkapcsolási funkciót lehessen-e használni vagy sem."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "A Privoxy CGI-oldalaihoz intézett kéréseket lehessen-e blokkolni vagy "
 "átirányítani."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr "A CGI felület maradjon-e kompatibilis a törött HTTP ügyfelekkel."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Csak egyetlen kiszolgálószálat futtasson-e."
 
@@ -670,3 +669,6 @@ msgstr "vagy magasabb"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "kötelező"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Szintaxis: cél_minta socks_proxy[:port] http_szülő[:port]"

--- a/applications/luci-app-privoxy/po/it/privoxy.po
+++ b/applications/luci-app-privoxy/po/it/privoxy.po
@@ -50,7 +50,7 @@ msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 "Un indirizzo di posta elettronica per contattare l'amministratore di Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -62,11 +62,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Ritardo all'avvio"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interfaccia Utente CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -77,19 +77,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -196,25 +196,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr "Visualizzatore Registro"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -286,16 +286,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -309,7 +309,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Per favore premi il pulsante [Leggi]"
 
@@ -340,19 +340,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Leggi / Rileggi registro"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -377,24 +377,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sintassi:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -413,7 +411,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -443,11 +441,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -465,7 +463,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -483,6 +481,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -498,11 +497,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -510,7 +509,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -518,10 +517,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -539,7 +538,7 @@ msgstr "Versione"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -549,17 +548,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -575,16 +574,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/ja/privoxy.po
+++ b/applications/luci-app-privoxy/po/ja/privoxy.po
@@ -14,15 +14,17 @@ msgstr ""
 msgid ""
 "A URL to be displayed in the error page that users will see if access to an "
 "untrusted page is denied."
-msgstr "信頼されていないページへのアクセスが拒否された場合に、ユーザーに表示されるエ"
+msgstr ""
+"信頼されていないページへのアクセスが拒否された場合に、ユーザーに表示されるエ"
 "ラーページに表示されるURL。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:226
 msgid ""
 "A URL to documentation about the local Privoxy setup, configuration or "
 "policies."
-msgstr "ローカルの Privoxy のセットアップ、構成、"
-"またはポリシーに関するドキュメントへの URL。"
+msgstr ""
+"ローカルの Privoxy のセットアップ、構成、またはポリシーに関するドキュメントへ"
+"の URL。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:325
 msgid "A directory where Privoxy can create temporary files."
@@ -45,7 +47,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -55,11 +57,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGIユーザーインターフェイス"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -70,19 +72,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "ファイルが見つからないか空です"
@@ -189,25 +191,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr "ログファイル・ビューア"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -256,7 +258,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -279,16 +281,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -302,7 +304,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "[読込] ボタンを押してください"
 
@@ -333,19 +335,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "ログファイルの読み込み/再読み込み"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -370,24 +372,22 @@ msgstr "開始 / 停止"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -406,7 +406,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -436,11 +436,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -458,7 +458,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -476,6 +476,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -491,11 +492,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -503,7 +504,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr "0 から 300 の間の値ではありません"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "0 から 9 の間の値ではありません"
 
@@ -511,10 +512,10 @@ msgstr "0 から 9 の間の値ではありません"
 msgid "Value not between 1 and 4096"
 msgstr "1 から 4096 の間の値ではありません"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -532,7 +533,7 @@ msgstr "バージョン"
 msgid "Version Information"
 msgstr "バージョン情報"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -542,17 +543,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -568,16 +569,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/ko/privoxy.po
+++ b/applications/luci-app-privoxy/po/ko/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr "버전"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/lt/privoxy.po
+++ b/applications/luci-app-privoxy/po/lt/privoxy.po
@@ -47,7 +47,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr "El. pašto adresas, norint pasiekti „Privoxy“ administratorių."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -59,11 +59,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Paleidimo atidėjimas"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "„CGI“ naudotojo/vartotojo sąsaja"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Dažnas žurnalo formatas"
 
@@ -74,25 +74,26 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "„GIF de-animacijos“ derinimas"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Derinti priverstiną funkciją"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Derinti nukreipimus/peradresavimus"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:152
 msgid "Delay (in seconds) during system boot before Privoxy start"
-msgstr "Atidėjimas (sekundėmis), kol sistema kraunasi prieš „Privoxy“ paleidimą"
+msgstr ""
+"Atidėjimas (sekundėmis), kol sistema kraunasi prieš „Privoxy“ paleidimą"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:261
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:298
@@ -142,7 +143,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Failas „%s“ nerastas konfigūracijos kataloge (vietovėje)"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Failas nerastas arba tuščias"
@@ -193,19 +194,19 @@ msgstr "„Privoxy“ naudotojo gido/instrukcijų vietovė."
 msgid "Log File Viewer"
 msgstr "Žurnalo failo žiūrovas/-ė"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Žurnalinti visus duomenų skaitymus iš tinklo"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Žurnalinti visus duomenų įrašymus į tinklą"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Žurnalinti pritaikomus veiksmus"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -213,7 +214,7 @@ msgstr ""
 "Žurnalinti paskirtį, kiekvienai užklausai, kurią „Privoxy“ praleidžią. Tai "
 "pat peržiūrėti: „Debug 1024“."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -267,7 +268,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Privaloma įvestis: joks tinkamas prievadas nepateiktas!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -290,16 +291,16 @@ msgstr "Neįdiegta"
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -313,7 +314,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Prašome įdiegti dabartinę versiją !"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Prašome paspausti [Skaityta] mygtuką"
 
@@ -344,19 +345,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Skaityti / Iš naujo perskaityti žurnalo failą"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Rodyti Į/I būklę/būseną"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Rodyti kiekvieno prisijungimo būsenas"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -381,26 +382,23 @@ msgstr "Pradėti / Stabdyti"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Paleisti/Stabdyti „Privoxy WEB“ įgaliotąjį"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sintaksė:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Sintakse: „target_pattern http_parent[:prievadas]“"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr ""
-"Sintaksė: „target_pattern socks_proxy[:prievadas] http_parent[:prievadas]“"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -418,7 +416,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -448,11 +446,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -470,7 +468,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -488,6 +486,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -503,11 +502,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Reikšmė nėra skaičius"
 
@@ -515,7 +514,7 @@ msgstr "Reikšmė nėra skaičius"
 msgid "Value not between 0 and 300"
 msgstr "Reikšmė nėra tarp 0 ir 300-ų"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Reikšmė nėra tarp 0 ir 9-ų"
 
@@ -523,10 +522,10 @@ msgstr "Reikšmė nėra tarp 0 ir 9-ų"
 msgid "Value not between 1 and 4096"
 msgstr "Reikšmė nėra tarp 1 ir 4096-ų"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Reikšmė nėra didesnis negu 0-is ar tuščias"
 
@@ -545,7 +544,7 @@ msgstr "Versija"
 msgid "Version Information"
 msgstr "Versijos informacija"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -555,17 +554,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -581,16 +580,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 
@@ -615,3 +614,7 @@ msgstr "arba aukštesnį"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "reikalingas/-aujamas"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr ""
+#~ "Sintaksė: „target_pattern socks_proxy[:prievadas] http_parent[:prievadas]“"

--- a/applications/luci-app-privoxy/po/mr/privoxy.po
+++ b/applications/luci-app-privoxy/po/mr/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/ms/privoxy.po
+++ b/applications/luci-app-privoxy/po/ms/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/nb_NO/privoxy.po
+++ b/applications/luci-app-privoxy/po/nb_NO/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr "Versjon"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/nl/privoxy.po
+++ b/applications/luci-app-privoxy/po/nl/privoxy.po
@@ -42,7 +42,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -52,11 +52,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -67,19 +67,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -186,25 +186,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -253,7 +253,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -276,16 +276,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -299,7 +299,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -330,19 +330,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -367,24 +367,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -403,7 +401,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -433,11 +431,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -455,7 +453,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -473,6 +471,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -488,11 +487,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -500,7 +499,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -508,10 +507,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -529,7 +528,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -539,17 +538,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -565,16 +564,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/pl/privoxy.po
+++ b/applications/luci-app-privoxy/po/pl/privoxy.po
@@ -50,7 +50,7 @@ msgstr "Alternatywny katalog, z którego ładowane są szablony."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Adres e-mail, aby skontaktować się z administratorem Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -62,11 +62,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Opóźnienie rozruchu"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interfejs użytkownika CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Wspólny format dziennika"
 
@@ -80,19 +80,19 @@ msgstr ""
 "Należy pamiętać, że macierzyste serwery proxy mogą znacznie zmniejszyć "
 "poziom prywatności. Również określone tutaj są SOCKS proxies."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Debugowanie GIF de-animacji"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Wymuś debugowanie funkcji"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Debuguj przekierowania"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Debuguj filtry wyrażeń regularnych"
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Plik '%s' nie został znaleziony wewnątrz katalogu konfiguracji"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Plik nie został znaleziony lub jest pusty"
@@ -209,19 +209,19 @@ msgstr "Lokalizacja instrukcji obsługi Privoxy."
 msgid "Log File Viewer"
 msgstr "Przeglądarka plików dziennika"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Rejestruj wszystkie dane odczytane z sieci"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Rejestruj wszystkie dane zapisane w sieci"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Rejestruj zastosowane operacje"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -229,7 +229,7 @@ msgstr ""
 "Rejestruj miejsce docelowe dla każdego żądania przepuszczającego Privoxy. "
 "Zobacz również \"Debug 1024\"."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -280,7 +280,7 @@ msgstr "Obowiązkowe wejście: Nie podano poprawnego adresu IPv6!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Obowiązkowe wejście: Nie podano aktualnego Portu!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Maksymalna liczba połączeń z klientami, które będą obsługiwane."
 
@@ -303,17 +303,17 @@ msgstr "Nie zainstalowany"
 msgid "No trailing '/', please."
 msgstr "Żadnego tropienia '/', proszę."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Non-fatal errors - *zalecamy, aby to włączyć*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Liczba sekund, po których gniazdo się wyłącza w przypadku braku danych."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Zainstaluj aktualną wersję!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Proszę nacisnąć przycisk [Czytaj]"
 
@@ -370,19 +370,19 @@ msgstr ""
 "internetowej i nagłówków HTTP, kontrolowania dostępu oraz usuwania reklam i "
 "innych okropnych śmieci internetowych."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Wczytaj / Ponownie wczytaj plik dziennika"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Pokaż status We/Wy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Pokaż status każdego połączenia"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Pokaż nagłówek ścieżki"
 
@@ -407,25 +407,23 @@ msgstr "Start/Stop"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Włącz/Wyłącz Privoxy WEB Proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Baner startowy i ostrzeżenia."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Składnia:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Składnia: nazwy nagłówków klienta rozdzielone spacjami."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Składnia: target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Składnia: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -446,7 +444,7 @@ msgid ""
 msgstr ""
 "Adres i port TCP, na którym Privoxy będzie nasłuchiwać żądania klientów."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -484,12 +482,12 @@ msgstr ""
 "Plik dziennika, którego należy użyć. Nazwa pliku, odnosząca się do katalogu "
 "logu."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "Kolejność, w jakiej nagłówki klientów są sortowane przed ich przekazaniem."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -513,7 +511,7 @@ msgstr ""
 "Wartość tej opcji ma znaczenie tylko wtedy, gdy eksperymentalny mechanizm "
 "zaufania został aktywowany."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -536,6 +534,7 @@ msgstr ""
 "Privoxy."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -555,11 +554,11 @@ msgstr "Modyfikacje użytkownika"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Wartość nie jest liczbą"
 
@@ -567,7 +566,7 @@ msgstr "Wartość nie jest liczbą"
 msgid "Value not between 0 and 300"
 msgstr "Wartość nie mieszcząca się w przedziale od 0 do 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Wartość nie mieszcząca się w przedziale od 0 do 9"
 
@@ -575,10 +574,10 @@ msgstr "Wartość nie mieszcząca się w przedziale od 0 do 9"
 msgid "Value not between 1 and 4096"
 msgstr "Wartość nie mieszcząca się w przedziale od 1 do 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Wartość nie większa niż 0 lub pusta"
 
@@ -596,7 +595,7 @@ msgstr "Wersja"
 msgid "Version Information"
 msgstr "Informacja o wersji"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Czy przechwycone zapytania powinny być traktowane jako ważne."
 
@@ -608,12 +607,12 @@ msgstr ""
 "Czy Privoxy rozpoznaje specjalne nagłówki HTTP, aby zmienić stan "
 "przełącznika, czy też nie."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 "Czy zawartość buforowana jest kompresowana przed przekazaniem, czy też nie."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -621,7 +620,7 @@ msgstr ""
 "Czy połączenia wychodzące, które zostały utrzymane przy życiu, powinny być "
 "dzielone między różne połączenia przychodzące, czy też nie."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Czy prośby powinny być doręczane w formie potokowej, czy też nie."
 
@@ -638,19 +637,19 @@ msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 "Czy można korzystać z funkcji przełączania stron internetowych, czy też nie."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Czy żądania do stron CGI Privoxy mogą być zablokowane lub przekierowane."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Czy interfejs CGI powinien pozostać kompatybilny z uszkodzonymi klientami "
 "HTTP."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Czy uruchomić tylko jeden wątek serwera."
 
@@ -675,3 +674,6 @@ msgstr "lub wyżej"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "wymagany"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Składnia: target_pattern socks_proxy[:port] http_parent[:port]"

--- a/applications/luci-app-privoxy/po/pt/privoxy.po
+++ b/applications/luci-app-privoxy/po/pt/privoxy.po
@@ -47,7 +47,7 @@ msgstr "Um diretório alternativo de onde os modelos são carregados."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Um endereço de e-mail para alcançar o administrador do Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -59,11 +59,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Atraso de iniciação"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interface de utilizador CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Formato de registos (log) comum"
 
@@ -77,19 +77,19 @@ msgstr ""
 "múltiplos proxies. Note-se que proxies pai pode diminuir muito o nível de "
 "privacidade. Também serão aceitos proxies SOCKS."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Depurar de-animação GIF"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Recurso de depuração forçado"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Redirecionamentos de depuração"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Depuração de filtros de expressão regular"
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "O ficheiro '%s' não foi encontrado dentro do Diretório de Configuração"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Ficheiro não encontrado ou vazio"
@@ -207,19 +207,19 @@ msgstr "Localização do Manual do Utilizador do Privoxy."
 msgid "Log File Viewer"
 msgstr "Visualizador de ficheiro de log"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Registar todos os dados lidos da rede"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Registar todos os dados gravados na rede"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Registar as ações aplicadas"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -227,7 +227,7 @@ msgstr ""
 "Registar o destino para cada pedido que o Privoxy deixou passar. Consulte "
 "também 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -279,7 +279,7 @@ msgstr "Entrada obrigatória: Nenhum endereço IPv6 válido foi informado!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Entrada obrigatória: Nenhuma porta válida foi informada!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "O número máximo de conexões de cliente que será aceito."
 
@@ -302,18 +302,18 @@ msgstr "NÃO instalado"
 msgid "No trailing '/', please."
 msgstr "Sem '/' final, por favor."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Erros não fatais - *é altamente recomendado ativar isto*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Número de segundos após o qual uma conexão expira se nenhum dado for "
 "recebido."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Por favor, instale a versão atual!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Por favor pressione o botão [Ler]"
 
@@ -368,19 +368,19 @@ msgstr ""
 "controlar o acesso e remover anúncios e outras porcarias detestável da "
 "Internet."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Ler / Ler novamente o ficheiro de log"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Mostrar estado de Entrada/Saída"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Mostrar cada estado de conexão"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Mostrar análise do cabeçalho"
 
@@ -405,25 +405,23 @@ msgstr "Iniciar / Parar"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Inicia / Para o Privoxy Web Proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Mensagens e avisos iniciais."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sintaxe:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Sintaxe: nomes de cabeçalho do cliente delimitados por espaços."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Sintaxe: padrão_alvo http_superior[:porta]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Sintaxe: padrão_alvo proxy_socks[:porta] http_superior[:porta]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -444,7 +442,7 @@ msgid ""
 msgstr ""
 "O endereço e porta TCP em que Privoxy vai esperar por pedidos dos clientes."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -483,13 +481,13 @@ msgstr ""
 "O ficheiro de registos a ser usado. O nome do ficheiro, relativo ao "
 "diretório de log."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "A ordem em que os cabeçalhos dos clientes são classificados antes de "
 "encaminhá-los."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -513,7 +511,7 @@ msgstr ""
 "O valor desta opção só importa se o mecanismo de confiança experimental foi "
 "ativado."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -537,6 +535,7 @@ msgstr ""
 "segurança."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -555,11 +554,11 @@ msgstr "Personalizações do utilizador"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "O valor não é um número"
 
@@ -567,7 +566,7 @@ msgstr "O valor não é um número"
 msgid "Value not between 0 and 300"
 msgstr "Valor não está entre 0 e 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Valor não está entre 0 e 9"
 
@@ -575,10 +574,10 @@ msgstr "Valor não está entre 0 e 9"
 msgid "Value not between 1 and 4096"
 msgstr "Valor não entre 1 e 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Valor não é maior que 0 ou vazio"
 
@@ -596,7 +595,7 @@ msgstr "Versão"
 msgid "Version Information"
 msgstr "Informação da Versão"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Se as solicitações interceptados deve ser tratadas como válidas."
 
@@ -608,11 +607,11 @@ msgstr ""
 "Se o Privoxy deve reconhecer cabeçalhos HTTP especiais para mudar de "
 "alternância do estado."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "Se o conteúdo em buffer é comprimido antes da entrega."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -620,7 +619,7 @@ msgstr ""
 "Se as conexões de saída que foram mantidas vivas devem ser compartilhadas "
 "entre diferentes conexões de entrada."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Se os pedidos de pipeline deve ser aceitos."
 
@@ -636,20 +635,20 @@ msgstr "Se o editor de ficheiros de ações baseadas na web deve ser utilizado."
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Se deve ser usado o recurso de alternância baseado na web."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Se as solicitações para páginas CGI do Privoxy podem ser bloqueadas ou "
 "redirecionadas."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Se a interface CGI deve se manter compatível com clientes HTTP mal "
 "implementados."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Se deseja executar o servidor como apenas uma thread."
 
@@ -674,3 +673,6 @@ msgstr "ou maior"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "necessário"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Sintaxe: padrão_alvo proxy_socks[:porta] http_superior[:porta]"

--- a/applications/luci-app-privoxy/po/pt_BR/privoxy.po
+++ b/applications/luci-app-privoxy/po/pt_BR/privoxy.po
@@ -50,7 +50,7 @@ msgstr "Um diretório alternativo de onde os modelos são carregados."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Um endereço de e-mail para alcançar o administrador do Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -62,11 +62,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Atraso de iniciação"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interface de usuário CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Formato de registros (log) comum"
 
@@ -80,19 +80,19 @@ msgstr ""
 "múltiplos proxies. Note-se que proxies pai pode diminuir muito o nível de "
 "privacidade. Também serão aceitos proxies SOCKS."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Depurar de-animação GIF"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Recurso de depuração forçado"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Redirecionamentos de depuração"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Depuração de filtros de expressão regular"
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "O arquivo '%s' não foi encontrado dentro do Diretório de Configuração"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Arquivo não encontrado ou vazio"
@@ -210,19 +210,19 @@ msgstr "Localização do Manual do Usuário do Privoxy."
 msgid "Log File Viewer"
 msgstr "Visualizador de arquivo de registro"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Registrar todos os dados lidos da rede"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Registrar todos os dados gravados na rede"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Registrar as ações aplicadas"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -230,7 +230,7 @@ msgstr ""
 "Registrar o destino para cada pedido que o Privoxy deixou passar. Consulte "
 "também 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -283,7 +283,7 @@ msgstr "Entrada obrigatória: Nenhum endereço IPv6 válido foi informado!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Entrada obrigatória: Nenhuma porta válida foi informada!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "O número máximo de conexões de cliente que será aceito."
 
@@ -306,18 +306,18 @@ msgstr "NÃO instalado"
 msgid "No trailing '/', please."
 msgstr "Sem '/' final, por favor."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Erros não fatais - *é altamente recomendado ativar isto*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Número de segundos após o qual uma conexão expira se nenhum dado for "
 "recebido."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Por favor, instale a versão atual!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Por favor, pressione o botão [Ler]"
 
@@ -372,19 +372,19 @@ msgstr ""
 "controlar o acesso e remover anúncios e outras porcarias detestável da "
 "Internet."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Ler / Ler novamente o arquivo do registro log"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Mostrar status de Entrada/Saída"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Mostrar cada estado de conexão"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Mostrar análise do cabeçalho"
 
@@ -409,25 +409,23 @@ msgstr "Iniciar / Parar"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Inicia / Para o Privoxy Web Proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Mensagens e avisos iniciais."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sintaxe:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Sintaxe: nomes de cabeçalho do cliente delimitados por espaços."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Sintaxe: padrão_alvo http_superior[:porta]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Sintaxe: padrão_alvo proxy_socks[:porta] http_superior[:porta]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -448,7 +446,7 @@ msgid ""
 msgstr ""
 "O endereço e porta TCP em que Privoxy vai esperar por pedidos dos clientes."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -486,13 +484,13 @@ msgstr ""
 "O arquivo de registros a ser usado. O nome do arquivo, relativo ao diretório "
 "de log."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "A ordem em que os cabeçalhos dos clientes são classificados antes de "
 "encaminhá-los."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -516,7 +514,7 @@ msgstr ""
 "O valor desta opção só importa se o mecanismo de confiança experimental foi "
 "ativado."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -540,6 +538,7 @@ msgstr ""
 "segurança."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -558,11 +557,11 @@ msgstr "Personalizações do usuário"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "O valor não é um número"
 
@@ -570,7 +569,7 @@ msgstr "O valor não é um número"
 msgid "Value not between 0 and 300"
 msgstr "Valor não está entre 0 e 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Valor não está entre 0 e 9"
 
@@ -578,10 +577,10 @@ msgstr "Valor não está entre 0 e 9"
 msgid "Value not between 1 and 4096"
 msgstr "Valor não entre 1 e 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Valor não é maior que 0 ou vazio"
 
@@ -599,7 +598,7 @@ msgstr "Versão"
 msgid "Version Information"
 msgstr "Informação da Versão"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Se as solicitações interceptados deve ser tratadas como válidas."
 
@@ -611,11 +610,11 @@ msgstr ""
 "Se o Privoxy deve reconhecer cabeçalhos HTTP especiais para mudar de "
 "alternância do estado."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "Se o conteúdo em buffer é comprimido antes da entrega."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -623,7 +622,7 @@ msgstr ""
 "Se as conexões de saída que foram mantidas vivas devem ser compartilhadas "
 "entre diferentes conexões de entrada."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Se os pedidos de pipeline deve ser aceitos."
 
@@ -639,20 +638,20 @@ msgstr "Se o editor de arquivos de ações baseadas na web deve ser utilizado."
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Se deve ser usado o recurso de alternância baseado na web."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Se as solicitações para páginas CGI do Privoxy podem ser bloqueadas ou "
 "redirecionadas."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Se a interface CGI deve se manter compatível com clientes HTTP mal "
 "implementados."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Se deseja executar o servidor como apenas uma thread."
 
@@ -677,3 +676,6 @@ msgstr "ou maior"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "necessário"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Sintaxe: padrão_alvo proxy_socks[:porta] http_superior[:porta]"

--- a/applications/luci-app-privoxy/po/ro/privoxy.po
+++ b/applications/luci-app-privoxy/po/ro/privoxy.po
@@ -49,7 +49,7 @@ msgstr "Un director alternativ din care se încarcă șabloanele."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "O adresă de e-mail pentru a contacta administratorul Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -61,11 +61,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Întârziere la pornire"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Interfață utilizator CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Format comun de jurnal"
 
@@ -79,19 +79,19 @@ msgstr ""
 "multiple. Rețineți că proxies de tip parental pot scădea considerabil "
 "nivelul de confidențialitate. Tot aici sunt specificate și proxy-urile SOCKS."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Depanare GIF de-animare"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Funcția Debug Force"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Depanarea redirecționărilor"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Depanarea filtrelor de expresie regulată"
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Fișierul '%s' nu a fost găsit în directorul de configurare"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Fișier nedescoperit sau gol"
@@ -209,19 +209,19 @@ msgstr "Locația manualului de utilizare Privoxy."
 msgid "Log File Viewer"
 msgstr "Vizualizator de fișiere jurnal"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Înregistrați toate datele citite din rețea"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Înregistrați toate datele scrise în rețea"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Înregistrați acțiunile de aplicare"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -229,7 +229,7 @@ msgstr ""
 "Înregistrați destinația pentru fiecare solicitare pe care Privoxy o lasă să "
 "treacă. A se vedea și 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -281,7 +281,7 @@ msgstr "Intrare obligatorie: Nu a fost furnizată nicio adresă IPv6 validă!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Intrare obligatorie: Nu a fost indicat niciun port valid!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Numărul maxim de conexiuni client care vor fi servite."
 
@@ -304,17 +304,17 @@ msgstr "NU este instalat"
 msgid "No trailing '/', please."
 msgstr "Fără '/' la sfârșit, vă rog."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Erorile non-fatal - *recomandăm cu tărie activarea acestui lucru*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Numărul de secunde după care un socket se termină dacă nu se primesc date."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Vă rugăm să instalați versiunea curentă!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Vă rugăm să apăsați butonul [Read]"
 
@@ -370,19 +370,19 @@ msgstr ""
 "web și a antetelor HTTP, controlul accesului și eliminarea reclamelor și a "
 "altor prostii enervante de pe internet."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Citiți / Recitiți fișierul jurnal"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Afișați starea I/O"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Afișați starea fiecărei conexiuni"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Afișați parsarea antetului"
 
@@ -407,25 +407,23 @@ msgstr "Pornire / Oprire"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Porniți/Opriți Privoxy WEB Proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Banner de pornire și avertismente."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sintaxă:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Sintaxă: Nume de antet client delimitate prin spații."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Sintaxă: target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Sintaxă: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -445,7 +443,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr "Adresa și portul TCP pe care Privoxy va asculta cererile clienților."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -483,12 +481,12 @@ msgstr ""
 "Fișierul de jurnal care urmează să fie utilizat. Numele fișierului, în "
 "raport cu directorul de jurnal."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "Ordinea în care sunt sortate antetele clienților înainte de a le transmite."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -512,7 +510,7 @@ msgstr ""
 "Valoarea acestei opțiuni contează numai dacă a fost activat mecanismul "
 "experimental de încredere."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -536,6 +534,7 @@ msgstr ""
 "configurației Privoxy."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -555,11 +554,11 @@ msgstr "Personalizări ale utilizatorului"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Valoarea nu este un număr"
 
@@ -567,7 +566,7 @@ msgstr "Valoarea nu este un număr"
 msgid "Value not between 0 and 300"
 msgstr "Valoarea nu este cuprinsă între 0 și 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Valoarea nu este cuprinsă între 0 și 9"
 
@@ -575,10 +574,10 @@ msgstr "Valoarea nu este cuprinsă între 0 și 9"
 msgid "Value not between 1 and 4096"
 msgstr "Valoarea nu este cuprinsă între 1 și 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Valoarea nu este mai mare de 0 sau goală"
 
@@ -598,7 +597,7 @@ msgstr "Versiune"
 msgid "Version Information"
 msgstr "Informații despre versiune"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Dacă cererile interceptate trebuie tratate ca fiind valide."
 
@@ -610,11 +609,11 @@ msgstr ""
 "Dacă Privoxy recunoaște sau nu antetele HTTP speciale pentru a schimba "
 "starea de comutare."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "Dacă conținutul tamponat este sau nu comprimat înainte de livrare."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -622,7 +621,7 @@ msgstr ""
 "Dacă conexiunile de ieșire care au fost menținute în viață ar trebui sau nu "
 "să fie partajate între diferite conexiuni de intrare."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Dacă trebuie sau nu servite cereri în lanț."
 
@@ -639,19 +638,19 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Dacă poate fi utilizată sau nu funcția de comutare bazată pe web."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Dacă cererile către paginile CGI ale Privoxy pot fi blocate sau "
 "redirecționate."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Dacă interfața CGI trebuie să rămână compatibilă cu clienții HTTP defectuoși."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Dacă se va rula doar un singur fir de server."
 
@@ -676,3 +675,6 @@ msgstr "sau mai mare"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "necesară"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Sintaxă: target_pattern socks_proxy[:port] http_parent[:port]"

--- a/applications/luci-app-privoxy/po/ru/privoxy.po
+++ b/applications/luci-app-privoxy/po/ru/privoxy.po
@@ -55,7 +55,7 @@ msgstr "Дополнительная директория, из которой �
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Адрес электронной почты для связи с администратором Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -67,11 +67,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Задержка загрузки"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Пользовательский интерфейс CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Типичный формат системного журнала"
 
@@ -86,19 +86,19 @@ msgstr ""
 "значительно снизить уровень конфиденциальности. Здесь же настройка SOCKS "
 "прокси."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Отладка GIF де-анимации"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Отладка функции назначения"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Отладка перенаправлений"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Отладка фильтров регулярных выражений"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Файл '%S' не найден в папке с config файлами"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Файл не найден или пустой"
@@ -214,19 +214,19 @@ msgstr "Расположение руководства пользователя
 msgid "Log File Viewer"
 msgstr "Просмотр файла журнала"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Записывать в системный журнал все данные, считываемые сетью"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Записывать в системный журнал все данные, отправленные в сеть"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Записывать в системный журнал все действия"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -234,7 +234,7 @@ msgstr ""
 "Записывать в системный журнал места назначения для каждого запроса, который "
 "передает Privoxy. См. также 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -283,7 +283,7 @@ msgstr "Обязательный ввод: Не указан действите�
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Обязательный ввод: Не указан действительный порт!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Максимальное число обслуживаемых клиентских подключений."
 
@@ -306,20 +306,20 @@ msgstr "Не установлена"
 msgid "No trailing '/', please."
 msgstr "Не используйте символ '/'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 "Отсутствуют неустранимые ошибки - *мы настоятельно рекомендуем включить эту "
 "функцию*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Количество секунд по истечении которых, время сокета истекает, если данные "
 "не получены."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Установите текущую версию !"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Нажмите кнопку [Читать]"
 
@@ -377,19 +377,19 @@ msgstr ""
 "всплывающих окон, а также любого другого нежелательного контента («интернет-"
 "мусора»)."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Читать / Перечитать файл журнала"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Показать статус ввода-вывода"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Показать состояние каждого соединения"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Показать анализ заголовка"
 
@@ -414,25 +414,23 @@ msgstr "Старт / Стоп"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Запуск и остановка Privoxy WEB proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Баннер запуска и предупреждения."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Синтаксис:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Синтаксис: имя заголовка клиента, разделенное пробелами."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Синтаксис: target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Синтаксис: target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -452,7 +450,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr "Адрес и TCP-порт Privoxy для входящих запросов клиентов."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -488,11 +486,11 @@ msgstr ""
 "Используемый файл системного журнала. Имя файла относительно папки системных "
 "журналов."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr "Порядок сортировки заголовков клиентов перед их пересылкой."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -516,7 +514,7 @@ msgstr ""
 "Этот параметр будет задействован, только если активирован экспериментальный "
 "механизм доверия."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -538,6 +536,7 @@ msgid ""
 msgstr "Страница контролирует безопасность, важные аспекты настройки Privoxy."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -557,11 +556,11 @@ msgstr "Пользовательские действия"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Значение не является числом"
 
@@ -569,7 +568,7 @@ msgstr "Значение не является числом"
 msgid "Value not between 0 and 300"
 msgstr "Значение не между 0 и 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Значение не от 0 до 9"
 
@@ -577,10 +576,10 @@ msgstr "Значение не от 0 до 9"
 msgid "Value not between 1 and 4096"
 msgstr "Значения не от 1 до 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Значение не больше 0 или пустое"
 
@@ -598,7 +597,7 @@ msgstr "Версия"
 msgid "Version Information"
 msgstr "Информация о версии"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Следует ли рассматривать перехваченные запросы как действительные."
 
@@ -610,11 +609,11 @@ msgstr ""
 "Распознает ли Privoxy специальные заголовки HTTP для изменения состояния "
 "переключения."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "Сжатие буферизованного содержимого перед доставкой."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -622,7 +621,7 @@ msgstr ""
 "Должны ли исходящие соединения, сохраненные в действующих, совместно "
 "использоваться различными входящими соединениями."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Могут или нет подаваться pipelined запросы."
 
@@ -638,19 +637,19 @@ msgstr "Может ли использоваться редактор файло
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Может ли использоваться веб-функция переключения."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Могут ли запросы на CGI-страницы Privoxy быть заблокированы или "
 "перенаправлены."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Должен ли CGI интерфейс оставаться совместимым со сломанными http-клиентами."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Должен ли выполняться только один серверный поток."
 
@@ -675,3 +674,6 @@ msgstr "или выше"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "требовать"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Синтаксис: target_pattern socks_proxy[:port] http_parent[:port]"

--- a/applications/luci-app-privoxy/po/sk/privoxy.po
+++ b/applications/luci-app-privoxy/po/sk/privoxy.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -53,11 +53,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -68,19 +68,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -187,25 +187,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -277,16 +277,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -300,7 +300,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -331,19 +331,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -368,24 +368,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -404,7 +402,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -434,11 +432,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -456,7 +454,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -474,6 +472,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -489,11 +488,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -501,7 +500,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -509,10 +508,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -530,7 +529,7 @@ msgstr "Verzia"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -540,17 +539,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -566,16 +565,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/sv/privoxy.po
+++ b/applications/luci-app-privoxy/po/sv/privoxy.po
@@ -45,7 +45,7 @@ msgstr "En alternativ mapp som mallar laddas från."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "En e-postadress för att nå Privoxy-administratören."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -55,11 +55,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGI-användargränssnitt"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Vanliga loggformat"
 
@@ -70,19 +70,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Felsök omdirigeringar"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Filen '%s' hittades inte inuti konfigurationsmappen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Filen hittades inte eller så är den tom"
@@ -191,25 +191,25 @@ msgstr "Plats för Privoxy's användarmanual."
 msgid "Log File Viewer"
 msgstr "Visare av loggfil"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Logga all läst data från nätverket"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Logga all data som skrivits till nätverket"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Logga de verkställande handlingarna"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -258,7 +258,7 @@ msgstr "Obligatorisk inmatning: Ingen giltig IPv6-adress angavs!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Obligatorisk inmatning: Ingen giltig port angavs!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Maximalt antal klientanslutningar som blir betjänade."
 
@@ -281,17 +281,17 @@ msgstr "INTE installerad"
 msgid "No trailing '/', please."
 msgstr "Vänligen, inget eftersläpande '/'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 "Icke-dödliga fel - *vi rekommenderar verkligen att man aktiverar det här*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Vänligen installera den nuvarande versionen !"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Vänligen tryck på [Läs]-knappen"
 
@@ -336,19 +336,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Läs / Läs om loggfilen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Visa I/O-status"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Visa varje anslutnings status"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -373,24 +373,22 @@ msgstr "Starta / Stoppa"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Starta/Stoppa Privoxy WEB-proxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Syntax:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -409,7 +407,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -439,11 +437,11 @@ msgstr "Värdnamnet som visas på CGI-sidor."
 msgid "The log file to use. File name, relative to log directory."
 msgstr "Loggfilen att använda. Filnamn, relativt till logg-mappen."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -461,7 +459,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -479,6 +477,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -494,11 +493,11 @@ msgstr "Anpassningar för användare"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Värdet är inte ett nummer"
 
@@ -506,7 +505,7 @@ msgstr "Värdet är inte ett nummer"
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Värdet är inte mellan 0 och 9"
 
@@ -514,10 +513,10 @@ msgstr "Värdet är inte mellan 0 och 9"
 msgid "Value not between 1 and 4096"
 msgstr "Värdet är inte mellan 1 och 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Värdet är inte större än 0 eller tomt"
 
@@ -535,7 +534,7 @@ msgstr "Version"
 msgid "Version Information"
 msgstr "Information om versionen"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -545,17 +544,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -571,16 +570,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Om det endast ska köras en server-tråd."
 

--- a/applications/luci-app-privoxy/po/templates/privoxy.pot
+++ b/applications/luci-app-privoxy/po/templates/privoxy.pot
@@ -34,7 +34,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -44,11 +44,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -59,19 +59,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -178,25 +178,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -268,16 +268,16 @@ msgstr ""
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -359,24 +359,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -395,7 +393,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -425,11 +423,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -447,7 +445,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -465,6 +463,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -480,11 +479,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -492,7 +491,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -500,10 +499,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -521,7 +520,7 @@ msgstr ""
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -531,17 +530,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -557,16 +556,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/tr/privoxy.po
+++ b/applications/luci-app-privoxy/po/tr/privoxy.po
@@ -47,7 +47,7 @@ msgstr "Şablonların yüklendiği alternatif bir dizin."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Privoxy yöneticisine ulaşmak için bir e-posta adresi."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -59,11 +59,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Önyükleme gecikmesi"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGI kullanıcı arayüzü"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Ortak Günlük Formatı"
 
@@ -78,19 +78,19 @@ msgstr ""
 "ciddi şekilde düşürebileceğini unutmayın. Burada ayrıca SOCKS vekil "
 "sunucuları da belirtilmiştir."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Hata ayıklama GIF de-animasyonu"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Hata ayıklama zorlama özelliği"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Yönlendirmelerde hata ayıklama"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Normal ifade filtrelerinde hata ayıklama"
 
@@ -152,7 +152,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Yapılandırma Dizini içinde '%s' dosyası bulunamadı"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Dosya bulunamadı veya boş"
@@ -209,19 +209,19 @@ msgstr "Privoxy Kullanım Kılavuzunun Yeri."
 msgid "Log File Viewer"
 msgstr "Günlük Dosyası Görüntüleyicisi"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Ağdan okunan tüm verileri günlüğe kaydedin"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Ağa yazılan tüm verileri günlüğe kaydedin"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Uygulama eylemlerini günlüğe kaydedin"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
@@ -229,7 +229,7 @@ msgstr ""
 "Privoxy'nin geçmesine izin verilen her istek için hedefi günlüğe kaydedin. "
 "Ayrıca '1024 Hata Ayıklama' konusuna bakın."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -280,7 +280,7 @@ msgstr "Zorunlu Giriş: Geçerli bir IPv6 adresi verilmedi!"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Zorunlu Giriş: Belirtilen geçerli Bağlantı Noktası yok!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Sağlanacak maksimum istemci bağlantısı sayısı."
 
@@ -303,18 +303,18 @@ msgstr "Yüklü değil"
 msgid "No trailing '/', please."
 msgstr "Sonda '/' yok, lütfen."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 "Önemli olmayan hatalar - * bunu etkinleştirmenizi şiddetle tavsiye ederiz *"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 "Veri alınmazsa soketin zaman aşımına uğramasından sonraki saniye sayısı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "Açık bir bağlantının artık tekrar kullanılmayacağı saniye sayısı."
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr "Lütfen güncel sürümü kurun!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Lütfen [Oku] düğmesine basın"
 
@@ -368,19 +368,19 @@ msgstr ""
 "çöplerini kaldırmak için gelişmiş filtreleme yeteneklerine sahip, önbelleğe "
 "alınmayan bir web proxy'sidir."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Günlük dosyasını oku / yeniden oku"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "G / Ç durumunu göster"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Her bağlantı durumunu göster"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Üstbilgi ayrıştırmasını göster"
 
@@ -405,27 +405,23 @@ msgstr "Başlat/Durdur"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Privoxy WEB Proxy'i Başlat/Durdur"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Başlangıç başlığı ve uyarılar."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Sözdizimi:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Sözdizimi: Boşluklarla ayrılmış istemci başlığı adları."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Sözdizimi: target_pattern http_parent[:bağlantı noktası]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr ""
-"Sözdizimi: target_pattern socks_proxy[:bağlantı noktası] http_parent[:"
-"bağlantı noktası]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -446,7 +442,7 @@ msgid ""
 msgstr ""
 "Privoxy'nin istemci isteklerini dinleyeceği adres ve TCP bağlantı noktası."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -482,11 +478,11 @@ msgstr "CGI sayfalarında gösterilen ana bilgisayar adı."
 msgid "The log file to use. File name, relative to log directory."
 msgstr "Kullanılacak günlük dosyası. Günlük dizinine göre dosya adı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr "İstemci başlıklarının iletilmeden önce sıralandığı sıra."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -510,7 +506,7 @@ msgstr ""
 "Bu seçeneğin değeri, yalnızca deneysel güven mekanizması etkinleştirildiyse "
 "önemlidir."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -534,6 +530,7 @@ msgstr ""
 "eder."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -551,11 +548,11 @@ msgstr "Kullanıcı özelleştirmeleri"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Değer bir sayı değil"
 
@@ -563,7 +560,7 @@ msgstr "Değer bir sayı değil"
 msgid "Value not between 0 and 300"
 msgstr "Değer 0 ile 300 arasında değil"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Değer 0 ile 9 arasında değil"
 
@@ -571,10 +568,10 @@ msgstr "Değer 0 ile 9 arasında değil"
 msgid "Value not between 1 and 4096"
 msgstr "Değer 1 ile 4096 arasında değil"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Değer 0'dan büyük değil veya boş"
 
@@ -592,7 +589,7 @@ msgstr "Versiyon"
 msgid "Version Information"
 msgstr "Sürüm bilgisi"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 "Yakalanan isteklerin geçerli olarak değerlendirilip değerlendirilmeyeceği."
@@ -605,13 +602,13 @@ msgstr ""
 "Privoxy'nin geçiş durumunu değiştirmek için özel HTTP başlıklarını tanıyıp "
 "tanımadığı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 "Arabelleğe alınan içeriğin teslim edilmeden önce sıkıştırılıp "
 "sıkıştırılmayacağı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -619,13 +616,14 @@ msgstr ""
 "Canlı tutulan giden bağlantıların farklı gelen bağlantılar arasında "
 "paylaşılıp paylaşılmayacağı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Ardışık düzenlenmiş isteklerin sunulup sunulmayacağı."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:600
 msgid "Whether or not proxy authentication through Privoxy should work."
-msgstr "Privoxy aracılığıyla proxy kimlik doğrulamasının çalışıp çalışmayacağı."
+msgstr ""
+"Privoxy aracılığıyla proxy kimlik doğrulamasının çalışıp çalışmayacağı."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:582
 msgid "Whether or not the web-based actions file editor may be used."
@@ -636,18 +634,18 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "Web tabanlı geçiş özelliğinin kullanılıp kullanılamayacağı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Privoxy'nin CGI sayfalarına gelen isteklerin engellenip engellenemeyeceği "
 "veya yeniden yönlendirilip yönlendirilemeyeceği."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr "CGI arayüzünün bozuk HTTP istemcileriyle uyumlu olup olmayacağı."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Yalnızca bir sunucu iş parçacığının çalıştırılıp çalıştırılmayacağı."
 
@@ -672,3 +670,8 @@ msgstr "veya daha yüksek"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "gereklidir"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr ""
+#~ "Sözdizimi: target_pattern socks_proxy[:bağlantı noktası] http_parent[:"
+#~ "bağlantı noktası]"

--- a/applications/luci-app-privoxy/po/uk/privoxy.po
+++ b/applications/luci-app-privoxy/po/uk/privoxy.po
@@ -48,7 +48,7 @@ msgstr ""
 msgid "An email address to reach the Privoxy administrator."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -58,11 +58,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr ""
 
@@ -73,19 +73,19 @@ msgid ""
 "Also specified here are SOCKS proxies."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "File '%s' not found inside Configuration Directory"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr ""
@@ -192,25 +192,25 @@ msgstr ""
 msgid "Log File Viewer"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Mandatory Input: No valid Port given!"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr ""
 
@@ -282,16 +282,16 @@ msgstr "Не інстальовано"
 msgid "No trailing '/', please."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Please install current version !"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr ""
 
@@ -336,19 +336,19 @@ msgid ""
 "access, and removing ads and other obnoxious Internet junk."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr ""
 
@@ -373,24 +373,22 @@ msgstr ""
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
-msgstr ""
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
@@ -409,7 +407,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -439,11 +437,11 @@ msgstr ""
 msgid "The log file to use. File name, relative to log directory."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -461,7 +459,7 @@ msgid ""
 "has been activated."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -479,6 +477,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -494,11 +493,11 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr ""
 
@@ -506,7 +505,7 @@ msgstr ""
 msgid "Value not between 0 and 300"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr ""
 
@@ -514,10 +513,10 @@ msgstr ""
 msgid "Value not between 1 and 4096"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr ""
 
@@ -535,7 +534,7 @@ msgstr "Версія"
 msgid "Version Information"
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr ""
 
@@ -545,17 +544,17 @@ msgid ""
 "state."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr ""
 
@@ -571,16 +570,16 @@ msgstr ""
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr ""
 

--- a/applications/luci-app-privoxy/po/vi/privoxy.po
+++ b/applications/luci-app-privoxy/po/vi/privoxy.po
@@ -48,7 +48,7 @@ msgstr "Một thư mục thay thế nơi các mẫu được tải từ."
 msgid "An email address to reach the Privoxy administrator."
 msgstr "Một địa chỉ email để liên hệ với quản trị viên Privoxy."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -60,11 +60,11 @@ msgstr ""
 msgid "Boot delay"
 msgstr "Độ trễ khởi động"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "Giao diện người dùng CGI"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "Định dạng nhật ký chung"
 
@@ -78,19 +78,19 @@ msgstr ""
 "Lưu ý rằng các proxy cha có thể làm giảm mức độ riêng tư của bạn nghiêm "
 "trọng. Cũng được chỉ định tại đây là các proxy SOCKS."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "Gỡ lỗi GIF hủy hoạt hình"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "Tính năng gỡ lỗi buộc"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "Gỡ lỗi chuyển hướng"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "Gỡ lỗi bộ lọc biểu thức chính quy"
 
@@ -142,7 +142,8 @@ msgstr "Kích Hoạt"
 msgid ""
 "Enabling this option is NOT recommended if there is no parent proxy that "
 "requires authentication!"
-msgstr "Không nên bật tùy chọn này nếu không có proxy cha nào yêu cầu xác thực!"
+msgstr ""
+"Không nên bật tùy chọn này nếu không có proxy cha nào yêu cầu xác thực!"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:368
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:404
@@ -150,7 +151,7 @@ msgstr "Không nên bật tùy chọn này nếu không có proxy cha nào yêu 
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "Không tìm thấy tệp '%s' trong Thư mục Cấu hình"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "Không tìm thấy tệp hoặc tệp trống"
@@ -206,26 +207,26 @@ msgstr "Vị trí của Sổ tay Người dùng Privoxy."
 msgid "Log File Viewer"
 msgstr "Trình xem Tệp Nhật ký"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "Ghi nhật ký tất cả dữ liệu đọc từ mạng"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "Ghi nhật ký tất cả dữ liệu ghi vào mạng"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "Ghi nhật ký các hành động áp dụng"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr ""
 "Ghi nhật ký điểm đến cho mỗi yêu cầu Privoxy cho qua. Xem thêm 'Debug 1024'."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -277,7 +278,7 @@ msgstr "Đầu vào Bắt buộc: Không có địa chỉ IPv6 hợp lệ nào �
 msgid "Mandatory Input: No valid Port given!"
 msgstr "Đầu vào Bắt buộc: Không có Cổng hợp lệ nào được cung cấp!"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "Số lượng kết nối khách hàng tối đa sẽ được phục vụ."
 
@@ -300,16 +301,17 @@ msgstr "CHƯA được cài đặt"
 msgid "No trailing '/', please."
 msgstr "Không có dấu '/' ở cuối, xin vui lòng."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "Gây lỗi nhỏ - *chúng tôi khuyến khích bạn bật tính năng này*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
-msgstr "Số giây sau đó một socket bị hết thời gian nếu không nhận được dữ liệu."
+msgstr ""
+"Số giây sau đó một socket bị hết thời gian nếu không nhận được dữ liệu."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "Số giây sau đó một kết nối mở sẽ không được sử dụng lại."
@@ -323,7 +325,7 @@ msgstr "Chỉ khi sử dụng 'bộ lọc bên ngoài', Privoxy phải tạo cá
 msgid "Please install current version !"
 msgstr "Vui lòng cài đặt phiên bản hiện tại !"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "Vui lòng nhấn nút [Đọc]"
 
@@ -360,19 +362,19 @@ msgstr ""
 "cường quyền riêng tư, sửa đổi dữ liệu trang web và tiêu đề HTTP, kiểm soát "
 "truy cập và loại bỏ quảng cáo và các rác rưởi Internet khó chịu khác."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "Đọc / Đọc lại tệp nhật ký"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "Hiển thị trạng thái I/O"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "Hiển thị trạng thái của từng kết nối"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "Hiển thị phân tích tiêu đề"
 
@@ -397,25 +399,23 @@ msgstr "Bắt đầu / Dừng"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "Bắt đầu/Dừng Proxy WEB Privoxy"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "Biểu ngữ khởi động và cảnh báo."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "Cú pháp:"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "Cú pháp: Tên tiêu đề khách hàng được phân cách bằng dấu cách."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "Cú pháp: mẫu_đích http_cha[:cổng]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "Cú pháp: mẫu_đích socks_proxy[:cổng] http_cha[:cổng]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -433,9 +433,10 @@ msgstr ""
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:453
 msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
-msgstr "Địa chỉ và cổng TCP mà Privoxy sẽ lắng nghe các yêu cầu của khách hàng."
+msgstr ""
+"Địa chỉ và cổng TCP mà Privoxy sẽ lắng nghe các yêu cầu của khách hàng."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -468,12 +469,12 @@ msgstr "Tên máy chủ được hiển thị trên các trang CGI."
 msgid "The log file to use. File name, relative to log directory."
 msgstr "Tệp nhật ký để sử dụng. Tên tệp, tương đối với thư mục nhật ký."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr ""
 "Thứ tự mà các tiêu đề khách hàng được sắp xếp trước khi chuyển tiếp chúng."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -497,7 +498,7 @@ msgstr ""
 "Giá trị của tùy chọn này chỉ quan trọng nếu cơ chế tin cậy thử nghiệm đã "
 "được kích hoạt."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -520,6 +521,7 @@ msgstr ""
 "Tab này điều khiển các khía cạnh liên quan đến bảo mật của cấu hình Privoxy."
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -537,11 +539,11 @@ msgstr "Tùy chỉnh của người dùng"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "Giá trị không phải là một số"
 
@@ -549,7 +551,7 @@ msgstr "Giá trị không phải là một số"
 msgid "Value not between 0 and 300"
 msgstr "Giá trị không nằm trong khoảng từ 0 đến 300"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "Giá trị không nằm trong khoảng từ 0 đến 9"
 
@@ -557,10 +559,10 @@ msgstr "Giá trị không nằm trong khoảng từ 0 đến 9"
 msgid "Value not between 1 and 4096"
 msgstr "Giá trị không nằm trong khoảng từ 1 đến 4096"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "Giá trị không lớn hơn 0 hoặc rỗng"
 
@@ -578,7 +580,7 @@ msgstr "Phiên bản"
 msgid "Version Information"
 msgstr "Thông tin phiên bản"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "Có phải các yêu cầu bị chặn nên được coi là hợp lệ hay không."
 
@@ -590,11 +592,11 @@ msgstr ""
 "Privoxy có nhận ra các tiêu đề HTTP đặc biệt để thay đổi trạng thái chuyển "
 "đổi hay không."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "Có phải nội dung đệm được nén trước khi giao hay không."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
@@ -602,7 +604,7 @@ msgstr ""
 "Có phải các kết nối đi ra đã được giữ sống nên được chia sẻ giữa các kết nối "
 "đến khác nhau hay không."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "Có phải các yêu cầu được xếp hàng nên được phục vụ hay không."
 
@@ -621,20 +623,20 @@ msgid "Whether or not the web-based toggle feature may be used."
 msgstr ""
 "Có phải tính năng chuyển đổi dựa trên web có thể được sử dụng hay không."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr ""
 "Có phải các yêu cầu đến các trang CGI của Privoxy có thể bị chặn hoặc chuyển "
 "hướng hay không."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr ""
 "Dù giao diện CGI nên duy trì khả năng tương thích với các khách hàng HTTP bị "
 "lỗi."
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "Dù chạy chỉ một luồng máy chủ hay không."
 
@@ -659,3 +661,6 @@ msgstr "hoặc cao hơn"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "bắt buộc"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "Cú pháp: mẫu_đích socks_proxy[:cổng] http_cha[:cổng]"

--- a/applications/luci-app-privoxy/po/zh_Hans/privoxy.po
+++ b/applications/luci-app-privoxy/po/zh_Hans/privoxy.po
@@ -50,7 +50,7 @@ msgstr "可选的目录，放在里面的模板会被加载。"
 msgid "An email address to reach the Privoxy administrator."
 msgstr "用于联系 Privoxy 管理员的邮箱地址。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -60,11 +60,11 @@ msgstr "当服务端没有指定超时时间时假定的超时时间（单位：
 msgid "Boot delay"
 msgstr "启动延时"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGI 用户界面"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "通用日志格式"
 
@@ -77,19 +77,19 @@ msgstr ""
 "在这里设置 HTTP 请求所经过的多重代理链。注意：父级代理可能严重降低您的隐私安"
 "全度。在这里还可以设置 SOCKS 代理。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "调试 GIF 动画"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "调试 Force feature"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "调试重定向"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "调试正则表达式"
 
@@ -145,7 +145,7 @@ msgstr "如果没有需要认证的父级代理时，不推荐开启这个选项
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "在设置目录中未找到文件“%s”"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "文件不存在或为空"
@@ -198,25 +198,25 @@ msgstr "Privoxy 用户手册位置。"
 msgid "Log File Viewer"
 msgstr "日志查看器"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "记录所有接收的网络数据"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "记录所有发送的网络数据"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "记录配置保存动作"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr "记录 Privoxy 允许的所有请求。另请参考“Debug 1024”。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -265,7 +265,7 @@ msgstr "必需选项：没有设置有效的 IPv6 地址！"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "必需选项：没有设置有效的端口！"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "客户端数量上限。"
 
@@ -288,16 +288,16 @@ msgstr "未安装"
 msgid "No trailing '/', please."
 msgstr "路径结尾不要加“/”。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "非致命性错误 - *强烈建议启用*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr "Socket 连接未收到数据的超时时间。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "开放的连接不再重复使用的超时时间。"
@@ -311,7 +311,7 @@ msgstr "只有使用外置规则时，Privoxy 才需要创建临时文件。"
 msgid "Please install current version !"
 msgstr "请安装当前版本！"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "请按下 [读取] 按钮"
 
@@ -346,19 +346,19 @@ msgstr ""
 "Privoxy 是一个无缓存的网络代理，具有高级过滤功能，能够修改网页数据和 HTTP 请"
 "求头、控制访问、移除广告等。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "读取/重新读取 日志文件"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "显示 I/O 状态"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "显示每个连接的状态"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "显示请求头 解析"
 
@@ -383,25 +383,23 @@ msgstr "启动 / 停止"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "启动/停止 Privoxy 网络代理"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "启动标语和警告。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "语法："
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "格式：由空格分隔的客户端请求头名称。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "格式：target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "格式：target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -419,7 +417,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr "Privoxy 接收客户端请求时监听的地址和 TCP 端口。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -449,11 +447,11 @@ msgstr "CGI 页面显示的主机名。"
 msgid "The log file to use. File name, relative to log directory."
 msgstr "日志文件名称，与日志路径相对。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr "转发数据前，客户端请求头的排序。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -471,7 +469,7 @@ msgid ""
 "has been activated."
 msgstr "只有开启了信任机制时这个选项的值才有效。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -489,6 +487,7 @@ msgid ""
 msgstr "这个标签用于设置与安全相关的 Privoxy 选项。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -505,11 +504,11 @@ msgstr "用户自定义"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "输入值不是一个数字"
 
@@ -517,7 +516,7 @@ msgstr "输入值不是一个数字"
 msgid "Value not between 0 and 300"
 msgstr "输入值不在 0 和 300 之间"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "输入值不在 0 和 9 之间"
 
@@ -525,10 +524,10 @@ msgstr "输入值不在 0 和 9 之间"
 msgid "Value not between 1 and 4096"
 msgstr "输入值不在 1 和 4096 之间"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "输入值为空或者不是大于零"
 
@@ -546,7 +545,7 @@ msgstr "版本"
 msgid "Version Information"
 msgstr "版本信息"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "是否应把被拦截的请求当作是有效的。"
 
@@ -556,17 +555,17 @@ msgid ""
 "state."
 msgstr "是否让 Privoxy 识别特殊的 HTTP 请求头以切换状态。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "是否在传递之前压缩缓冲内容。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr "是否应在不同的入站连接之间共享持久出站连接。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "是否处理管道化的请求。"
 
@@ -582,16 +581,16 @@ msgstr "是否使用基于网页的规则编辑器。"
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "是否启用基于网页的切换功能。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr "是否可以被拦截或重定向访问 Privoxy CGI 页面的请求。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr "是否让 CGI 界面兼容过时的 HTTP 客户端。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "是否只运行一个服务线程。"
 
@@ -616,3 +615,6 @@ msgstr "或更高"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "需要"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "格式：target_pattern socks_proxy[:port] http_parent[:port]"

--- a/applications/luci-app-privoxy/po/zh_Hant/privoxy.po
+++ b/applications/luci-app-privoxy/po/zh_Hant/privoxy.po
@@ -50,7 +50,7 @@ msgstr "可選的目錄，放在裡面的模板會被載入。"
 msgid "An email address to reach the Privoxy administrator."
 msgstr "用於聯絡 Privoxy 管理員的郵箱地址。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:691
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:695
 msgid ""
 "Assumed server-side keep-alive timeout (in seconds) if not specified by the "
 "server."
@@ -60,11 +60,11 @@ msgstr "當服務端沒有指定超時時間時假定的超時時間（單位：
 msgid "Boot delay"
 msgstr "開機延遲"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:869
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:873
 msgid "CGI user interface"
 msgstr "CGI 使用者介面"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:857
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:861
 msgid "Common Log Format"
 msgstr "通用日誌格式"
 
@@ -77,19 +77,19 @@ msgstr ""
 "在這裡設定 HTTP 請求所經過的多重代理鏈。注意：父級代理可能嚴重降低您的隱私安"
 "全度。在這裡還可以設定 SOCKS 代理。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:851
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:855
 msgid "Debug GIF de-animation"
 msgstr "除錯 GIF 動畫"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:833
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:837
 msgid "Debug force feature"
 msgstr "除錯 Force feature"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:845
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:849
 msgid "Debug redirects"
 msgstr "除錯重定向"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:839
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:843
 msgid "Debug regular expression filters"
 msgstr "除錯正則表示式"
 
@@ -145,7 +145,7 @@ msgstr "如果沒有需要認證的父級代理時，不推薦開啟這個選項
 msgid "File '%s' not found inside Configuration Directory"
 msgstr "在設定目錄中未找到檔案“%s”"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:915
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:919
 #: applications/luci-app-privoxy/luasrc/view/privoxy/detail_logview.htm:12
 msgid "File not found or empty"
 msgstr "檔案不存在或為空"
@@ -198,25 +198,25 @@ msgstr "Privoxy 使用者手冊位置。"
 msgid "Log File Viewer"
 msgstr "日誌檔檢視器"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:895
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:899
 msgid "Log all data read from the network"
 msgstr "記錄所有接收的網路資料"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:827
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:831
 msgid "Log all data written to the network"
 msgstr "記錄所有傳送的網路資料"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:901
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:905
 msgid "Log the applying actions"
 msgstr "記錄配置儲存動作"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:803
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:807
 msgid ""
 "Log the destination for each request Privoxy let through. See also 'Debug "
 "1024'."
 msgstr "記錄 Privoxy 允許的所有請求。另請參考“Debug 1024”。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:863
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:867
 msgid ""
 "Log the destination for requests Privoxy didn't let through, and the reason "
 "why."
@@ -265,7 +265,7 @@ msgstr "必需選項：沒有設定有效的 IPv6 地址！"
 msgid "Mandatory Input: No valid Port given!"
 msgstr "必需選項：沒有設定有效的埠！"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:733
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:737
 msgid "Maximum number of client connections that will be served."
 msgstr "客戶端數量上限。"
 
@@ -288,16 +288,16 @@ msgstr "未安裝"
 msgid "No trailing '/', please."
 msgstr "路徑結尾不要加“/”。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:881
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:885
 msgid "Non-fatal errors - *we highly recommended enabling this*"
 msgstr "非致命性錯誤 - *強烈建議啟用*"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:714
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:718
 msgid ""
 "Number of seconds after which a socket times out if no data is received."
 msgstr "Socket 連線未收到資料的超時時間。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:668
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:672
 msgid ""
 "Number of seconds after which an open connection will no longer be reused."
 msgstr "開放的連線不再重複使用的超時時間。"
@@ -311,7 +311,7 @@ msgstr "只有使用外接規則時，Privoxy 才需要建立臨時檔案。"
 msgid "Please install current version !"
 msgstr "請安裝當前版本！"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:913
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:917
 msgid "Please press [Read] button"
 msgstr "請點按［讀取］按鈕"
 
@@ -346,19 +346,19 @@ msgstr ""
 "Privoxy 是一個無快取的網路代理，具有高階過濾功能，能夠修改網頁資料和 HTTP 請"
 "求頭、控制訪問、移除廣告等。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:908
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:912
 msgid "Read / Reread log file"
 msgstr "讀取／重讀日誌檔"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:815
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:819
 msgid "Show I/O status"
 msgstr "顯示 I/O 狀態"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:809
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:813
 msgid "Show each connection status"
 msgstr "顯示每個連線的狀態"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:821
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:825
 msgid "Show header parsing"
 msgstr "顯示請求頭 解析"
 
@@ -383,25 +383,23 @@ msgstr "啟動 / 停止"
 msgid "Start/Stop Privoxy WEB Proxy"
 msgstr "啟動/停止 Privoxy 網路代理"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:875
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:879
 msgid "Startup banner and warnings."
 msgstr "啟動標語和警告。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:455
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:635
 msgid "Syntax:"
 msgstr "語法："
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:786
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:790
 msgid "Syntax: Client header names delimited by spaces."
 msgstr "格式：由空格分隔的客戶端請求頭名稱。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:612
 msgid "Syntax: target_pattern http_parent[:port]"
 msgstr "格式：target_pattern http_parent[:port]"
-
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:620
-msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
-msgstr "格式：target_pattern socks_proxy[:port] http_parent[:port]"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:59
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:62
@@ -419,7 +417,7 @@ msgid ""
 "The address and TCP port on which Privoxy will listen for client requests."
 msgstr "Privoxy 接收客戶端請求時監聽的地址和 TCP 埠。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:766
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:770
 msgid ""
 "The compression level that is passed to the zlib library when compressing "
 "buffered content."
@@ -449,11 +447,11 @@ msgstr "CGI 頁面顯示的主機名。"
 msgid "The log file to use. File name, relative to log directory."
 msgstr "要使用的日誌檔；檔案名稱與日誌目錄相對。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:784
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:788
 msgid "The order in which client headers are sorted before forwarding them."
 msgstr "轉發資料前，客戶端請求頭的排序。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:751
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:755
 msgid ""
 "The status code Privoxy returns for pages blocked with +handle-as-empty-"
 "document."
@@ -471,7 +469,7 @@ msgid ""
 "has been activated."
 msgstr "只有開啟了信任機制時這個選項的值才有效。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:796
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:800
 msgid ""
 "This option is only there for debugging purposes. It will drastically reduce "
 "performance."
@@ -489,6 +487,7 @@ msgid ""
 msgstr "這個標籤用於設定與安全相關的 Privoxy 選項。"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:618
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:633
 msgid ""
 "Through which SOCKS proxy (and optionally to which parent HTTP proxy) "
 "specific requests should be routed."
@@ -505,11 +504,11 @@ msgstr "使用者自定義"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:166
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:543
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:673
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:696
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:720
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:739
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:772
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:677
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:700
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:724
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:743
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:776
 msgid "Value is not a number"
 msgstr "值不是號碼"
 
@@ -517,7 +516,7 @@ msgstr "值不是號碼"
 msgid "Value not between 0 and 300"
 msgstr "值不介在 0 和 300 之間"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:774
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:778
 msgid "Value not between 0 and 9"
 msgstr "輸入值不在 0 和 9 之間"
 
@@ -525,10 +524,10 @@ msgstr "輸入值不在 0 和 9 之間"
 msgid "Value not between 1 and 4096"
 msgstr "輸入值不在 1 和 4096 之間"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:675
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:698
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:722
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:741
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:679
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:702
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:726
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:745
 msgid "Value not greater 0 or empty"
 msgstr "輸入值為空或者不是大於零"
 
@@ -546,7 +545,7 @@ msgstr "版本"
 msgid "Version Information"
 msgstr "版本資訊"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:646
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:650
 msgid "Whether intercepted requests should be treated as valid."
 msgstr "是否應把被攔截的請求當作是有效的。"
 
@@ -556,17 +555,17 @@ msgid ""
 "state."
 msgstr "是否讓 Privoxy 識別特殊的 HTTP 請求頭以切換狀態。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:758
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:762
 msgid "Whether or not buffered content is compressed before delivery."
 msgstr "是否在傳遞之前壓縮緩衝內容。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:706
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:710
 msgid ""
 "Whether or not outgoing connections that have been kept alive should be "
 "shared between different incoming connections."
 msgstr "是否應在不同的入站連線之間共享持久出站連線。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:683
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:687
 msgid "Whether or not pipelined requests should be served."
 msgstr "是否處理管道化的請求。"
 
@@ -582,16 +581,16 @@ msgstr "是否使用基於網頁的規則編輯器。"
 msgid "Whether or not the web-based toggle feature may be used."
 msgstr "是否啟用基於網頁的切換功能。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:653
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:657
 msgid "Whether requests to Privoxy's CGI pages can be blocked or redirected."
 msgstr "是否可以被攔截或重定向訪問 Privoxy CGI 頁面的請求。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:660
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:664
 msgid ""
 "Whether the CGI interface should stay compatible with broken HTTP clients."
 msgstr "是否讓 CGI 介面相容過時的 HTTP 客戶端。"
 
-#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:794
+#: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:798
 msgid "Whether to run only one server thread."
 msgstr "是否只執行一個服務執行緒。"
 
@@ -616,3 +615,6 @@ msgstr "或更高"
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:89
 msgid "required"
 msgstr "需要"
+
+#~ msgid "Syntax: target_pattern socks_proxy[:port] http_parent[:port]"
+#~ msgstr "格式：target_pattern socks_proxy[:port] http_parent[:port]"


### PR DESCRIPTION
Privoxy supports login password for socks5 proxy forwarding. It allows use proxy in format [user:pass@]socks_proxy[:port] http_parent[:port] as noted in the official documentations.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] Fixes openwrt/luci#7251
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
