### PR TITLE
luci-app-package-manager: Show the executed command

### DIFF
--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -1021,6 +1021,9 @@ function handlePkg(ev)
 		fs.exec_direct('/usr/libexec/package-manager-call', argv, 'json').then(function(res) {
 			dlg.removeChild(dlg.lastChild);
 
+			if (res.pkmcmd)
+				dlg.appendChild(E('pre', [ res.pkmcmd ]));
+
 			if (res.stdout)
 				dlg.appendChild(E('pre', [ res.stdout ]));
 

--- a/applications/luci-app-package-manager/root/usr/libexec/package-manager-call
+++ b/applications/luci-app-package-manager/root/usr/libexec/package-manager-call
@@ -88,6 +88,7 @@ case "$action" in
 			fi
 
 			if flock -x 200; then
+				pkmcmd="$cmd $action $@"
 				$cmd $action "$@" </dev/null >/tmp/ipkg.out 2>/tmp/ipkg.err
 				code=$?
 				stdout=$(cat /tmp/ipkg.out)
@@ -99,6 +100,7 @@ case "$action" in
 
 			json_init
 			json_add_int code $code
+			[ -n "$pkmcmd" ] && json_add_string pkmcmd "$pkmcmd"
 			[ -n "$stdout" ] && json_add_string stdout "$stdout"
 			[ -n "$stderr" ] && json_add_string stderr "$stderr"
 			json_dump


### PR DESCRIPTION
Clarify the output of the LuCI package manager actions: 
show also the exact command passed to apk & opkg
(in addition to output & errors from the command)
That will help debugging.

Examples:

installation:
![image](https://github.com/user-attachments/assets/81e132d2-b9d9-46b4-b5d5-f29311430b33)

removal:
![image](https://github.com/user-attachments/assets/59159c09-b22b-4172-89ba-12f26c050dca)

![image](https://github.com/user-attachments/assets/02d17f0a-4ea9-4033-9b78-25f08565f7a8)


