### PR TITLE
luci-proto-modemmanager: add initial EPS bearer support

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -147,9 +147,9 @@ return network.registerProtocol('modemmanager', {
 
 		o = s.taboption('general', form.Value, 'signalrate', _('Signal Refresh Rate'), _("In seconds"));
 		o.datatype = 'uinteger';
-		
+
 		s.taboption('general', form.Value, 'metric', _('Gateway metric'));
-		
+
 		s.taboption('advanced', form.Flag, 'debugmode', _('Enable Debugmode'));
 
 		o = s.taboption('advanced', form.ListValue, 'loglevel', _('Log output level'));
@@ -158,6 +158,52 @@ return network.registerProtocol('modemmanager', {
 		o.value('INFO', _('Info'));
 		o.value('DEBUG', _('Debug'));
 		o.default = 'ERR';
-		
+
+		o = s.taboption('general', form.ListValue, 'init_epsbearer', _('Initial EPS Bearer'),
+		_('none: Do not set an initial EPS bearer (default behaviour)') + '<br/>' +
+		_('default: Use the configuration options above (APN, IP Type, ...).') + '<br/>' +
+		_('custom: Use different options when establishing a connection (these options are prefixed with %s).').format('<code>init_</code>'));
+		o.value('', _('none'));
+		o.value('default', 'default');
+		o.value('custom', 'custom');
+		o.default = '';
+
+		o = s.taboption('general', form.Value, 'init_apn', _('Initial EPS Bearer APN'));
+		o.depends('init_epsbearer', 'custom');
+		o.default = '';
+
+		o = s.taboption('general', form.ListValue, 'init_allowedauth', _('Initial EPS Bearer Authentication Type'));
+		o.depends('init_epsbearer', 'custom');
+		o.value('pap', 'PAP');
+		o.value('chap', 'CHAP');
+		o.value('mschap', 'MSCHAP');
+		o.value('mschapv2', 'MSCHAPv2');
+		o.value('eap', 'EAP');
+		o.value('', _('None'));
+		o.default = '';
+
+		o = s.taboption('general', form.Value, 'init_username', _('Initial EPS Bearer Username'));
+		o.depends('init_allowedauth', 'pap');
+		o.depends('init_allowedauth', 'chap');
+		o.depends('init_allowedauth', 'mschap');
+		o.depends('init_allowedauth', 'mschapv2');
+		o.depends('init_allowedauth', 'eap');
+		o.default = '';
+
+		o = s.taboption('general', form.Value, 'init_password', _('Initial EPS Bearer Password'));
+		o.depends('init_allowedauth', 'pap');
+		o.depends('init_allowedauth', 'chap');
+		o.depends('init_allowedauth', 'mschap');
+		o.depends('init_allowedauth', 'mschapv2');
+		o.depends('init_allowedauth', 'eap');
+		o.default = '';
+		o.password = true;
+
+		o = s.taboption('general', form.ListValue, 'init_iptype', _('Initial EPS Bearer IP Type'));
+		o.depends('init_epsbearer', 'custom');
+		o.value('ipv4v6', _('IPv4/IPv6 (both - defaults to IPv4)'))
+		o.value('ipv4', _('IPv4 only'));
+		o.value('ipv6', _('IPv6 only'));
+		o.default = 'ipv4v6';
 	}
 });


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (qualcommax/ipq60xx, main, Chrome) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)

ModemManager protocol has supported setting initial EPS bearer since package commit [1], so lets expose the same support via LuCI as well.

[1] https://github.com/openwrt/packages/commit/af12147f8c54ac3a44d32c5c1bd95099bc9a6c74
