### PR TITLE
luci-app-opkg: fix passing wrong option on opkg update/install

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -984,7 +984,10 @@ function handleOpkg(ev)
 				_('Waiting for the <em>opkg %h</em> command to complete…').format(cmd))
 		]);
 
-		var argv = [ cmd, '--force-removal-of-dependent-packages' ];
+		var argv = [ cmd ];
+
+		if (cmd == 'remove')
+			argv.push('--force-removal-of-dependent-packages')
 
 		if (rem && rem.checked)
 			argv.push('--autoremove');

--- a/applications/luci-app-opkg/root/usr/share/rpcd/acl.d/luci-app-opkg.json
+++ b/applications/luci-app-opkg/root/usr/share/rpcd/acl.d/luci-app-opkg.json
@@ -17,9 +17,10 @@
 		},
 		"write": {
 			"file": {
+				"/usr/libexec/opkg-call install": [ "exec" ],
 				"/usr/libexec/opkg-call install *": [ "exec" ],
 				"/usr/libexec/opkg-call remove *": [ "exec" ],
-				"/usr/libexec/opkg-call update *": [ "exec" ],
+				"/usr/libexec/opkg-call update": [ "exec" ],
 				"/etc/opkg.conf": [ "write" ],
 				"/etc/opkg/*.conf": [ "write" ],
 				"/tmp/upload.ipk": [ "write" ]


### PR DESCRIPTION
Fix passing wrong option on opkg update/install. While starting to introduce support for APK in the opkg module, it was notice that --force-removal-of-dependent-packages was always passed even with update and install command.

This was probably a leftover/oversight of old one. To fix this, limit this option only on remove and also update the acl.d to support single call to update or install.

Fixes: 9b25031cb29b ("luci-app-opkg: rework backend operations")
