### PR TITLE
Fix the model text alignment

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
@@ -118,7 +118,7 @@
 }
 
 .Dashboard .settings-info p span:nth-child(2){
-    display: inline-block;
+    display: inline-flex;
     word-break: break-all;
 }
 


### PR DESCRIPTION
The model name misalignment, with "out" appearing on a separate line, is due to `inline-block` styling in `luci-mod-dashboard`, which causes unintended text wrapping. 

Switching to `inline-flex` fixes this by keeping elements on the same line.

