### PR TITLE
luci-app-openvpn: Handle missing openvpn config file.

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
@@ -18,15 +18,7 @@ local function makeForm(id, title, desc)
 	return f
 end
 
-if not cfg_file or not fs.access(cfg_file) then
-	local f = makeForm("error", nil, translatef("The OVPN config file (%s) could not be found, please check your configuration.", cfg_file or "n/a"))
-	f:append(Template("openvpn/ovpn_css"))
-	f.reset = false
-	f.submit = false
-	return f
-end
-
-if fs.stat(cfg_file).size >= 102400 then
+if fs.access(cfg_file) and fs.stat(cfg_file).size >= 102400 then
 	local f = makeForm("error", nil,
 		translatef("The size of the OVPN config file (%s) is too large for online editing in LuCI (&ge; 100 KB). ", cfg_file)
 		.. translate("Please edit this file directly in a terminal session."))


### PR DESCRIPTION
With this change if the specified config file (from UCI) doesn't exist, 
it won't error out. instead it treats it as an empty file. 
Previously, when clicking edit on the custom_config option in the UI, it
will show an error because the file doesn't exist there by default. As a
result, a user can't easily add (paste) a config file content.

Signed-off-by: Milad Mohtashamirad <milad.mohtashamirad@morsemicro.com>

@jow- 

when clicking on this button:
![image](https://github.com/user-attachments/assets/754120eb-aa25-4d5b-a6b3-d4d326e1566a)
It used to show this (if the specified file didn't exist):
![image](https://github.com/user-attachments/assets/fe39984a-6a05-4c31-97db-5c5465e71708)
But now it considers it as an empty file and allows editing (or pasting a content):
![image](https://github.com/user-attachments/assets/73a2be2c-6c16-4c8a-957c-3d64bb2fb892)
