### PR TITLE
Add $(FPIC) build flags to fix LTO builds.

### DIFF
--- a/libs/luci-lib-ip/src/Makefile
+++ b/libs/luci-lib-ip/src/Makefile
@@ -7,7 +7,7 @@ IP_LIB = ip.so
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LUA_CFLAGS) $(IP_CFLAGS) $(FPIC) -c -o $@ $<
 
 compile: $(IP_OBJ)
-	$(CC) $(LDFLAGS) -shared -o $(IP_LIB) $(IP_OBJ) $(IP_LDFLAGS)
+	$(CC) $(LDFLAGS) -shared -o $(IP_LIB) $(IP_OBJ) $(IP_LDFLAGS) $(FPIC)
 
 install: compile
 	mkdir -p $(DESTDIR)/usr/lib/lua/luci

--- a/libs/luci-lib-jsonc/src/Makefile
+++ b/libs/luci-lib-jsonc/src/Makefile
@@ -7,7 +7,7 @@ JSONC_LIB = jsonc.so
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LUA_CFLAGS) $(JSONC_CFLAGS) $(FPIC) -c -o $@ $<
 
 compile: $(JSONC_OBJ)
-	$(CC) $(LDFLAGS) -shared -o $(JSONC_LIB) $(JSONC_OBJ) $(JSONC_LDFLAGS)
+	$(CC) $(LDFLAGS) -shared -o $(JSONC_LIB) $(JSONC_OBJ) $(JSONC_LDFLAGS) $(FPIC)
 
 install: compile
 	mkdir -p $(DESTDIR)/usr/lib/lua/luci

--- a/libs/luci-lib-nixio/src/Makefile
+++ b/libs/luci-lib-nixio/src/Makefile
@@ -66,7 +66,7 @@ endif
 
 
 %.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) -c -o $@ $< 
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) -c -o $@ $<
 
 ifneq ($(NIXIO_TLS),)
 tls-crypto.o: $(TLS_DEPENDS) tls-crypto.c
@@ -74,18 +74,18 @@ tls-crypto.o: $(TLS_DEPENDS) tls-crypto.c
 
 tls-context.o: $(TLS_DEPENDS) tls-context.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) $(TLS_CFLAGS) -c -o $@ tls-context.c
-	
+
 tls-socket.o: $(TLS_DEPENDS) tls-socket.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) $(TLS_CFLAGS) -c -o $@ tls-socket.c
-	
+
 axtls-compat.o: libaxtls.a axtls-compat.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) $(TLS_CFLAGS) -c -o $@ axtls-compat.c
 	mkdir -p dist
 	cp -pR axtls-root/* dist/
-endif	
+endif
 
 compile: $(NIXIO_OBJ)
-	$(CC) $(LDFLAGS) $(SHLIB_FLAGS) -o $(NIXIO_SO) $(NIXIO_OBJ) $(NIXIO_LDFLAGS) $(NIXIO_LDFLAGS_POST)
+	$(CC) $(LDFLAGS) $(SHLIB_FLAGS) -o $(NIXIO_SO) $(NIXIO_OBJ) $(NIXIO_LDFLAGS) $(NIXIO_LDFLAGS_POST) $(FPIC)
 	mkdir -p dist/usr/lib/lua
 	cp $(NIXIO_SO) dist/usr/lib/lua/$(NIXIO_SO)
 

--- a/modules/luci-lua-runtime/src/Makefile
+++ b/modules/luci-lua-runtime/src/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -f contrib/lemon parser.so plural_formula.c plural_formula.h *.o
 
 parser.so: template_parser.o template_utils.o template_lmo.o template_lualib.o plural_formula.o
-	$(CC) $(LDFLAGS) -shared -o $@ $^
+	$(CC) $(LDFLAGS) $(FPIC) -shared -o $@ $^
 
 version.lua:
 	./mkversion.sh $@ $(LUCI_VERSION) "$(LUCI_GITBRANCH)"


### PR DESCRIPTION
Add $(FPIC) build flags to fix building with CONFIG_USE_LTO enabled.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)
