### PR TITLE
luci-proto-3g/ppp/pppossh: fix being unable to set keepalive to 0

### DIFF
--- a/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
+++ b/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
@@ -26,13 +26,13 @@ function write_keepalive(section_id, value) {
 	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
 	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
 
-	if (f == null || f == '' || isNaN(f))
-		f = 0;
+	if (f === '' || isNaN(f))
+		f = null;
 
 	if (i == null || i == '' || isNaN(i) || i < 1)
 		i = 1;
 
-	if (f > 0)
+	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
 	else
 		uci.unset('network', section_id, 'keepalive');

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js
@@ -26,13 +26,13 @@ function write_keepalive(section_id, value) {
 	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
 	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
 
-	if (f == null || f == '' || isNaN(f))
-		f = 0;
+	if (f === '' || isNaN(f))
+		f = null;
 
 	if (i == null || i == '' || isNaN(i) || i < 1)
 		i = 1;
 
-	if (f > 0)
+	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
 	else
 		uci.unset('network', section_id, 'keepalive');

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js
@@ -11,13 +11,13 @@ function write_keepalive(section_id, value) {
 	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
 	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
 
-	if (f == null || f == '' || isNaN(f))
-		f = 0;
+	if (f === '' || isNaN(f))
+		f = null;
 
 	if (i == null || i == '' || isNaN(i) || i < 1)
 		i = 1;
 
-	if (f > 0)
+	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
 	else
 		uci.unset('network', section_id, 'keepalive');

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js
@@ -11,13 +11,13 @@ function write_keepalive(section_id, value) {
 	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
 	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
 
-	if (f == null || f == '' || isNaN(f))
-		f = 0;
+	if (f === '' || isNaN(f))
+		f = null;
 
 	if (i == null || i == '' || isNaN(i) || i < 1)
 		i = 1;
 
-	if (f > 0)
+	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
 	else
 		uci.unset('network', section_id, 'keepalive');

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js
@@ -11,13 +11,13 @@ function write_keepalive(section_id, value) {
 	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
 	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
 
-	if (f == null || f == '' || isNaN(f))
-		f = 0;
+	if (f === '' || isNaN(f))
+		f = null;
 
 	if (i == null || i == '' || isNaN(i) || i < 1)
 		i = 1;
 
-	if (f > 0)
+	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
 	else
 		uci.unset('network', section_id, 'keepalive');

--- a/protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js
+++ b/protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js
@@ -11,13 +11,13 @@ function write_keepalive(section_id, value) {
 	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
 	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
 
-	if (f == null || f == '' || isNaN(f))
-		f = 0;
+	if (f === '' || isNaN(f))
+		f = null;
 
 	if (i == null || i == '' || isNaN(i) || i < 1)
 		i = 1;
 
-	if (f > 0)
+	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
 	else
 		uci.unset('network', section_id, 'keepalive');


### PR DESCRIPTION
Since on openwrt keepalive option defaults to "5 1" when it's not defined 
(see https://github.com/openwrt/openwrt/blob/6720c4ccba256186bf2f1b1edadb851c447e62a5/package/network/services/ppp/files/ppp.sh#L128).
Users must be able to set it to 0 to ignore connection failures.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (mt7621 mipsel, openwrt 23.05.04 firefox) :white_check_mark:
- [x] Mention: @jow- 
- [x] Closes: openwrt/luci#2112
- [x] Description: (describe the changes proposed in this PR)
