### PR TITLE
luci-mod-dashboard: custom.css: Add color variables

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
@@ -3,11 +3,11 @@
 **/
 
 .Dashboard {
-    color: #212529!important;
+    color: var(--text-color-high, #212529) !important;
 }
 
 .Dashboard h3 {
-    color:#000;
+    color: var(--text-color-high, #000);
 }
 
 .Dashboard hr {
@@ -16,7 +16,7 @@
     overflow: visible;
     margin: 0;
     box-sizing: content-box;
-    border-top: 1px solid rgba(0,0,0,.1);
+    border-top: 1px solid var(--border-color-medium, rgba(0, 0, 0, 0.1));
 }
 
 .Dashboard .box-s1 {
@@ -29,7 +29,7 @@
 
 .Dashboard .dashboard-bg {
     border-radius: 16px;
-    background-color: #e0e0e0;
+    background-color: var(--background-color-medium, #e0e0e0);
 }
 
 .Dashboard .title {
@@ -189,7 +189,7 @@
 }
 
 .Dashboard .wifi-info .devices-info .table-titles {
-    border-bottom:1px solid rgba(0,0,0,.1);
+    border-bottom: 1px solid var(--border-color-medium, rgba(0, 0, 0, 0.1));
 }
 
 /**
@@ -227,7 +227,7 @@
 
     .Dashboard .section-content .internet-status-info .settings-info > div:first-child {
         margin-bottom: 10px;
-        border-bottom: 1px solid rgba(0,0,0,.1);
+        border-bottom: 1px solid var(--border-color-medium, rgba(0, 0, 0, 0.1));
     }
 
     .Dashboard .section-content .router-status-lan .devices-info .table-titles {


### PR DESCRIPTION
Add color variable references from luci-theme-boostrap to facilitate light and dark color scheme switching by default. Fallback to original colors when variables are not declared by theme.

![Screenshot comparison of dark color scheme before and after changes](https://github.com/user-attachments/assets/2d312dc0-302e-4398-b67c-a9fbfd6222fa)

![Screenshot comparison of light color scheme before and after changes](https://github.com/user-attachments/assets/6360f16c-1992-4bb7-a8c9-162e10786045)

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

