### PR TITLE
luci-app-package-manager: Fix upgrade action for apk

### DIFF
--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -261,6 +261,7 @@ function display(pattern)
 			btn = E('div', {
 				'class': 'btn cbi-button-positive',
 				'data-package': name,
+				'data-action': 'upgrade',
 				'click': handleInstall
 			}, _('Upgrade…'));
 		}
@@ -284,12 +285,14 @@ function display(pattern)
 				btn = E('div', {
 					'class': 'btn cbi-button-action',
 					'data-package': name,
+					'data-action': 'install',
 					'click': handleInstall
 				}, _('Install…'));
 			else if (inst.installed && inst.version != pkg.version)
 				btn = E('div', {
 					'class': 'btn cbi-button-positive',
 					'data-package': name,
+					'data-action': 'upgrade',
 					'click': handleInstall
 				}, _('Upgrade…'));
 			else
@@ -661,6 +664,7 @@ function handleReset(ev)
 function handleInstall(ev)
 {
 	var name = ev.target.getAttribute('data-package'),
+	    installcmd = ev.target.getAttribute('data-action'),
 	    pkg = packages.available.pkgs[name],
 	    depcache = {},
 	    size;
@@ -800,7 +804,7 @@ function handleInstall(ev)
 			}, _('Cancel')),
 			' ',
 			E('div', {
-				'data-command': 'install',
+				'data-command': installcmd,
 				'data-package': name,
 				'class': 'btn cbi-button-action',
 				'click': handlePkg,
@@ -872,7 +876,7 @@ function handleConfig(ev)
 				} else if (partials[i].name.match(/\.conf$/)) {
 					files.push(base_dir + '/' + partials[i].name);
 				}
-			}			
+			}
 		}
 
 		return Promise.all(files.map(function(file) {

--- a/applications/luci-app-package-manager/root/usr/share/rpcd/acl.d/luci-app-package-manager.json
+++ b/applications/luci-app-package-manager/root/usr/share/rpcd/acl.d/luci-app-package-manager.json
@@ -20,6 +20,8 @@
 				"/usr/libexec/package-manager-call install *": [ "exec" ],
 				"/usr/libexec/package-manager-call remove *": [ "exec" ],
 				"/usr/libexec/package-manager-call update": [ "exec" ],
+				"/usr/libexec/package-manager-call upgrade": [ "exec" ],
+				"/usr/libexec/package-manager-call upgrade *": [ "exec" ],
 				"/etc/opkg.conf": [ "write" ],
 				"/etc/opkg/*.conf": [ "write" ],
 				"/etc/apk/repositories": [ "write" ],


### PR DESCRIPTION
cc @Ansuel @aparcar 

Fix upgrade action for apk by passing an attribute via 'handleInstall' to set correctly the command for 'handlePkg' in order to differentiate between install and upgrade actions.  (Note: 'handleManualInstall' sets always 'install')
Adjust acl accordingly.

Remove extra whitespace.

Tested on live system for 
* both apk & opkg enables systems, 
* both install (single package and packages with dependencies to install) and upgrade.


apk
```
Executing package manager

(1/1) Upgrading luci-app-adblock (24.284.61488~02f2d47 -> 24.304.46082~f9899fd)
OK: 70 MiB in 307 packages
```
opkg
```
Executing package manager

Upgrading ca-bundle on root from 20230311-1 to 20240203-r1...
Downloading https://downloads.openwrt.org/snapshots/packages/aarch64_cortex-a53/base/ca-bundle_20240203-r1_all.ipk
Configuring ca-bundle.
```