### PR TITLE
luci-app-eventcat: add package.

### DIFF
--- a/applications/luci-app-eventcat/Makefile
+++ b/applications/luci-app-eventcat/Makefile
@@ -1,0 +1,13 @@
+# This is free software, licensed under the Apache License, Version 2.0 .
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Support for Eventcat
+LUCI_DEPENDS:=+luci-base +eventcat
+
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js
+++ b/applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js
@@ -1,0 +1,86 @@
+'use strict';
+'require view';
+'require form';
+'require tools.widgets as widgets';
+
+return view.extend({
+    render: function () {
+        var m, s, o;
+
+        m = new form.Map('eventcat',
+            _('Eventcat'),
+            _('Configure Eventcat to monitor network connectivity and execute actions based on connectivity status or periodic checks.'));
+
+        s = m.section(form.TypedSection, 'eventcat', _('Eventcat'), _('These rules will govern how the device reacts to network events.'));
+        s.anonymous = true;
+        s.addremove = true;
+
+        s.tab('general', _('General Settings'));
+
+        o = s.taboption('general', form.ListValue, 'mode',
+            _('Mode'),
+            _('Select the mode for Eventcat. Connectivity Check monitors hosts periodically, while Periodic runs actions at regular intervals.'));
+        o.value('connectivity_check', _('Connectivity Check'));
+        o.value('periodic', _('Periodic'));
+
+        o = s.taboption('general', form.ListValue, 'action',
+            _('Action'),
+            _('Select the action to take when the condition is met.'));
+        o.value('reboot', _('Reboot Device'));
+        o.value('restart_interface', _('Restart Interface'));
+        o.value('run_script', _('Run Script'));
+
+        o = s.taboption('general', form.Value, 'period',
+            _('Period'),
+            _('Interval in seconds for periodic actions or connectivity checks.'));
+        o.datatype = 'string';
+        o.validate = function (section_id, value) {
+            return (/^\d+[smhd]?$/).test(value) ? true : _('Invalid period format. Use numbers optionally followed by s, m, h, or d (e.g., 10, 10s, 10d).');
+        };
+        o.default = '6h';
+
+        o = s.taboption('general', widgets.DeviceSelect, 'interface',
+            _('Interface'),
+            _('Network interface to monitor or restart.'));
+        o.depends({ action: 'restart_interface' });
+        o.depends({ mode: 'connectivity_check' });
+
+        o = s.taboption('general', form.DynamicList, 'host',
+            _('Hosts to Check'),
+            _('List of hosts (IP addresses) to check for connectivity.'));
+        o.datatype = 'host';
+        o.depends({ mode: 'connectivity_check' });
+
+        o = s.taboption('general', form.Value, 'script',
+            _('Script to Run'),
+            _('Specify the script path to execute when action is set to "Run Script".'));
+        o.datatype = 'file';
+        o.default = '/usr/bin/custom_script.sh';
+        o.depends({ action: 'run_script' });
+
+        o = s.taboption('general', form.ListValue, 'address_family',
+            _('Address Family'),
+            _('Select the IP address family for pinging the host.'));
+        o.value('ipv4', _('IPv4'));
+        o.value('ipv6', _('IPv6'));
+        o.value('any', _('Any'));
+        o.default = 'ipv4';
+        o.depends({ mode: 'connectivity_check' });
+
+        o = s.taboption('general', form.Value, 'ping_interval',
+            _('Ping Interval'),
+            _('Interval in seconds between each connectivity check.'));
+        o.datatype = 'uinteger';
+        o.default = '30';
+        o.depends({ mode: 'connectivity_check' });
+
+        o = s.taboption('general', form.Value, 'ping_timeout',
+            _('Ping Timeout'),
+            _('Timeout in seconds for each ping attempt.'));
+        o.datatype = 'uinteger';
+        o.default = '5';
+        o.depends({ mode: 'connectivity_check' });
+
+        return m.render();
+    }
+});

--- a/applications/luci-app-eventcat/po/templates/watchcat.pot
+++ b/applications/luci-app-eventcat/po/templates/watchcat.pot
@@ -1,0 +1,139 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:27
+msgid "Action"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:62
+msgid "Address Family"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:66
+msgid "Any"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:12
+msgid ""
+"Configure Eventcat to monitor network connectivity and execute actions based "
+"on connectivity status or periodic checks."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:23
+msgid "Connectivity Check"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:11
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:14
+#: applications/luci-app-eventcat/root/usr/share/luci/menu.d/luci-app-eventcat.json:3
+msgid "Eventcat"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:18
+msgid "General Settings"
+msgstr ""
+
+#: applications/luci-app-eventcat/root/usr/share/rpcd/acl.d/luci-app-eventcat.json:3
+msgid "Grant access to LuCI app eventcat"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:49
+msgid "Hosts to Check"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:64
+msgid "IPv4"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:65
+msgid "IPv6"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:43
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:72
+msgid "Interval in seconds between each connectivity check."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:35
+msgid "Interval in seconds for periodic actions or connectivity checks."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:38
+msgid ""
+"Invalid period format. Use numbers optionally followed by s, m, h, or d (e."
+"g., 10, 10s, 10d)."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:50
+msgid "List of hosts (IP addresses) to check for connectivity."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:21
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:44
+msgid "Network interface to monitor or restart."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:34
+msgid "Period"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:24
+msgid "Periodic"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:71
+msgid "Ping Interval"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:78
+msgid "Ping Timeout"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:29
+msgid "Reboot Device"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:30
+msgid "Restart Interface"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:31
+msgid "Run Script"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:55
+msgid "Script to Run"
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:63
+msgid "Select the IP address family for pinging the host."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:28
+msgid "Select the action to take when the condition is met."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:22
+msgid ""
+"Select the mode for Eventcat. Connectivity Check monitors hosts "
+"periodically, while Periodic runs actions at regular intervals."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:56
+msgid ""
+"Specify the script path to execute when action is set to \"Run Script\"."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:14
+msgid "These rules will govern how the device reacts to network events."
+msgstr ""
+
+#: applications/luci-app-eventcat/htdocs/luci-static/resources/view/eventcat.js:79
+msgid "Timeout in seconds for each ping attempt."
+msgstr ""

--- a/applications/luci-app-eventcat/root/usr/share/luci/menu.d/luci-app-eventcat.json
+++ b/applications/luci-app-eventcat/root/usr/share/luci/menu.d/luci-app-eventcat.json
@@ -1,0 +1,15 @@
+{
+    "admin/services/eventcat": {
+        "title": "Eventcat",
+        "order": 90,
+        "action": {
+            "type": "view",
+            "path": "eventcat"
+        },
+        "depends": {
+            "acl": [
+                "luci-app-eventcat"
+            ]
+        }
+    }
+}

--- a/applications/luci-app-eventcat/root/usr/share/rpcd/acl.d/luci-app-eventcat.json
+++ b/applications/luci-app-eventcat/root/usr/share/rpcd/acl.d/luci-app-eventcat.json
@@ -1,0 +1,20 @@
+{
+    "luci-app-eventcat": {
+        "description": "Grant access to LuCI app eventcat",
+        "read": {
+            "file": {
+                "/usr/bin/eventcat.sh": [
+                    "exec"
+                ]
+            },
+            "uci": [
+                "eventcat"
+            ]
+        },
+        "write": {
+            "uci": [
+                "eventcat"
+            ]
+        }
+    }
+}

--- a/applications/luci-app-eventcat/root/usr/share/ucitrack/luci-app-eventcat.json
+++ b/applications/luci-app-eventcat/root/usr/share/ucitrack/luci-app-eventcat.json
@@ -1,0 +1,4 @@
+{
+    "config": "eventcat",
+    "init": "eventcat"
+}


### PR DESCRIPTION
Eventcat is like Watchcat but written in Lua and can react to interface up/down events. Depends on https://github.com/openwrt/packages/pull/25088

<img width="992" alt="Screenshot 2024-10-06 at 21 02 53" src="https://github.com/user-attachments/assets/f32d5062-2d41-4d58-94dc-876c8e372f09">

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
