### PR TITLE
luci-app-package-manager: support new APK repositories.d configs

### DIFF
--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -865,8 +865,13 @@ function handleConfig(ev)
 	fs.list(base_dir).then(function(partials) {
 		var files = [];
 
-		if (!L.hasSystemFeature('apk'))
-			files.push(base_dir + '.conf')
+		if (L.hasSystemFeature('apk')) {
+                        files.push(base_dir + '/' + 'repositories.d/customfeeds.list',
+                                   base_dir + '/' + 'repositories.d/distfeeds.list'
+                        )
+                } else {
+                        files.push(base_dir + '.conf')
+                }
 
 		for (var i = 0; i < partials.length; i++) {
 			if (partials[i].type == 'file') {

--- a/applications/luci-app-package-manager/root/usr/share/rpcd/acl.d/luci-app-package-manager.json
+++ b/applications/luci-app-package-manager/root/usr/share/rpcd/acl.d/luci-app-package-manager.json
@@ -8,7 +8,9 @@
 				"/usr/libexec/package-manager-call list-available": [ "exec" ],
 				"/etc/opkg.conf": [ "read" ],
 				"/etc/opkg/*.conf": [ "read" ],
-				"/etc/apk/repositories": [ "read" ]
+				"/etc/apk/repositories": [ "read" ],
+				"/etc/apk/repositories.d/distfeeds.list": [ "read" ],
+				"/etc/apk/repositories.d/customfeeds.list": [ "read" ]
 			},
 			"ubus": {
 				"luci": [ "getMountPoints" ]
@@ -25,6 +27,8 @@
 				"/etc/opkg.conf": [ "write" ],
 				"/etc/opkg/*.conf": [ "write" ],
 				"/etc/apk/repositories": [ "write" ],
+				"/etc/apk/repositories.d/distfeeds.list": [ "write" ],
+				"/etc/apk/repositories.d/customfeeds.list": [ "write" ],
 				"/tmp/upload.ipk": [ "write" ],
 				"/tmp/upload.apk": [ "write" ]
 			}


### PR DESCRIPTION
Support new APK repositories.d configs following OPKG was to better split distfeeds and customfeeds.

Support for ""legacy"" repositories is kept to support migration period and to support custom scenario where user use this file instead.
