### PR TITLE
[23.05] luci-app-advanced-reboot: update to 1.0.1-15

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-r10
+PKG_VERSION:=1.0.1-11
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-advanced-reboot
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=13
+PKG_RELEASE:=15
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -1,19 +1,29 @@
-# Copyright 2017-2018 Stan Grishin (stangri@melmac.net)
-# This is free software, licensed under the GNU General Public License v3.
+# Copyright 2017-2024 MOSSDeF, Stan Grishin (stangri@melmac.ca).
+# This is free software, licensed under AGPL-3.0-or-later.
 
 include $(TOPDIR)/rules.mk
 
-PKG_LICENSE:=GPL-3.0-or-later
-PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-11
+PKG_NAME:=luci-app-advanced-reboot
+PKG_LICENSE:=AGPL-3.0-or-later
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=13
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
-LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/
+LUCI_URL:=https://github.com/stangri/luci-app-advanced-reboot/
 LUCI_DESCRIPTION:=Provides Web UI (found under System/Advanced Reboot) to reboot supported Linksys and ZyXEL routers to\
 	an alternative partition. Also provides Web UI to shut down (power off) your device. 	Supported dual-partition\
 	routers are listed at https://docs.openwrt.melmac.net/luci-app-advanced-reboot/
 LUCI_DEPENDS:=+luci-mod-admin-full +jshn
 LUCI_PKGARCH:=all
+
+define Package/$(PKG_NAME)/config
+# shown in make menuconfig <Help>
+help
+	$(LUCI_TITLE)
+	.
+	Version: $(PKG_VERSION)-$(PKG_RELEASE)
+endef
 
 include ../../luci.mk
 

--- a/applications/luci-app-advanced-reboot/README.md
+++ b/applications/luci-app-advanced-reboot/README.md
@@ -1,3 +1,3 @@
-# Advanced Reboot Web UI (luci-app-advanced-reboot)
+# README
 
-README has been moved to [https://docs.openwrt.melmac.net/luci-app-advanced-reboot/](<https://docs.openwrt.melmac.net/luci-app-advanced-reboot/>).
+Documentation for this project is available at [https://docs.openwrt.melmac.net/luci-app-advanced-reboot/](https://docs.openwrt.melmac.net/luci-app-advanced-reboot/).

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea6350v4.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea6350v4.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "EA6350v4",
+	"boardNames": [ "linksys,ea6350-v4" ],
+	"partition1MTD": "mtd5",
+	"partition2MTD": "mtd7",
+	"labelOffset": 32,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-mx4200v1.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-mx4200v1.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "MX4200v1",
+	"boardNames": [ "linksys,mx4200v1" ],
+	"partition1MTD": "mtd21",
+	"partition2MTD": "mtd23",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-mx4200v2.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-mx4200v2.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "MX4200v2",
+	"boardNames": [ "linksys,mx4200v2" ],
+	"partition1MTD": "mtd21",
+	"partition2MTD": "mtd23",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-mx4300.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-mx4300.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "MX4300",
+	"boardNames": [ "linksys,mx4300" ],
+	"partition1MTD": "mtd21",
+	"partition2MTD": "mtd23",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw03.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw03.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "WHW03 (Velop)",
+	"boardNames": [ "linksys,whw03" ],
+	"partition1MTD": "mmcblk0p14",
+	"partition2MTD": "mmcblk0p16",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 23.05.5
Run tested: ramips/mt7621, Linksys EA6350v4, OpenWrt 23.05.5 (by [Seraphin84](https://github.com/Seraphin84))

Update to the most recent version, this update includes:
* copyright & license updates
* better package definitions in Makefile
* better presence in make menuconfig
* better version/release information compatible with both opkg/apk
* updated link to upstream code
* updated README link wording
* add support for Linksys MX4200v1
* add support for Linksys MX4200v2
* add support for Linksys MX4300
* add support for Linksys WHW03
* add support for Linksys EA6350v4

Signed-off-by: Stan Grishin <stangri@melmac.ca>
