### PR TITLE
luci-mod-network: add 11be support - revert hwval null check 

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -521,9 +521,7 @@ var CBIWifiFrequencyValue = form.Value.extend({
 		if (hwval != null) {
 			this.useBandOption = false;
 
-			if (/be/.test(mode.value))
-				band.value = '6g';
-			else if (/ax/.test(mode.value))
+			if (/a/.test(hwval))
 				band.value = '5g';
 			else
 				band.value = '2g';


### PR DESCRIPTION
revert hwval null check by removing ax/be check that were misplaced - this check only applies to 5g/2g 

ping @Shine-