### PR TITLE
luci-theme-openwrt: change to HTML (like all other themes) instead of XML to fix incompatibility

### DIFF
--- a/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
+++ b/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
@@ -10,12 +10,11 @@
 	const boardinfo = ubus.call('system', 'board');
 	const loadinfo =  ubus.call("system", "info")?.load;
 
-	http.prepare_content("application/xhtml+xml");
+	http.prepare_content('text/html; charset=UTF-8');
 -%}
 
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{{ dispatcher.lang }}" lang="{{ dispatcher.lang }}">
+<!DOCTYPE html>
+<html lang="{{ dispatcher.lang }}">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
luci-theme-openwrt: change to HTML (like all other themes) instead of XML to fix incompatibility

see also https://github.com/openwrt/luci/issues/7229
