### PR TITLE
luci-app-keepalived: add notification tab

### DIFF
--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/notification.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/notification.js
@@ -1,0 +1,38 @@
+'use strict';
+'require view';
+'require fs';
+'require ui';
+
+var isReadonlyView = !L.hasViewPermission() || null;
+
+return view.extend({
+	load: function() {
+		return L.resolveDefault(fs.read('/etc/keepalived.user'), '');
+	},
+
+	handleSave: function(ev) {
+		var value = (document.querySelector('textarea').value || '').trim().replace(/\r\n/g, '\n') + '\n';
+
+		return fs.write('/etc/keepalived.user', value).then(function(rc) {
+			document.querySelector('textarea').value = value;
+			ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
+
+			return fs.exec('/etc/init.d/keepalived', [ 'reload' ]);
+		}).catch(function(e) {
+			ui.addNotification(null, E('p', _('Unable to save contents: %s').format(e.message)));
+		});
+	},
+
+	render: function(keepalived) {
+		return E([
+			E('h2', _('Keepalived.user')),
+			E('p', { 'class': 'cbi-section-descr' }, _('This is the /etc/keepalived.user file in which custom commands can be defined.')),
+			E('p', {}, E('textarea', { 'style': 'width:100%', 'rows': 25, 'disabled': isReadonlyView }, [ keepalived != null ? keepalived : '' ]))
+		]);
+	},
+
+	handleSaveApply: null,
+	handleReset: null
+});
+
+

--- a/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
+++ b/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
@@ -98,6 +98,15 @@
 		}
 	},
 
+	"admin/services/keepalived/notification": {
+		"title": "Notification",
+		"order": 150,
+		"action": {
+			"type": "view",
+			"path": "keepalived/notification"
+		}
+	},
+
 	"admin/status/keepalived": {
 		"title": "VRRP",
 		"order": 10,

--- a/applications/luci-app-keepalived/root/usr/share/rpcd/acl.d/luci-app-keepalived.json
+++ b/applications/luci-app-keepalived/root/usr/share/rpcd/acl.d/luci-app-keepalived.json
@@ -5,12 +5,16 @@
 			"ubus" : {
 				"keepalived" : [ "*" ]
 			},
-			"uci": [ "keepalived" ]
+			"uci": [ "keepalived" ],
+			"file": {
+				"/etc/keepalived.user": [ "read" ]
+			}
 		},
 		"write" : {
 			"uci": [ "keepalived" ],
 			"file" : {
-				"/etc/keepalived/keys/*" : [ "write" ]
+				"/etc/keepalived/keys/*" : [ "write" ],
+				"/etc/keepalived.user": [ "write" ]
 			}
 		}
 	}


### PR DESCRIPTION
This commit adds a tab to modify keepalived.user file. With this commit it is possible to specify notifications.
![image](https://github.com/user-attachments/assets/881ecc6a-d2b0-42ee-b1b3-2f35584eb58c)

Maintainer: @jempatel 