### PR TITLE
luci-mod-network: split interface name and protocol validation

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1237,7 +1237,10 @@ return view.extend({
 			};
 
 			proto = s2.option(form.ListValue, 'proto', _('Protocol'));
-			proto.validate = name.validate;
+			proto.onchange = function(ev, section_id, value) {
+				var elem = name.getUIElement(section_id);
+				elem.triggerValidation();
+			};
 
 			device = s2.option(widgets.DeviceSelect, 'device', _('Device'));
 			device.noaliases = false;


### PR DESCRIPTION
The previous implementation of binding the protocol validation to the name validation caused problems when creating a new interface where an already existing interface had the new one's protocol as its name, as the protocol would be used when validating if an interface of that name already existed.

Consider the following case:
1. Interface 'gre' with protocol PPPoE is created
2. Interface 'foo' with protocol GRE tunnel over IPv4 (which resolves to 'gre') tries to be created

Creating interface 'foo' would error out during protocol validation as 'gre' would be passed to the name validation, which in turn would check if an interface with name 'gre' already exists, which it does.

Instead of reusing the validation logic, simply trigger the name validation manually as the protocol changes to properly pass the name of the interface instead of the protocol. This also gives the benefit of keeping all error states related to the name contained in the appropriate UI element.

Fixes #7146

List of existing interfaces:

![Screenshot_45](https://github.com/user-attachments/assets/666b4ae1-008f-43bd-a3e2-e5e9468afa42)

Before:
![Screenshot_43](https://github.com/user-attachments/assets/80a8c507-446b-4811-b719-9778da465653)

After:
![Screenshot_44](https://github.com/user-attachments/assets/0ef95943-4efb-4e3c-8428-347558c0d0cc)

All existing validation logic still works as expected:
![Screenshot_46](https://github.com/user-attachments/assets/40c5267f-b871-428d-968e-e38c3af2f98d)
![Screenshot_47](https://github.com/user-attachments/assets/61ae8e92-cff7-42e0-97b9-1c06a0cacc34)

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile N/A
- [X] Tested on: (x86/64, SNAPSHOT r27466-f368e2d5ec, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @jow
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: e.g. #7146 
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
