### PR TITLE
luci-app-statistics: render all graphs on refresh if no summary

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/graphs.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/graphs.js
@@ -74,7 +74,7 @@ return view.extend({
 					'data-tab-title': multiple ? title : null,
 					'data-plugin': plugin,
 					'data-plugin-instance': plugin_instance,
-					'data-is-index': i ? null : true,
+					'data-is-index': i || render_instances.length == 1 ? null : true,
 					'cbi-tab-active': function(ev) { activeInstance = ev.target.getAttribute('data-plugin-instance') }
 				}, blobs.map(function(blob) {
 					return E('img', {


### PR DESCRIPTION
In the past, a summary page would usually be generated for the data, but this did not occur when there was only a single instance (e.g., a single Wi-Fi interface). As a result, the refresh mistakenly requested the summary instead of the available data.

i.e. graphs would mysteriously disappear on refresh.

See #6468 for more context.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: private fork of 23.05 - haven't tried on master; my apologies.
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] Closes #6468 
- [x] Description: (describe the changes proposed in this PR)
