### PR TITLE
ci: fix build error and account for APK as default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,15 +54,18 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci
+          V: s
 
       - name: Move created packages to project dir
-        run: cp bin/packages/${{ matrix.arch }}/packages_ci/*.ipk . || true
+        run: cp bin/packages/${{ matrix.arch }}/packages_ci/* . || true
 
       - name: Store packages
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.arch}}-packages
-          path: "*.ipk"
+          path: |
+            *.ipk
+            *.apk
 
       - name: Store logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
       - name: Build
-        uses: openwrt/gh-action-sdk@v5
+        uses: openwrt/gh-action-sdk@v7
         env:
           ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
           FEEDNAME: packages_ci


### PR DESCRIPTION
See separate commits for details. The first commit should fix all the recent build errors for the task `Test x86_64` ([1](https://github.com/openwrt/luci/actions/runs/11852952401/job/33032096379?pr=7394), [2](https://github.com/openwrt/luci/actions/runs/11764799075/job/32770355810), [3](https://github.com/openwrt/luci/actions/runs/11795975811/job/32856854484)). For reviewers, make sure to check that the workflow run is green and produces the expected results.

* ci: upgrade openwrt/gh-action-sdk workflow to v7

    With the change of the Docker container not including pre-built
    binaries [1], the previous version of the workflow fails as it still
    expects those to be present in the upstream container while the new
    versions runs a file called setup.sh if present to configure the
    container.

    By upgrading openwrt/gh-action-sdk workflow to v7, we make sure that
    setup.sh is run and configures the container [2].

    [1] https://github.com/openwrt/docker/commit/9b55784b18f8d2c684aac4dd21a224320bb9b9ce
    [2] https://github.com/openwrt/gh-action-sdk/commit/0c00b28c11bed5c7697e807d4cb8ef176ca688ef

* ci: account for APK as default on main branch

    With APK defaulted on openwrt:main, we should include packages with the
    .apk file extension as artifacts. Also default the logging to V=s as
    otherwise the APK version check won't be printed to stdout.

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile N/A
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark: N/A
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
