### PR TITLE
RFC: luci-mod-system: Allow selective file restore from backups

### DIFF
--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -149,6 +149,9 @@
 			"cgi-io": [ "upload" ],
 			"file": {
 				"/bin/tar -tzf /tmp/backup.tar.gz": [ "exec" ],
+				"/bin/mkdir -p /tmp/selective_restore/": [ "exec" ],
+				"/bin/tar -xzf /tmp/backup.tar.gz -T /tmp/filelist.txt -C /tmp/selective_restore/": [ "exec" ],
+				"/bin/tar -czf /tmp/selective_restore.tar.gz -T /tmp/filelist.txt -C /tmp/selective_restore/": [ "exec" ],
 				"/etc/sysupgrade.conf": [ "write" ],
 				"/sbin/firstboot -r -y": [ "exec" ],
 				"/sbin/reboot": [ "exec" ],
@@ -162,8 +165,10 @@
 				"/sbin/sysupgrade -u /tmp/firmware.bin": [ "exec" ],
 				"/sbin/sysupgrade -u -k /tmp/firmware.bin": [ "exec" ],
 				"/sbin/sysupgrade --restore-backup /tmp/backup.tar.gz": [ "exec" ],
+				"/sbin/sysupgrade --restore-backup /tmp/selective_restore.tar.gz": [ "exec" ],
 				"/sbin/sysupgrade --test /tmp/firmware.bin": [ "exec" ],
 				"/sbin/sysupgrade /tmp/firmware.bin": [ "exec" ],
+				"/tmp/filelist.txt": [ "write" ],
 				"/tmp/backup.tar.gz": [ "write" ],
 				"/tmp/firmware.bin": [ "write" ]
 			},


### PR DESCRIPTION
This is useful when you're importing backups intended for different hardware, for example, where e.g. `/etc/config/[network|wireless]` are not suitable for the target platform, but everything else useful.

Current iteration caveats: subsequent extraction and compression steps happen on the target device, to then feed the selective_backup archive to sysupgrade. ( It's not impossible that a users `/etc/sysupgrade.conf` that created the original backup stashed gigs of stuff in there... but this is an extreme and unlikely edge case, in which case they're better off using just the original restore ).

Next version avoids this once https://github.com/openwrt/openwrt/pull/16656 is merged 

Feedback welcome. 

The backup restore overview
![Screenshot 2024-10-11 at 01 04 21](https://github.com/user-attachments/assets/55098fcd-d512-43a1-83ff-6cde05a92ebd)

the selective dialogue
![Screenshot 2024-10-11 at 01 21 16](https://github.com/user-attachments/assets/6e416086-e278-45cc-9869-12d5845f4a90)

In case nothing was chosen
![Screenshot 2024-10-11 at 01 10 57](https://github.com/user-attachments/assets/2e580ac5-148e-4056-bac2-be62086bb2e9)



<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: 23.05.5
- [x] \( Preferred ) Mention: @jow- @Ansuel @hnyman 
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
