### PR TITLE
luci-light: move firewall and ppp to luci collection

### DIFF
--- a/collections/luci-light/Makefile
+++ b/collections/luci-light/Makefile
@@ -13,9 +13,7 @@ LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (light)
 LUCI_DESCRIPTION:=Light OpenWrt set including admin support and the default Bootstrap theme
 LUCI_DEPENDS:= \
 	+IPV6:luci-proto-ipv6 \
-	+luci-app-firewall \
 	+luci-mod-admin-full \
-	+luci-proto-ppp \
 	+luci-theme-bootstrap \
 	+rpcd-mod-rrdns \
 	+uhttpd \

--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -13,6 +13,8 @@ LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
 LUCI_DESCRIPTION:=Standard OpenWrt set including package management and attended sysupgrades support
 LUCI_DEPENDS:= \
 	+luci-light \
+	+luci-app-firewall \
+	+luci-proto-ppp \
 	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Allow luci compilation without firewall and ppp proto. A Firewall or ppp is not needed for the AP basic functions.

This way it is possible to save memory and flash space in low memory enviroments.
