### PR TITLE
luci-app-ttyd-fix ttyd config innerHTML error

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -1378,7 +1378,12 @@
 				return node.appendChild(children);
 			}
 			else if (children !== null && children !== undefined) {
-				node.innerHTML = '' + children;
+				try {
+					node.innerHTML = '' + children;
+				} catch (error) {
+					console.error("Failed to set innerHTML:", error);
+					node.textContent = '' + children;
+				}
 				return node.lastChild;
 			}
 


### PR DESCRIPTION
luci-app-ttyd Under OpenWrt theme, luci-app-ttyd page cannot be displayed
![image](https://github.com/user-attachments/assets/3e0f63f4-ae35-4036-91bb-955394c3cfeb)
