### PR TITLE
luci-app-commands: correctly pass custom arguments as query string

### DIFF
--- a/applications/luci-app-commands/ucode/template/commands.ut
+++ b/applications/luci-app-commands/ucode/template/commands.ut
@@ -45,7 +45,8 @@
 			legend.parentNode.style.display = 'block';
 			legend.style.display = 'inline';
 
-			L.Request.get(L.url('admin/system/commands/run', id), field ? { args: field.value } : null).then(function(reply) {
+			var options = field ? { query: { args: field.value } } : null;
+			L.Request.get(L.url('admin/system/commands/run', id), options).then(function(reply) {
 				var st = reply.json();
 
 				if (st.binary)


### PR DESCRIPTION
Commit 702c007 changed the request to be invoked via the Request.get function instead of the deprecated XHR one. The request options object requires the query string to be located inside of the subobject "query", otherwise they are not picked up. This resulted in breaking the custom arguments functionality as the input would simply be ignored.

Fixes #7255

Before:
![Screenshot_3](https://github.com/user-attachments/assets/c5a0e0a1-94cd-4df4-bcb9-dbb020b8c22c)

After:
![Screenshot_4](https://github.com/user-attachments/assets/ab515318-879f-43d5-8106-830c4a614b8c)

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/64, SNAPSHOT r27433-7e1d092552, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @jow- 
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: openwrt/luci#7255
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
