### PR TITLE
luci-nginx: rename luci-app-opkg to luci-app-package-manager

### DIFF
--- a/applications/luci-app-package-manager/Makefile
+++ b/applications/luci-app-package-manager/Makefile
@@ -13,6 +13,8 @@ LUCI_DEPENDS:=+luci-base
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
+PKG_PROVIDES:=luci-app-opkg
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -13,7 +13,7 @@ LUCI_TITLE:=LuCI interface with Nginx as Webserver
 LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
 LUCI_DEPENDS:= \
 	+nginx +nginx-mod-luci +luci-mod-admin-full +luci-theme-bootstrap \
-	+luci-app-firewall +luci-app-opkg +luci-proto-ppp +IPV6:luci-proto-ipv6 \
+	+luci-app-firewall +luci-app-package-manager +luci-proto-ppp +IPV6:luci-proto-ipv6 \
 	+rpcd-mod-rrdns
 
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Rename luci-app-opkg to luci-app-package-manager.

See openwrt/luci#7345 for more context.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @Ansuel the original code author for feedback
- [x] \( Optional ) Closes: openwrt/luci#7345
