### PR TITLE
luci-mod-status: channel_analysis: detect 160 MHz capable AP

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -314,6 +314,22 @@ return view.extend({
 					if (res.vht_operation.channel_width == 80) {
 						chan_width = 8;
 						res.channel_width = "80 MHz";
+
+						/* If needed, adjust based on the 802.11ac Wave 2 interop workaround. */
+						if (res.vht_operation.center_freq_2) {
+							var diff = Math.abs(res.vht_operation.center_freq_2 -
+							                    res.vht_operation.center_freq_1);
+
+							if (diff == 8) {
+								chan_width = 16;
+								res.channel_width = "160 MHz";
+								center_channels.push(res.vht_operation.center_freq_2);
+							} else if (diff > 8) {
+								chan_width = 8;
+								res.channel_width = "80+80 MHz";
+								center_channels.push(res.vht_operation.center_freq_2);
+							}
+						}
 					} else if (res.vht_operation.channel_width == 8080) {
 						res.channel_width = "80+80 MHz";
 						chan_width = 8;


### PR DESCRIPTION
Implement a workaround to detect an 160MHz capable AP. It was introduced in the mac80211 in 2016 with 802.11ac Wave 2. APs capable of 160 MHz are detected by the shift of central frequencies. More detailed description in the link [1]. Every AP I have seen presents support for 160 MHz this way.

[1] https://github.com/torvalds/linux/commit/23665aaf9170ae6328cc4f68250c529a628af2ab
Fixes: #6262
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>

![obraz](https://github.com/user-attachments/assets/8baf724f-de22-461f-b35c-07f10ad0d68d)

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: WAX206 (mediatek/mt7622), OpenWRT snapshot, Firefox 131.0.3 :white_check_mark:
- [x] \( Preferred ) Mention: @Ansuel  the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#6262
- [x] Description: (describe the changes proposed in this PR)
