### PR TITLE
luci-mod-status: channel_analysis: detect 40 MHz (20+20 bonded) APs

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -291,20 +291,24 @@ return view.extend({
 					continue;
 
 				res.channel_width = "20 MHz";
-				if (res.ht_operation != null)
-					if (res.ht_operation.channel_width == 2040) { /* 40 MHz Channel Enabled */
-						if (res.ht_operation.secondary_channel_offset == "below") {
-							res.channel_width = "40 MHz";
-							chan_width = 4; /* 40 MHz Channel Used */
-							center_channels[0] -= 2;
-						} else if (res.ht_operation.secondary_channel_offset == "above") {
-							res.channel_width = "40 MHz";
-							chan_width = 4; /* 40 MHz Channel Used */
-							center_channels[0] += 2;
-						} else {
+				if (res.ht_operation != null) {
+					/* Detect 40 MHz operation by looking for the presence of
+					 * a secondary channel. */
+					if (res.ht_operation.secondary_channel_offset == "below") {
+						res.channel_width = "40 MHz";
+						chan_width = 4; /* 40 MHz Channel Used */
+						center_channels[0] -= 2;
+					} else if (res.ht_operation.secondary_channel_offset == "above") {
+						res.channel_width = "40 MHz";
+						chan_width = 4; /* 40 MHz Channel Used */
+						center_channels[0] += 2;
+					} else {
+						/* Fallback to 20 MHz due to discovery of other APs on the
+						 * same channel (802.11n coexistence mechanism). */
+						if (res.ht_operation.channel_width == 2040)
 							res.channel_width = "20 MHz (40 MHz Intolerant)";
-						}
 					}
+				}
 
 				/* if channel_width <= 40, refer to HT (above) for actual channel width,
 				 * as vht_operation.channel_width == 40 really only means that the used


### PR DESCRIPTION
At the moment, 40 MHz detection works only for some APs. HT (802.11n) exposes the 40 MHz capability of APs in two ways. The first way is a continuous 40 Mhz band. The second way is two 20MHz bonded channels. Linux detects the presence of 40 MHz by checking the presence of the second channel. It is always absent when the AP supports only 20 MHz. This PR fixes this issue and both ways are supported.

Fixes: #6839

Example:
~~~
Cell 28 - Address: 5C:7B:5C:6F:51:CB
          ESSID: unknown
          Mode: Master  Frequency: 2.442 GHz  Band: 2.4 GHz  Channel: 7
          Signal: -88 dBm  Quality: 22/70
          Encryption: WPA2 PSK (CCMP)
          HT Operation:
                    Primary Channel: 7
                    Secondary Channel Offset: above
                    Channel Width: 40 MHz or higher

Cell 32 - Address: 54:A6:5C:56:11:B5
          ESSID: "2.4G-Vectra-WiFi-5611B0"
          Mode: Master  Frequency: 2.437 GHz  Band: 2.4 GHz  Channel: 6
          Signal: -85 dBm  Quality: 25/70
          Encryption: mixed WPA/WPA2 PSK (TKIP, CCMP)
          HT Operation:
                    Primary Channel: 6
                    Secondary Channel Offset: above
                    Channel Width: 20 MHz

Cell 34 - Address: 84:A1:D1:C7:6D:B0
          ESSID: "FunBox3-6DB0"
          Mode: Master  Frequency: 2.412 GHz  Band: 2.4 GHz  Channel: 1
          Signal: -78 dBm  Quality: 32/70
          Encryption: WPA2 PSK (CCMP)
          HT Operation:
                    Primary Channel: 1
                    Secondary Channel Offset: no secondary
                    Channel Width: 40 MHz or higher
~~~

![obraz](https://github.com/user-attachments/assets/5bcbb9e7-ff44-4679-93f2-64b3216fb801)

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: WAX206 (mediatek/mt7622), OpenWRT snapshot, Firefox 131.0.3 :white_check_mark:
- [x] \( Preferred ) Mention: @Ansuel @knarrff  the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#6262
- [x] Description: (describe the changes proposed in this PR)
