### PR TITLE
luci-proto-wireguard: fixed bug with incorrect peer name detection

### DIFF
--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for WireGuard VPN
-LUCI_DEPENDS:=+wireguard-tools +ucode +luci-lib-uqr
+LUCI_DEPENDS:=+wireguard-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -15,6 +15,19 @@ function command(cmd) {
 	return trim(popen(cmd)?.read?.('all'));
 }
 
+function checkPeerHost(configHost, configPort, wgHost) {
+	const ips = popen(`resolveip ${configHost} 2>/dev/null`);
+	if (ips) {
+		for (let line = ips.read('line'); length(line); line = ips.read('line')) {
+			const ip =  rtrim(line, '\n');
+			if (ip + ":" + configPort == wgHost) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 
 const methods = {
 	generatePsk: {
@@ -76,7 +89,7 @@ const methods = {
 						let peer_name;
 
 						uci.foreach('network', `wireguard_${last_device}`, (s) => {
-							if (s.public_key == record[1])
+							if (!s.disabled && s.public_key == record[1] && checkPeerHost(s.endpoint_host, s.endpoint_port, record[3]))
 								peer_name = s.description;
 						});
 


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: this-username-has-been-taken <119663930+this-username-has-been-taken@users.noreply.github.com>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: OpenWrt SNAPSHOT r27859-f9da81d32f; mediatek/filogic; aarch64_cortex-a53; Firefox
- [X] \( Preferred ) Mention: @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: https://github.com/openwrt/luci/issues/7339
- [X] Description:

Fixed bug with incorrect peer name detection on `Status -> WireGuard` page when more than one peer with the same public key exist:
1. Peers are now tested not only by public key, but also by enabled/disabled status, peer host (both IP and FQDN are supported) and port.
2. Added required `resolveip` dependency.
