### PR TITLE
luci-app-upnp: Finalise changes for OpenWrt 24.10 release

### DIFF
--- a/applications/luci-app-upnp/Makefile
+++ b/applications/luci-app-upnp/Makefile
@@ -6,7 +6,7 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Universal Plug and Play (UPnP IGD) & PCP/NAT-PMP configuration module
+LUCI_TITLE:=UPnP IGD & PCP/NAT-PMP configuration module | Universal Plug and Play
 LUCI_DEPENDS:=+luci-base +miniupnpd +rpcd-mod-ucode
 
 PKG_LICENSE:=Apache-2.0

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -28,7 +28,7 @@ handleDelRule = function(num, ev) {
 };
 
 return baseclass.extend({
-	title: _('Active Port Forwards'),
+	title: _('Active UPnP IGD & PCP/NAT-PMP Port Maps'),
 
 	load: function() {
 		return Promise.all([
@@ -40,11 +40,11 @@ return baseclass.extend({
 
 		var table = E('table', { 'class': 'table', 'id': 'upnp_status_table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
-				E('th', { 'class': 'th' }, _('Protocol')),
-				E('th', { 'class': 'th' }, _('External Port')),
+				E('th', { 'class': 'th' }, _('Client Name')),
 				E('th', { 'class': 'th' }, _('Client Address')),
-				E('th', { 'class': 'th' }, _('Host')),
 				E('th', { 'class': 'th' }, _('Client Port')),
+				E('th', { 'class': 'th' }, _('External Port')),
+				E('th', { 'class': 'th' }, _('Protocol')),
 				E('th', { 'class': 'th' }, _('Description')),
 				E('th', { 'class': 'th cbi-section-actions' }, '')
 			])
@@ -54,11 +54,11 @@ return baseclass.extend({
 
 		var rows = rules.map(function(rule) {
 			return [
-				rule.proto,
-				rule.extport,
-				rule.intaddr,
 				rule.host_hint || _('Unknown'),
+				rule.intaddr,
 				rule.intport,
+				rule.extport,
+				rule.proto,
 				rule.descr,
 				E('button', {
 					'class': 'btn cbi-button-remove',
@@ -67,7 +67,7 @@ return baseclass.extend({
 			];
 		});
 
-		cbi_update_table(table, rows, E('em', _('There are no active port forwards.')));
+		cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
 
 		return table;
 	}

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -18,7 +18,7 @@ callInitAction = rpc.declare({
 callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',
-	expect: {  }
+	expect: {}
 });
 
 callUpnpDeleteRule = rpc.declare({
@@ -50,11 +50,11 @@ return view.extend({
 
 		var rows = rules.map(function(rule) {
 			return [
-				rule.proto,
-				rule.extport,
-				rule.intaddr,
 				rule.host_hint || _('Unknown'),
+				rule.intaddr,
 				rule.intport,
+				rule.extport,
+				rule.proto,
 				rule.descr,
 				E('button', {
 					'class': 'btn cbi-button-remove',
@@ -63,7 +63,7 @@ return view.extend({
 			];
 		});
 
-		cbi_update_table(nodes.querySelector('#upnp_status_table'), rows, E('em', _('There are no active port forwards.')));
+		cbi_update_table(nodes.querySelector('#upnp_status_table'), rows, E('em', _('There are no active port maps.')));
 
 		return;
 	},
@@ -73,18 +73,18 @@ return view.extend({
 		var m, s, o;
 
 		m = new form.Map('upnpd', [_('UPnP IGD & PCP/NAT-PMP Service')],
-			_('UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically configure port forwards on the router. Also called Universal Plug and Play.'));
+			_('The %s protocols allow clients on the local network to configure port maps/forwards on the router autonomously.', 'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local network to configure port maps/forwards on the router autonomously.').format('%s & %s/%s').format('<a href="https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol" target="_blank" rel="noreferrer"><abbr title="UPnP Internet Gateway Device (Control Protocol)">UPnP IGD</abbr></a>', '<a href="https://en.wikipedia.org/wiki/Port_Control_Protocol" target="_blank" rel="noreferrer"><abbr title="Port Control Protocol">PCP</abbr></a>', '<a href="https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol" target="_blank" rel="noreferrer"><abbr title="NAT Port Mapping Protocol">NAT-PMP</abbr></a>'));
 
 		s = m.section(form.GridSection, '_active_rules');
 
 		s.render = L.bind(function(view, section_id) {
 			var table = E('table', { 'class': 'table cbi-section-table', 'id': 'upnp_status_table' }, [
 				E('tr', { 'class': 'tr table-titles' }, [
-					E('th', { 'class': 'th' }, _('Protocol')),
-					E('th', { 'class': 'th' }, _('External Port')),
+					E('th', { 'class': 'th' }, _('Client Name')),
 					E('th', { 'class': 'th' }, _('Client Address')),
-					E('th', { 'class': 'th' }, _('Host')),
 					E('th', { 'class': 'th' }, _('Client Port')),
+					E('th', { 'class': 'th' }, _('External Port')),
+					E('th', { 'class': 'th' }, _('Protocol')),
 					E('th', { 'class': 'th' }, _('Description')),
 					E('th', { 'class': 'th cbi-section-actions' }, '')
 				])
@@ -94,11 +94,11 @@ return view.extend({
 
 			var rows = rules.map(function(rule) {
 				return [
-					rule.proto,
-					rule.extport,
-					rule.intaddr,
 					rule.host_hint || _('Unknown'),
+					rule.intaddr,
 					rule.intport,
+					rule.extport,
+					rule.proto,
 					rule.descr,
 					E('button', {
 						'class': 'btn cbi-button-remove',
@@ -107,99 +107,121 @@ return view.extend({
 				];
 			});
 
-			cbi_update_table(table, rows, E('em', _('There are no active port forwards.')));
+			cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
 
 			return E('div', { 'class': 'cbi-section cbi-tblsection' }, [
-					E('h3', _('Active Port Forwards')), table ]);
+					E('h3', _('Active Service Port Maps')), table ]);
 		}, o, this);
 
 		s = m.section(form.NamedSection, 'config', 'upnpd', _('Service Settings'));
 		s.addremove = false;
-		s.tab('general',  _('General Settings'));
+		s.tab('setup', _('Service Setup'));
 		s.tab('advanced', _('Advanced Settings'));
 
-		o = s.taboption('general', form.Flag, 'enabled', _('Start service'));
-		o.rmempty  = false;
+		o = s.taboption('setup', form.Flag, 'enabled', _('Start service'),
+			_('Start autonomous port mapping service'));
+		o.rmempty = false;
 
-		s.taboption('general', form.Flag, 'enable_upnp', _('Enable UPnP IGD protocol')).default = '1'
-		s.taboption('general', form.Flag, 'enable_natpmp', _('Enable PCP/NAT-PMP protocol')).default = '1'
+		s.taboption('setup', form.Flag, 'enable_upnp', _('Enable UPnP IGD protocol')).default = '1';
 
-		s.taboption('general', form.Flag, 'secure_mode', _('Enable secure mode'),
-			_('Allow adding port forwards only to requesting IP addresses')).default = '1'
+		s.taboption('setup', form.Flag, 'enable_natpmp', _('Enable PCP/NAT-PMP protocols')).default = '1';
 
-		s.taboption('general', form.Flag, 'igdv1', _('Enable UPnP IGDv1 mode'),
-			_('Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2')).default = '0'
+		o = s.taboption('setup', form.Flag, 'igdv1', _('UPnP IGDv1 compatibility mode'),
+			_('Advertise as IGDv1 (IPv4 only) device instead of IGDv2'));
+		o.default = '1';
+		o.rmempty = false;
+		o.depends('enable_upnp', '1');
 
-		s.taboption('general', form.Flag, 'log_output', _('Enable additional logging'),
-			_('Puts extra debugging information into the system log'))
+		o = s.taboption('setup', form.Value, 'download', _('Download speed'),
+			_('Report maximum download speed in kByte/s'));
+		o.depends('enable_upnp', '1');
 
-		s.taboption('general', form.Value, 'download', _('Download speed'),
-			_('Value in KByte/s, informational only')).rmempty = true
+		o = s.taboption('setup', form.Value, 'upload', _('Upload speed'),
+			_('Report maximum upload speed in kByte/s'));
+		o.depends('enable_upnp', '1');
 
-		s.taboption('general', form.Value, 'upload', _('Upload speed'),
-			_('Value in KByte/s, informational only')).rmempty = true
+		s.taboption('advanced', form.Flag, 'use_stun', _('Use %s', 'Use %s (%s = STUN)').format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
+			_('To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs'));
 
-		o = s.taboption('general', form.Value, 'port', _('Port'))
-		o.datatype = 'port'
-		o.default  = 5000
-
-		s.taboption('advanced', form.Flag, 'system_uptime', _('Report system instead of service uptime')).default = '1'
-
-		s.taboption('advanced', form.Value, 'uuid', _('Device UUID'))
-		s.taboption('advanced', form.Value, 'serial_number', _('Announced serial number'))
-		s.taboption('advanced', form.Value, 'model_number', _('Announced model number'))
-
-		o = s.taboption('advanced', form.Value, 'notify_interval', _('Notify interval'))
-		o.datatype    = 'uinteger'
-		o.placeholder = 30
-
-		o = s.taboption('advanced', form.Value, 'clean_ruleset_threshold', _('Clean rules threshold'))
-		o.datatype    = 'uinteger'
-		o.placeholder = 20
-
-		o = s.taboption('advanced', form.Value, 'clean_ruleset_interval', _('Clean rules interval'))
-		o.datatype    = 'uinteger'
-		o.placeholder = 600
-
-		o = s.taboption('advanced', form.Value, 'presentation_url', _('Presentation URL'))
-		o.placeholder = 'http://192.168.1.1/'
-
-		o = s.taboption('advanced', form.Value, 'upnp_lease_file', _('Service lease file'))
-		o.placeholder = '/var/run/miniupnpd.leases'
-
-		s.taboption('advanced', form.Flag, 'use_stun', _('Use STUN'))
-
-		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN Host'))
+		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN Host'));
 		o.depends('use_stun', '1');
-		o.datatype    = 'host'
+		o.datatype = 'host';
 
-		o = s.taboption('advanced', form.Value, 'stun_port', _('STUN Port'))
+		o = s.taboption('advanced', form.Value, 'stun_port', _('STUN Port'));
 		o.depends('use_stun', '1');
-		o.datatype    = 'port'
-		o.placeholder = '0-65535'
+		o.datatype = 'port';
+		o.placeholder = '3478';
 
-		s = m.section(form.GridSection, 'perm_rule', _('Service ACLs'),
-			_('ACLs specify which external ports can be forwarded to which client addresses and ports, IPv6 always allowed.'))
+		o = s.taboption('advanced', form.Flag, 'secure_mode', _('Enable secure mode'),
+			_('Allow adding port maps for requesting IP addresses only'));
+		o.default = '1';
+		o.depends('enable_upnp', '1');
 
-		s.sortable  = true
-		s.anonymous = true
-		s.addremove = true
+		o = s.taboption('advanced', form.Value, 'notify_interval', _('Notify interval'),
+			_('A 900s interval will result in %s notifications with the minimum max-age of 1800s', 'A 900s interval will result in %s (%s = SSDP) notifications with the minimum max-age of 1800s').format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>'));
+		o.datatype = 'uinteger';
+		o.placeholder = '900';
+		o.depends('enable_upnp', '1');
 
-		s.option(form.Value, 'comment', _('Comment'))
+		o = s.taboption('advanced', form.Value, 'port', _('SOAP/HTTP port'));
+		o.datatype = 'port';
+		o.placeholder = '5000';
+		o.depends('enable_upnp', '1');
 
-		o = s.option(form.Value, 'ext_ports', _('External Port'))
-		o.datatype    = 'portrange'
-		o.placeholder = '0-65535'
+		o = s.taboption('advanced', form.Value, 'presentation_url', _('Presentation URL'),
+			_('Report custom router web interface (presentation) URL'));
+		o.placeholder = 'http://192.168.1.1/';
+		o.depends('enable_upnp', '1');
 
-		o = s.option(form.Value, 'int_addr', _('Client Address'))
-		o.datatype    = 'ip4addr'
-		o.placeholder = '0.0.0.0/0'
+		o = s.taboption('advanced', form.Value, 'uuid', _('Device UUID'));
+		o.depends('enable_upnp', '1');
 
-		o = s.option(form.Value, 'int_ports', _('Client Port'))
-		o.datatype    = 'portrange'
-		o.placeholder = '0-65535'
+		o = s.taboption('advanced', form.Value, 'model_number', _('Announced model number'));
+		o.depends('enable_upnp', '1');
 
-		o = s.option(form.ListValue, 'action', _('Action'))
+		o = s.taboption('advanced', form.Value, 'serial_number', _('Announced serial number'));
+		o.depends('enable_upnp', '1');
+
+		o = s.taboption('advanced', form.Flag, 'system_uptime', _('Report system instead of service uptime'));
+		o.default = '1';
+		o.depends('enable_upnp', '1');
+
+		s.taboption('advanced', form.Flag, 'log_output', _('Enable additional logging'),
+			_('Puts extra debugging information into the system log'));
+
+		o = s.taboption('advanced', form.Value, 'upnp_lease_file', _('Service lease file'));
+		o.placeholder = '/var/run/miniupnpd.leases';
+
+		s = m.section(form.GridSection, 'perm_rule', _('Service Access Control List'),
+			_('ACL specify which client addresses and ports can be mapped, IPv6 always allowed.'));
+		s.sortable = true;
+		s.anonymous = true;
+		s.addremove = true;
+
+		s.option(form.Value, 'comment', _('Comment'));
+
+		o = s.option(form.Value, 'int_addr', _('Client Address'));
+		o.datatype = 'ip4addr';
+		o.placeholder = '0.0.0.0/0';
+		o.validate = function (section_id, value) {
+			return value !== "";
+		};
+
+		o = s.option(form.Value, 'int_ports', _('Client Port'));
+		o.datatype = 'portrange';
+		o.default = '1-65535';
+		o.validate = function (section_id, value) {
+			return value !== "";
+		};
+
+		o = s.option(form.Value, 'ext_ports', _('External Port'));
+		o.datatype = 'portrange';
+		o.default = '1-65535';
+		o.validate = function (section_id, value) {
+			return value !== "";
+		};
+
+		o = s.option(form.ListValue, 'action', _('Action'));
 		o.value('allow', _('Allow'));
 		o.value('deny', _('Deny'));
 

--- a/applications/luci-app-upnp/po/ar/upnp.po
+++ b/applications/luci-app-upnp/po/ar/upnp.po
@@ -251,6 +251,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "ضيف"

--- a/applications/luci-app-upnp/po/ar/upnp.po
+++ b/applications/luci-app-upnp/po/ar/upnp.po
@@ -15,66 +15,75 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "إجراء"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "إعدادات متقدمة"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "تعليق"
 
@@ -84,7 +93,7 @@ msgstr "تعليق"
 msgid "Delete"
 msgstr "احدف"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -93,125 +102,144 @@ msgstr ""
 msgid "Description"
 msgstr "الوصف"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "الاعدادات العامة"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "ضيف"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "المنفذ"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "البروتوكول"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "المنفذ"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "الاعدادات العامة"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "مجهول"
 
@@ -219,11 +247,10 @@ msgstr "مجهول"
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr ""
+#~ msgid "Host"
+#~ msgstr "ضيف"

--- a/applications/luci-app-upnp/po/bg/upnp.po
+++ b/applications/luci-app-upnp/po/bg/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Действие"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Разширени настройки"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Коментар"
 
@@ -83,7 +92,7 @@ msgstr "Коментар"
 msgid "Delete"
 msgstr "Изтрий"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Общи настройки"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Хост"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Порт"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Порт"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Общи настройки"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -218,11 +246,10 @@ msgstr "Неизвестно"
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr ""
+#~ msgid "Host"
+#~ msgstr "Хост"

--- a/applications/luci-app-upnp/po/bg/upnp.po
+++ b/applications/luci-app-upnp/po/bg/upnp.po
@@ -250,6 +250,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "Хост"

--- a/applications/luci-app-upnp/po/bn_BD/upnp.po
+++ b/applications/luci-app-upnp/po/bn_BD/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "উন্নত সেটিংস"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr ""
 
@@ -83,7 +92,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "বর্ণনা"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "সাধারণ সেটিংস"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "পোর্ট"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "প্রোটোকল"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "পোর্ট"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "সাধারণ সেটিংস"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "অজানা"
 
@@ -218,11 +246,7 @@ msgstr "অজানা"
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/ca/upnp.po
+++ b/applications/luci-app-upnp/po/ca/upnp.po
@@ -252,30 +252,3 @@ msgstr "Enllaç de pujada"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Els ACL especifiquen quins ports externs es poden redirigir a quines "
-#~ "adreces i ports interns"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interval de neteja de regles"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Llindar de neteja de regles"
-
-#~ msgid "Host"
-#~ msgstr "Amfitrió"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP permet als clients de la xarxa local configurar automàticament el "
-#~ "router."
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valor en KByte/s, només per informació"

--- a/applications/luci-app-upnp/po/ca/upnp.po
+++ b/applications/luci-app-upnp/po/ca/upnp.po
@@ -16,68 +16,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Els ACL especifiquen quins ports externs es poden redirigir a quines adreces "
-"i ports interns"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Acció"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Redireccions UPnP actives"
+msgid "Active Service Port Maps"
+msgstr "Redireccions actives"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Configuració avançada"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Permet que s'afegeixin redireccions només a les adreces IP peticionant"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Número de model anunciat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Número de sèrie anunciat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Interval de neteja de regles"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Llindar de neteja de regles"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Adreça de client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port de client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Commentari"
 
@@ -87,7 +94,7 @@ msgstr "Commentari"
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -96,127 +103,144 @@ msgstr ""
 msgid "Description"
 msgstr "Descripció"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID de dispositiu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Enllaç de baixada"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Habilita la funcionalitat NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
-msgid "Enable UPnP IGD protocol"
-msgstr "Habilita la funcionalitat UPnP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+msgid "Enable UPnP IGD protocol"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Habilita el registre addicional"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Habilita mode segur"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Port extern"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Paràmetres generals"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Amfitrió"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Interval de notificació"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Posa informació extra de depuració en el registre de sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Reporta el temps actiu del sistema en lloc del del dimoni"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACLs de MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Ajusts de MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Paràmetres generals"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Fitxer d'arrendament UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Inicia el servei UPnP i NAP-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "No hi ha redireccions actives."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
-"UPnP permet als clients de la xarxa local configurar automàticament el "
-"router."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -224,11 +248,34 @@ msgstr "Desconegut"
 msgid "Upload speed"
 msgstr "Enllaç de pujada"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valor en KByte/s, només per informació"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Els ACL especifiquen quins ports externs es poden redirigir a quines "
+#~ "adreces i ports interns"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Interval de neteja de regles"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Llindar de neteja de regles"
+
+#~ msgid "Host"
+#~ msgstr "Amfitrió"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP permet als clients de la xarxa local configurar automàticament el "
+#~ "router."
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valor en KByte/s, només per informació"

--- a/applications/luci-app-upnp/po/cs/upnp.po
+++ b/applications/luci-app-upnp/po/cs/upnp.po
@@ -12,68 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.8.2-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL stanovují, které vnější porty by měly být přesměrovány na které vnitřní "
-"adresy a porty"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Akce"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktivní přesměrování UPnP"
+msgid "Active Service Port Maps"
+msgstr "Aktivní přesměrování"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Pokročilá nastavení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Inzerovat jako IGDv1 zařízení místo IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Povolit přesměrování pouze na dotazující ip adresy"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Oznámené číslo modelu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Oznámené sériové číslo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Interval čištění pravidel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Práh čištění pravidel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Adresa klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Komentář"
 
@@ -83,7 +90,7 @@ msgstr "Komentář"
 msgid "Delete"
 msgstr "Odstranit"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,126 +99,144 @@ msgstr ""
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID zařízení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Download speed"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Povolit funkčnost NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Povolit funkčnost UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Povolit režim IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Povolit přídavné logování"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Povolit bezpečný režim"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Vnější port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Obecná nastavení"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Udělit oprávnění k procedůrám upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Hostitel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Interval oznamování"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Prezentační URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Vypisovat extra ladící informace do systémového záznamu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Hlásit uptime systému namísto uptime daemonu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN Hostitel"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnP ACL listy"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Nastavení MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Obecná nastavení"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Soubor UPnP výpůjček"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Spustit službu UPnP a NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Neexistují žádná aktivní přesměrování."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Univerzální Plug & Play"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP umožňuje klientům v místní síti automaticky nakonfigurovat router."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Povolit režim UPnP IGDv1"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Neznámé"
 
@@ -219,11 +244,36 @@ msgstr "Neznámé"
 msgid "Upload speed"
 msgstr "Upload speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Použít STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Pouze informační hodnoty (v KByte/s)"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL stanovují, které vnější porty by měly být přesměrovány na které "
+#~ "vnitřní adresy a porty"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Interval čištění pravidel"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Práh čištění pravidel"
+
+#~ msgid "Host"
+#~ msgstr "Hostitel"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP umožňuje klientům v místní síti automaticky nakonfigurovat router."
+
+#~ msgid "Use %s"
+#~ msgstr "Použít %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Pouze informační hodnoty (v KByte/s)"

--- a/applications/luci-app-upnp/po/cs/upnp.po
+++ b/applications/luci-app-upnp/po/cs/upnp.po
@@ -248,32 +248,3 @@ msgstr "Upload speed"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL stanovují, které vnější porty by měly být přesměrovány na které "
-#~ "vnitřní adresy a porty"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interval čištění pravidel"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Práh čištění pravidel"
-
-#~ msgid "Host"
-#~ msgstr "Hostitel"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP umožňuje klientům v místní síti automaticky nakonfigurovat router."
-
-#~ msgid "Use %s"
-#~ msgstr "Použít %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Pouze informační hodnoty (v KByte/s)"

--- a/applications/luci-app-upnp/po/da/upnp.po
+++ b/applications/luci-app-upnp/po/da/upnp.po
@@ -250,33 +250,3 @@ msgstr "Upload speed"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL'er angiver, hvilke eksterne porte der kan omdirigeres til hvilke "
-#~ "interne adresser og porte"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interval for rene regler"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Tærskel for rene regler"
-
-#~ msgid "Host"
-#~ msgstr "Vært"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP gør det muligt for klienter i det lokale netværk at konfigurere "
-#~ "routeren automatisk."
-
-#~ msgid "Use %s"
-#~ msgstr "Brug %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Værdi i KByte/s, kun til information"

--- a/applications/luci-app-upnp/po/da/upnp.po
+++ b/applications/luci-app-upnp/po/da/upnp.po
@@ -14,68 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9.1-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL'er angiver, hvilke eksterne porte der kan omdirigeres til hvilke interne "
-"adresser og porte"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Handling"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktive UPnP-omdirigeringer"
+msgid "Active Service Port Maps"
+msgstr "Aktive omdirigeringer"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Avancerede indstillinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annoncerer som IGDv1-enhed i stedet for IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Tillad kun at tilføje viderestillinger til ip-adresser, der anmoder om"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Annonceret modelnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Annonceret serienummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Interval for rene regler"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Tærskel for rene regler"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Klient adresse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Klient port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -85,7 +92,7 @@ msgstr "Kommentar"
 msgid "Delete"
 msgstr "Slet"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -94,127 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Enhedens UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Download speed"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Aktiver NAT-PMP-funktionalitet"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Aktiver UPnP-funktionalitet"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Aktiver IGDv1-tilstand"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Aktiver yderligere logning"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Aktiver sikker tilstand"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Ekstern port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Generelle indstillinger"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Giv adgang til upnp-procedurer"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Vært"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Underretningsinterval"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL til præsentation"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Sætter ekstra fejlfindingsoplysninger i systemloggen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Rapportere system i stedet for dæmonens oppetid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN vært"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnP ACL'er"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP-indstillinger"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Generelle indstillinger"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP-lease-fil"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Start UPnP- og NAT-PMP-tjenesten"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Der er ingen aktive omdirigeringer."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Universelt plug &play"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP gør det muligt for klienter i det lokale netværk at konfigurere "
-"routeren automatisk."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Aktiver UPnP IGDv1-tilstand"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -222,11 +246,37 @@ msgstr "Ukendt"
 msgid "Upload speed"
 msgstr "Upload speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Brug STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Værdi i KByte/s, kun til information"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL'er angiver, hvilke eksterne porte der kan omdirigeres til hvilke "
+#~ "interne adresser og porte"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Interval for rene regler"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Tærskel for rene regler"
+
+#~ msgid "Host"
+#~ msgstr "Vært"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP gør det muligt for klienter i det lokale netværk at konfigurere "
+#~ "routeren automatisk."
+
+#~ msgid "Use %s"
+#~ msgstr "Brug %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Værdi i KByte/s, kun til information"

--- a/applications/luci-app-upnp/po/de/upnp.po
+++ b/applications/luci-app-upnp/po/de/upnp.po
@@ -14,68 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACLs definieren, welche externen Ports zu welchen internen Adressen und "
-"Ports weitergeleitet werden dürfen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Aktion"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktive UPnP-Weiterleitungen"
+msgid "Active Service Port Maps"
+msgstr "Aktive Weiterleitungen"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Als IGDv1-Gerät anstelle von IGDv2 bekanntgeben"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Erlauben"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Nur Weiterleitungen zurück zum anfordernden Client zulassen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Angekündigte Modellnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Angekündigte Seriennummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Aufräumintervall für Weiterleitungen"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Aufräumschwellenwert für Weiterleitungen"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Clientadresse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Clientport"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -85,7 +92,7 @@ msgstr "Kommentar"
 msgid "Delete"
 msgstr "Löschen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Ablehnen"
 
@@ -94,127 +101,144 @@ msgstr "Ablehnen"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Geräte-UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Download-Bandbreite"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "NAT-PMP Funktionalität aktivieren"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "UPnP Funktionalität aktivieren"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "IGDv1 Modus aktivieren"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Erweiterte Protokollierung aktivieren"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Sicheren Modus aktivieren"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Externer Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Allgemeine Einstellungen"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Zugriff auf UPNP-Prozeduren gewähren"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Benachrichtigungsintervall"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Präsentations-URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Schreibt zusätzliche Debug-Informationen in das Systemprotokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Systemlaufzeit statt Prozesslaufzeit melden"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN-Host"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN-Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACLs der MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP-Einstellungen"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Allgemeine Einstellungen"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP Lease-Datei"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "UPnP und NAT-PMP Dienst starten"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Es gibt keine aktiven Weiterleitungen."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP erlaubt es Clients im lokalen Netzwerk automatisch Port-Weiterleitungen "
-"auf diesem Router einzurichten."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "UPnP IGDv1 Modus aktivieren"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -222,11 +246,37 @@ msgstr "Unbekannt"
 msgid "Upload speed"
 msgstr "Upload speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "STUN verwenden"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Wert in Kilobyte/s, nur informativ"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACLs definieren, welche externen Ports zu welchen internen Adressen und "
+#~ "Ports weitergeleitet werden dürfen"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Aufräumintervall für Weiterleitungen"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Aufräumschwellenwert für Weiterleitungen"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP erlaubt es Clients im lokalen Netzwerk automatisch Port-"
+#~ "Weiterleitungen auf diesem Router einzurichten."
+
+#~ msgid "Use %s"
+#~ msgstr "%s verwenden"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Wert in Kilobyte/s, nur informativ"

--- a/applications/luci-app-upnp/po/de/upnp.po
+++ b/applications/luci-app-upnp/po/de/upnp.po
@@ -250,33 +250,3 @@ msgstr "Upload speed"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACLs definieren, welche externen Ports zu welchen internen Adressen und "
-#~ "Ports weitergeleitet werden dürfen"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Aufräumintervall für Weiterleitungen"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Aufräumschwellenwert für Weiterleitungen"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP erlaubt es Clients im lokalen Netzwerk automatisch Port-"
-#~ "Weiterleitungen auf diesem Router einzurichten."
-
-#~ msgid "Use %s"
-#~ msgstr "%s verwenden"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Wert in Kilobyte/s, nur informativ"

--- a/applications/luci-app-upnp/po/el/upnp.po
+++ b/applications/luci-app-upnp/po/el/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Δράση"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Ρυθμίσεις για προχωρημένους"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Σχόλιο"
 
@@ -83,7 +92,7 @@ msgstr "Σχόλιο"
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Γενικές ρυθμίσεις"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Θύρα"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Πρωτόκολλο"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Θύρα"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Γενικές ρυθμίσεις"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -218,11 +246,7 @@ msgstr ""
 msgid "Upload speed"
 msgstr "Ταχύτητα μεταφόρτωσης"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/en/upnp.po
+++ b/applications/luci-app-upnp/po/en/upnp.po
@@ -170,7 +170,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
 msgid "SOAP/HTTP port"
-msgstr "SOAP/HTTP port"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"

--- a/applications/luci-app-upnp/po/en/upnp.po
+++ b/applications/luci-app-upnp/po/en/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.3-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr ""
 
@@ -83,7 +92,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -218,11 +246,7 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/es/upnp.po
+++ b/applications/luci-app-upnp/po/es/upnp.po
@@ -14,69 +14,76 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Las Listas de Control de Acceso (ACL) especifican cuáles puertos externos "
-"pueden ser reenviados hacía las direcciones IP y puertos del cliente. Las "
-"direcciones IPv6 siempre son permitidas."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Acción"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
 msgstr "Reenvíos de puertos activos"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Ajustes avanzados"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Anunciar como dispositivo UPnP IGDv1 (sin IPv6) en lugar de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Permitir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
-msgstr "Permitir agregar reenvíos de puertos solo a direcciones IP solicitantes"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
+msgstr ""
+"Permitir agregar reenvíos de puertos solo a direcciones IP solicitantes"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Número de modelo anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Número de serie anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Intervalo de borrado de reglas"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Umbral de borrado de reglas"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Dirección del cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Puerto del cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Comentario"
 
@@ -86,7 +93,7 @@ msgstr "Comentario"
 msgid "Delete"
 msgstr "Eliminar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Denegar"
 
@@ -95,128 +102,144 @@ msgstr "Denegar"
 msgid "Description"
 msgstr "Descripción"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID del dispositivo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Velocidad de descarga"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Activar protocolo PCP/NAT-PMP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr "Activar protocolo UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Activar UPnP modo IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Activar registro adicional"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Activar modo seguro"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Puerto externo"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Ajustes generales"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Conceder acceso a UPnP IGD y PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Intervalo de notificación"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Puerto"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL de presentación"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Coloca información de depuración adicional en el registro del sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Informar tiempo de actividad del sistema en vez de la del servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Puerto"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Puerto STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "Listas de Control de Acceso (ACLs)"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr "Ajustes del Servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Ajustes generales"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
 msgstr "Archivo de tiempo de concesión del servicio"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr "Iniciar servicio"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "No hay reenvíos de puertos vigentes."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD y PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD y PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Servicio UPnP IGD y PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP IGD y PCP/NAT-PMP permiten a los clientes de la red local configurar "
-"automáticamente el reenvío de puertos en el enrutador. También llamado Plug "
-"and Play universal."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Activar UPnP modo IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -224,11 +247,39 @@ msgstr "Desconocido"
 msgid "Upload speed"
 msgstr "Velocidad de carga"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Utilizar STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valor en KBytes/s, sólo informativo"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Las Listas de Control de Acceso (ACL) especifican cuáles puertos externos "
+#~ "pueden ser reenviados hacía las direcciones IP y puertos del cliente. Las "
+#~ "direcciones IPv6 siempre son permitidas."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Intervalo de borrado de reglas"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Umbral de borrado de reglas"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP IGD y PCP/NAT-PMP permiten a los clientes de la red local configurar "
+#~ "automáticamente el reenvío de puertos en el enrutador. También llamado "
+#~ "Plug and Play universal."
+
+#~ msgid "Use %s"
+#~ msgstr "Utilizar %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valor en KBytes/s, sólo informativo"

--- a/applications/luci-app-upnp/po/es/upnp.po
+++ b/applications/luci-app-upnp/po/es/upnp.po
@@ -251,35 +251,3 @@ msgstr "Velocidad de carga"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Las Listas de Control de Acceso (ACL) especifican cuáles puertos externos "
-#~ "pueden ser reenviados hacía las direcciones IP y puertos del cliente. Las "
-#~ "direcciones IPv6 siempre son permitidas."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalo de borrado de reglas"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Umbral de borrado de reglas"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP IGD y PCP/NAT-PMP permiten a los clientes de la red local configurar "
-#~ "automáticamente el reenvío de puertos en el enrutador. También llamado "
-#~ "Plug and Play universal."
-
-#~ msgid "Use %s"
-#~ msgstr "Utilizar %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valor en KBytes/s, sólo informativo"

--- a/applications/luci-app-upnp/po/fi/upnp.po
+++ b/applications/luci-app-upnp/po/fi/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Toiminta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktiivise UPnP-uudelleenohjaukset"
+msgid "Active Service Port Maps"
+msgstr "Aktiivise uudelleenohjaukset"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Kommentti"
 
@@ -83,7 +92,7 @@ msgstr "Kommentti"
 msgid "Delete"
 msgstr "Poista"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "Kuvaus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Laitteen UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Käytä NAT-PMP-toiminnallisuutta"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Käytä UPnP-toiminnallisuutta"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Käytä IGDv1-tilaa"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Ulkoinen portti"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Yleiset asetukset"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Palvelin"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Ilmoitusväli"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Portti"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokolla"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Portti"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP-asetukset"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Yleiset asetukset"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP-lainatiedosto"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Käynnistä UPnP- ja NAT-PMP-palvelu"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Ei aktiivisia uudelleenohjauksia."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Käytä UPnP IGDv1-tilaa"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Tuntematon"
 
@@ -218,11 +246,13 @@ msgstr "Tuntematon"
 msgid "Upload speed"
 msgstr "Lähetysyhteys"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Käytä STUN:ia"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
+
+#~ msgid "Host"
+#~ msgstr "Palvelin"
+
+#~ msgid "Use %s"
+#~ msgstr "Käytä %s:ia"

--- a/applications/luci-app-upnp/po/fi/upnp.po
+++ b/applications/luci-app-upnp/po/fi/upnp.po
@@ -250,9 +250,3 @@ msgstr "Lähetysyhteys"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "Palvelin"
-
-#~ msgid "Use %s"
-#~ msgstr "Käytä %s:ia"

--- a/applications/luci-app-upnp/po/fr/upnp.po
+++ b/applications/luci-app-upnp/po/fr/upnp.po
@@ -14,70 +14,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Les ACLs définissent quels ports externes peuvent être redirigés, vers "
-"quelles adresses et ports internes"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Action"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Redirections UPnP actives"
+msgid "Active Service Port Maps"
+msgstr "Redirections actives"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annoncer comme dispositif IGDv1 au lieu de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permet d'ajouter des redirections seulement vers les adresses IP qui font "
 "des demandes"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Numéro de modèle annoncé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Numéro de série annoncé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Intervalle des règles de nettoyage"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Niveau des règles de nettoyage"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Adresse du client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port du client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -87,7 +94,7 @@ msgstr "Commentaire"
 msgid "Delete"
 msgstr "Effacer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -96,128 +103,145 @@ msgstr ""
 msgid "Description"
 msgstr "Description"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID du périphérique"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Liaison descendante"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Activer la fonctionnalité NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Activer la fonctionnalité UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Activer le mode IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Activer la journalisation additionnelle"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Activer le mode sécurisé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Port externe"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Réglages généraux"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Accorder l'accès aux procédures de upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Hôte"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Intervalle de notification"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL de présentation"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocole"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Rajoute des informations de debug dans le journal-système"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 "Indiquer la durée de fonctionnement du système plutôt que celle du démon UPnP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Hôte STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Port STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACLs MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Paramètres MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Réglages généraux"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Fichier des baux UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Démarrer les services UPnP et NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Il n'y a pas de redirections actives."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Plug & Play universel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP permet à des clients du réseau local de configurer automatiquement le "
-"routeur."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Activer le mode UPnP IGDv1"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Inconnue"
 
@@ -225,11 +249,37 @@ msgstr "Inconnue"
 msgid "Upload speed"
 msgstr "Liaison montante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Utiliser STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valeur en Ko/s, pour information seulement"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Les ACLs définissent quels ports externes peuvent être redirigés, vers "
+#~ "quelles adresses et ports internes"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Intervalle des règles de nettoyage"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Niveau des règles de nettoyage"
+
+#~ msgid "Host"
+#~ msgstr "Hôte"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP permet à des clients du réseau local de configurer automatiquement "
+#~ "le routeur."
+
+#~ msgid "Use %s"
+#~ msgstr "Utiliser %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valeur en Ko/s, pour information seulement"

--- a/applications/luci-app-upnp/po/fr/upnp.po
+++ b/applications/luci-app-upnp/po/fr/upnp.po
@@ -253,33 +253,3 @@ msgstr "Liaison montante"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Les ACLs définissent quels ports externes peuvent être redirigés, vers "
-#~ "quelles adresses et ports internes"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalle des règles de nettoyage"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Niveau des règles de nettoyage"
-
-#~ msgid "Host"
-#~ msgstr "Hôte"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP permet à des clients du réseau local de configurer automatiquement "
-#~ "le routeur."
-
-#~ msgid "Use %s"
-#~ msgstr "Utiliser %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valeur en Ko/s, pour information seulement"

--- a/applications/luci-app-upnp/po/ga/upnp.po
+++ b/applications/luci-app-upnp/po/ga/upnp.po
@@ -15,68 +15,75 @@ msgstr ""
 "n>6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 5.8-rc\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Sonraíonn ACLanna cé na calafoirt sheachtracha is féidir a chur ar aghaidh "
-"chuig a seoltaí cliant agus calafoirt, IPv6 ceadaithe i gcónaí."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Gníomhaíocht"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
 msgstr "Port Gníomhach ar Aghaidh"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Socruithe chun cinn"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Fógairt mar ghléas UPnP IGDv1 (gan IPv6) in ionad IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Ceadaigh"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Ceadaigh port a chur ar aghaidh chuig seoltaí IP amháin a iarrtar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Uimhir mhúnla fógartha"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Sraithuimhir fógartha"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Eatramh rialacha glan"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Táirseach rialacha glan"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Seoladh Cliant"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port Cliant"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Trácht"
 
@@ -86,7 +93,7 @@ msgstr "Trácht"
 msgid "Delete"
 msgstr "Scrios"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Shéanadh"
 
@@ -95,128 +102,144 @@ msgstr "Shéanadh"
 msgid "Description"
 msgstr "Cur síos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID Gléas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Gá le luas a íoslódáil"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Cumasaigh prótacal PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr "Cumasaigh prótacal UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Cumasaigh mód UPnP IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Cumasaigh logáil bhreise"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Cumasaigh mód slán"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Port Seachtrach"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Socruithe Ginearálta"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Deonaigh rochtain ar UPnP IGD & PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Óstach"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Eatramh fógra"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL cur i láthair"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Prótacal"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Cuireann sé faisnéis bhreise dífhabhtaithe isteach i loga an chórais"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Córas tuairisce in ionad aga fónaimh seirbhíse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN Óstach"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACLanna seirbhíse"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr "Socruithe Seirbhíse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Socruithe Ginearálta"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
 msgstr "Comhad léasa seirbhíse"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr "Tosaigh seirbhís"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Níl aon phort gníomhach ar aghaidh."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & Seirbhís PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"Ligeann UPnP IGD & PCP/NAT-PMP do chliaint ar an líonra áitiúil chun port ar "
-"aghaidh ar an ródaire a chumrú go huathoibríoch. Tugtar Breiseán Uilíoch "
-"agus Súgradh air freisin."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Cumasaigh mód UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Anaithnid"
 
@@ -224,11 +247,38 @@ msgstr "Anaithnid"
 msgid "Upload speed"
 msgstr "Luas uaslódála"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Bain úsáid as STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Luach i KByte/s, eolasach amháin"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Sonraíonn ACLanna cé na calafoirt sheachtracha is féidir a chur ar "
+#~ "aghaidh chuig a seoltaí cliant agus calafoirt, IPv6 ceadaithe i gcónaí."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Eatramh rialacha glan"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Táirseach rialacha glan"
+
+#~ msgid "Host"
+#~ msgstr "Óstach"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "Ligeann UPnP IGD & PCP/NAT-PMP do chliaint ar an líonra áitiúil chun port "
+#~ "ar aghaidh ar an ródaire a chumrú go huathoibríoch. Tugtar Breiseán "
+#~ "Uilíoch agus Súgradh air freisin."
+
+#~ msgid "Use %s"
+#~ msgstr "Bain úsáid as %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Luach i KByte/s, eolasach amháin"

--- a/applications/luci-app-upnp/po/ga/upnp.po
+++ b/applications/luci-app-upnp/po/ga/upnp.po
@@ -251,34 +251,3 @@ msgstr "Luas uaslódála"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Sonraíonn ACLanna cé na calafoirt sheachtracha is féidir a chur ar "
-#~ "aghaidh chuig a seoltaí cliant agus calafoirt, IPv6 ceadaithe i gcónaí."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Eatramh rialacha glan"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Táirseach rialacha glan"
-
-#~ msgid "Host"
-#~ msgstr "Óstach"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "Ligeann UPnP IGD & PCP/NAT-PMP do chliaint ar an líonra áitiúil chun port "
-#~ "ar aghaidh ar an ródaire a chumrú go huathoibríoch. Tugtar Breiseán "
-#~ "Uilíoch agus Súgradh air freisin."
-
-#~ msgid "Use %s"
-#~ msgstr "Bain úsáid as %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Luach i KByte/s, eolasach amháin"

--- a/applications/luci-app-upnp/po/he/upnp.po
+++ b/applications/luci-app-upnp/po/he/upnp.po
@@ -12,66 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "פעולה"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "הגדרות מתקדמות"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "תגובה"
 
@@ -81,7 +90,7 @@ msgstr "תגובה"
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -90,125 +99,144 @@ msgstr ""
 msgid "Description"
 msgstr "תיאור"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "פתחה"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "פתחה"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -216,11 +244,7 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/hi/upnp.po
+++ b/applications/luci-app-upnp/po/hi/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "उन्नत सेटिंग्स"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr ""
 
@@ -83,7 +92,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "अज्ञात"
 
@@ -218,11 +246,7 @@ msgstr "अज्ञात"
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/hu/upnp.po
+++ b/applications/luci-app-upnp/po/hu/upnp.po
@@ -250,30 +250,3 @@ msgstr "Kifelé menő kapcsolat"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Az ACL-ek határozzák meg, hogy melyik külső portok melyik belső portokra "
-#~ "és címekre kerülhetnek továbbításra"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Szabály törlési időköz"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Szabály törlési küszöbérték"
-
-#~ msgid "Host"
-#~ msgstr "Gép"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "Az UPnP lehetővé teszi a hálózatban lévő ügyfelek számára hogy "
-#~ "automatikusan beállítsák a routert."
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Érték KByte/s-ban, csak tájékoztató jellegű"

--- a/applications/luci-app-upnp/po/hu/upnp.po
+++ b/applications/luci-app-upnp/po/hu/upnp.po
@@ -12,70 +12,77 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Az ACL-ek határozzák meg, hogy melyik külső portok melyik belső portokra és "
-"címekre kerülhetnek továbbításra"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Művelet"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktív UPnP átirányítások"
+msgid "Active Service Port Maps"
+msgstr "Aktív átirányítások"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Haladó beállítások"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Hirdetés IGDv1 eszközként IGDv2 helyett"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Kizárólag a kérést küldő IP címre történő továbbítás hozzáadásának "
 "engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Bejelentett modellszám"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Bejelentett sorozatszám"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Szabály törlési időköz"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Szabály törlési küszöbérték"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -85,7 +92,7 @@ msgstr "Megjegyzés"
 msgid "Delete"
 msgstr "Törlés"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -94,127 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "Leírás"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Eszköz UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Befelé jövő kapcsolat"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "NAT-PMP funkció engedélyezése"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "UPnP funkció engedélyezése"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "IGDv1 mód engedélyezése"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "További naplózás engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Biztonságos mód engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Külső port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Általános beállítások"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Gép"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Értesítési időköz"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Bemutató URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "További hibakeresési információkat tesz a rendszernaplóba"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "A démon helyett a rendszer működési idejét jeleníti meg"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnP ACL-ek"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP beállítások"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Általános beállítások"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP bérlet fájl"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "UPnP és NAT-PMP szolgáltatás elindítása"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Nincsenek aktív átírányítások."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Univerzális Plug and Play"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"Az UPnP lehetővé teszi a hálózatban lévő ügyfelek számára hogy automatikusan "
-"beállítsák a routert."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "UPnP IGDv1 mód engedélyezése"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Ismeretlen"
 
@@ -222,11 +246,34 @@ msgstr "Ismeretlen"
 msgid "Upload speed"
 msgstr "Kifelé menő kapcsolat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Érték KByte/s-ban, csak tájékoztató jellegű"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Az ACL-ek határozzák meg, hogy melyik külső portok melyik belső portokra "
+#~ "és címekre kerülhetnek továbbításra"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Szabály törlési időköz"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Szabály törlési küszöbérték"
+
+#~ msgid "Host"
+#~ msgstr "Gép"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "Az UPnP lehetővé teszi a hálózatban lévő ügyfelek számára hogy "
+#~ "automatikusan beállítsák a routert."
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Érték KByte/s-ban, csak tájékoztató jellegű"

--- a/applications/luci-app-upnp/po/it/upnp.po
+++ b/applications/luci-app-upnp/po/it/upnp.po
@@ -250,34 +250,3 @@ msgstr "Velocità di upload"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Le ACL specificano quali porte esterne possono essere ridirezionate a "
-#~ "quali indirizzi e porte interni, IPv6 sempre consentito."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Cancella le regole"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Pulisci le regole degli eventi"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP permette ai dispositivi nella rete locale di configurare "
-#~ "automaticamente l'apertura delle porte del router. Anche conosciuto come "
-#~ "Universal Plug and Play."
-
-#~ msgid "Use %s"
-#~ msgstr "Usa %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valori in KByte/s (informativo)"

--- a/applications/luci-app-upnp/po/it/upnp.po
+++ b/applications/luci-app-upnp/po/it/upnp.po
@@ -14,68 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Le ACL specificano quali porte esterne possono essere ridirezionate a quali "
-"indirizzi e porte interni, IPv6 sempre consentito."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Azione"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Attiva reindirizzamento UPnP"
+msgid "Active Service Port Maps"
+msgstr "Attiva reindirizzamento"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Impostazioni avanzate"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Pubblicizza come dispositivo IGDv1 anziché IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Permetti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Permetti l'aggiunta della mappatura solo agli indirizzi IP richiedenti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Numero modello annunciato"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Numero seriale annunciato"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Cancella le regole"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Pulisci le regole degli eventi"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Indirizzo IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Porta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Commento"
 
@@ -85,7 +92,7 @@ msgstr "Commento"
 msgid "Delete"
 msgstr "Elimina"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Nega"
 
@@ -94,128 +101,144 @@ msgstr "Nega"
 msgid "Description"
 msgstr "Descrizione"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID del dispositivo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Velocità di download"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Abilita il protocollo NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Abilita il protocollo UPnP"
+msgstr "Abilita il protocollo UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Abilita modalità IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Abilita log addizionale"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Abilita la modalità sicura"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Porta Esterna"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Impostazioni Generali"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Concedere l'accesso alle procedure UPnP e PCP/NAT-PMP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Intervallo di notifica"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Porta"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL di presentazione"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocollo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Scrivi nel log di sistema ulteriori informazioni di debug"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Mostra l'uptime del sistema invece del servizio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Porta"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Porta STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr "Servizi ACL"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Opzioni di MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Impostazioni Generali"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "File di leasing UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Avvia il servizio UPnP e NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Non ci sono mappature attive."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD e PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD e PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Plug & Play universale"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP permette ai dispositivi nella rete locale di configurare "
-"automaticamente l'apertura delle porte del router. Anche conosciuto come "
-"Universal Plug and Play."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Abilita modalità UPnP IGDv1"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -223,11 +246,38 @@ msgstr "Sconosciuto"
 msgid "Upload speed"
 msgstr "Velocità di upload"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Usa STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valori in KByte/s (informativo)"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Le ACL specificano quali porte esterne possono essere ridirezionate a "
+#~ "quali indirizzi e porte interni, IPv6 sempre consentito."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Cancella le regole"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Pulisci le regole degli eventi"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP permette ai dispositivi nella rete locale di configurare "
+#~ "automaticamente l'apertura delle porte del router. Anche conosciuto come "
+#~ "Universal Plug and Play."
+
+#~ msgid "Use %s"
+#~ msgstr "Usa %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valori in KByte/s (informativo)"

--- a/applications/luci-app-upnp/po/ja/upnp.po
+++ b/applications/luci-app-upnp/po/ja/upnp.po
@@ -250,33 +250,3 @@ msgstr "アップリンク"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "アクセス制御リスト（ACL）は、どの外部ポートからどの内部アドレス及びポート"
-#~ "へリダイレクトするかを設定します。"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "ルール消去間隔"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "ルール消去しきい値"
-
-#~ msgid "Host"
-#~ msgstr "ホスト"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnPを使用することで、ローカルネットワーク内のクライアントが自動的にルータ"
-#~ "を構成することができます。"
-
-#~ msgid "Use %s"
-#~ msgstr "%s を使用"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "クライアントへの情報提供のみに使用される、KByte/sの値です"

--- a/applications/luci-app-upnp/po/ja/upnp.po
+++ b/applications/luci-app-upnp/po/ja/upnp.po
@@ -14,68 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"アクセス制御リスト（ACL）は、どの外部ポートからどの内部アドレス及びポートへリ"
-"ダイレクトするかを設定します。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "アクション"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "稼働中のUPnPリダイレクト"
+msgid "Active Service Port Maps"
+msgstr "稼働中のリダイレクト"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "IGDv2 ではなく IGDv1 デバイスとしてアドバタイズ"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "許可"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "要求元IPアドレスへの転送のみ、追加を許可します"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "通知するモデル番号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "通知するシリアル番号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "ルール消去間隔"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "ルール消去しきい値"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "クライアント・アドレス"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "クライアント・ポート"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "コメント"
 
@@ -85,7 +92,7 @@ msgstr "コメント"
 msgid "Delete"
 msgstr "削除"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "拒否"
 
@@ -94,127 +101,144 @@ msgstr "拒否"
 msgid "Description"
 msgstr "説明"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "デバイス UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "ダウンリンク"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "NAT-PMP機能を有効にする"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "UPnP機能を有効にする"
+msgstr "UPnP IGD機能を有効にする"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "IGDv1 モードを有効化"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "ログ機能を有効にする"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "セキュアモードを有効にする"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "外部ポート"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "一般設定"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "upnp プロシージャへのアクセスを許可"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "ホスト"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "通知間隔"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "ポート"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "プレゼンテーションURL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "プロトコル"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "追加のデバッグ情報をシステムログへ挿入する"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "サービスの起動時間の代わりにシステムの起動時間を使用する"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "ポート"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN ホスト"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN ポート"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnPアクセス制御リスト（ACL）"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP 設定"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "一般設定"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP リースファイル"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "UPnP及びNAT-PMPサービスを開始する"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "有効なリダイレクトはありません。"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGDとPCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGDとPCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "ユニバーサル プラグ & プレイ"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnPを使用することで、ローカルネットワーク内のクライアントが自動的にルータを"
-"構成することができます。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "UPnP IGDv1 モードを有効化"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "不明"
 
@@ -222,11 +246,37 @@ msgstr "不明"
 msgid "Upload speed"
 msgstr "アップリンク"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "STUN を使用"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "クライアントへの情報提供のみに使用される、KByte/sの値です"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "アクセス制御リスト（ACL）は、どの外部ポートからどの内部アドレス及びポート"
+#~ "へリダイレクトするかを設定します。"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "ルール消去間隔"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "ルール消去しきい値"
+
+#~ msgid "Host"
+#~ msgstr "ホスト"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnPを使用することで、ローカルネットワーク内のクライアントが自動的にルータ"
+#~ "を構成することができます。"
+
+#~ msgid "Use %s"
+#~ msgstr "%s を使用"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "クライアントへの情報提供のみに使用される、KByte/sの値です"

--- a/applications/luci-app-upnp/po/ko/upnp.po
+++ b/applications/luci-app-upnp/po/ko/upnp.po
@@ -250,6 +250,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "호스트"

--- a/applications/luci-app-upnp/po/ko/upnp.po
+++ b/applications/luci-app-upnp/po/ko/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "액션"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "고급 설정"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "메모"
 
@@ -83,7 +92,7 @@ msgstr "메모"
 msgid "Delete"
 msgstr "삭제"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "설명"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "기본 설정"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "호스트"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "포트"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "프로토콜"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "포트"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "기본 설정"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -218,11 +246,10 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr ""
+#~ msgid "Host"
+#~ msgstr "호스트"

--- a/applications/luci-app-upnp/po/lt/upnp.po
+++ b/applications/luci-app-upnp/po/lt/upnp.po
@@ -252,34 +252,3 @@ msgstr "Įkėlimo greitis"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "„ACL“ (dgs.) nurodo, į kuriuos išorinius prievadus galima persiųsti į "
-#~ "nurodytus kliento adresus ir prievadus, IPv6 yra visada leidžiamas."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Išvalyti taisyklių intervalus"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Išvalyti taisyklių slenksčius"
-
-#~ msgid "Host"
-#~ msgstr "Skleidėjas/Vedėjas"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "„UPnP IGD“ ir „PCP/NAT-PMP“ leidžia vietinio tinklo klientams "
-#~ "automatiškai konfigūruoti prievado persiuntimus maršrutizatoriuje. Taip "
-#~ "pat vadinamas – „Universal Plug and Play“."
-
-#~ msgid "Use %s"
-#~ msgstr "Naudoti „%s“"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Reikšmė kilobaitais per sekundę (KB/s), tik informacinis"

--- a/applications/luci-app-upnp/po/lt/upnp.po
+++ b/applications/luci-app-upnp/po/lt/upnp.po
@@ -13,71 +13,78 @@ msgstr ""
 "n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.8-rc\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"„ACL“ (dgs.) nurodo, į kuriuos išorinius prievadus galima persiųsti į "
-"nurodytus kliento adresus ir prievadus, IPv6 yra visada leidžiamas."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Veiksmas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
 msgstr "Aktyvūs prievadų persiuntimai"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Pažangūs nustatymai"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 "Reklamuoti/Skelbti kaip – „UPnP IGDv1“ įrenginį (be IPv6), vietoj „IGDv2“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Leisti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Leisti pridėti prievadų persiuntimus tik į užklausų reikalaujančius IP "
 "adresus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Paskelbtas modelio numeris"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Paskelbtas serijos numeris"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Išvalyti taisyklių intervalus"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Išvalyti taisyklių slenksčius"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Kliento adresas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Kliento prievadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Komentuoti"
 
@@ -87,7 +94,7 @@ msgstr "Komentuoti"
 msgid "Delete"
 msgstr "Ištrinti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Atmesti/Neprileisti"
 
@@ -96,128 +103,144 @@ msgstr "Atmesti/Neprileisti"
 msgid "Description"
 msgstr "Aprašas/-ymas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Įrenginio „UUID“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Atsisiuntimo greitis"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Įgalinti „NAT-PMP“ funkcionalumą"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Įgalinti „UPnP“ funkcionalumą"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Įjungti „IGDv1“ veikseną"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Įjungti papildomą žurnalinimą"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Įjungti „saugiąją veikseną“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Išorinis prievadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Bendri nustatymai"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Duoti prieigą prie „upnp procedures“"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Skleidėjas/Vedėjas"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Pranešimo intervalas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Prievadas"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Pateikties „URL“ – saitas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokolas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Įdeda papildomą derinimo informaciją į sistemos žurnalą"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Pranešti apie sistemos veikimo laiką, o ne tarnybos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Prievadas"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "„STUN“ skleidėjas/vedėjas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "„STUN“ prievadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "„Service ACLs“"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Tarnybos („MiniUPnP“) nustatymai"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Bendri nustatymai"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
 msgstr "Tarnybos nuomos failas"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Paleisti „UPnP“ ir „NAT-PMP“ tarnybą"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Nėra aktyvių prievadų persiuntimų."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "„UPnP IGD & PCP/NAT-PMP“"
+msgid "UPnP IGD & PCP"
+msgstr "„UPnP IGD & PCP“"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "„UPnP IGD & PCP/NAT-PMP“ tarnyba"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"„UPnP IGD“ ir „PCP/NAT-PMP“ leidžia vietinio tinklo klientams automatiškai "
-"konfigūruoti prievado persiuntimus maršrutizatoriuje. Taip pat vadinamas – „"
-"Universal Plug and Play“."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Įjungti „UPnP IGDv1“ veikseną"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Nežinoma/-s/-i"
 
@@ -225,11 +248,38 @@ msgstr "Nežinoma/-s/-i"
 msgid "Upload speed"
 msgstr "Įkėlimo greitis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Naudoti „STUN“"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Reikšmė kilobaitais per sekundę (KB/s), tik informacinis"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "„ACL“ (dgs.) nurodo, į kuriuos išorinius prievadus galima persiųsti į "
+#~ "nurodytus kliento adresus ir prievadus, IPv6 yra visada leidžiamas."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Išvalyti taisyklių intervalus"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Išvalyti taisyklių slenksčius"
+
+#~ msgid "Host"
+#~ msgstr "Skleidėjas/Vedėjas"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "„UPnP IGD“ ir „PCP/NAT-PMP“ leidžia vietinio tinklo klientams "
+#~ "automatiškai konfigūruoti prievado persiuntimus maršrutizatoriuje. Taip "
+#~ "pat vadinamas – „Universal Plug and Play“."
+
+#~ msgid "Use %s"
+#~ msgstr "Naudoti „%s“"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Reikšmė kilobaitais per sekundę (KB/s), tik informacinis"

--- a/applications/luci-app-upnp/po/mr/upnp.po
+++ b/applications/luci-app-upnp/po/mr/upnp.po
@@ -14,66 +14,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "प्रगत सेटिंग्ज"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "टिप्पणी"
 
@@ -83,7 +92,7 @@ msgstr "टिप्पणी"
 msgid "Delete"
 msgstr "हटवा"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -92,125 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "वर्णन"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "सामान्य सेटिंग्ज"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "पोर्ट"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "प्रोटोकॉल"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "पोर्ट"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "सामान्य सेटिंग्ज"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "अज्ञात"
 
@@ -218,11 +246,7 @@ msgstr "अज्ञात"
 msgid "Upload speed"
 msgstr "अपलिंक"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/ms/upnp.po
+++ b/applications/luci-app-upnp/po/ms/upnp.po
@@ -12,66 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Tindakan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Tetapan Lanjutan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Ulasan"
 
@@ -81,7 +90,7 @@ msgstr "Ulasan"
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -90,125 +99,144 @@ msgstr ""
 msgid "Description"
 msgstr "Keterangan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Hos"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -216,11 +244,10 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr ""
+#~ msgid "Host"
+#~ msgstr "Hos"

--- a/applications/luci-app-upnp/po/ms/upnp.po
+++ b/applications/luci-app-upnp/po/ms/upnp.po
@@ -248,6 +248,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "Hos"

--- a/applications/luci-app-upnp/po/nb_NO/upnp.po
+++ b/applications/luci-app-upnp/po/nb_NO/upnp.po
@@ -246,33 +246,3 @@ msgstr "Opplinje"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL angir hvilke eksterne porter som kan bli viderekoblet, og til hvilke "
-#~ "interne adresser og porter."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Nullstill UPnP Viderekoblinger intervall"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Nullstill UPnP terskel"
-
-#~ msgid "Host"
-#~ msgstr "Vert"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP gjør at klientene i det lokale nettverket automatisk kan konfigurere "
-#~ "ruteren."
-
-#~ msgid "Use %s"
-#~ msgstr "Bruk %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Verdi i KByte/sek, kun for informasjon"

--- a/applications/luci-app-upnp/po/nb_NO/upnp.po
+++ b/applications/luci-app-upnp/po/nb_NO/upnp.po
@@ -10,68 +10,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL angir hvilke eksterne porter som kan bli viderekoblet, og til hvilke "
-"interne adresser og porter."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Handling"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktive UPnP Viderekoblinger"
+msgid "Active Service Port Maps"
+msgstr "Aktive Viderekoblinger"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Avanserte innstillinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annonser som IGDv1-enhet istedenfor IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Tillat videkobling kun til IP adresser som ber om det"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Annonsert modellnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Annonsert serienummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Nullstill UPnP Viderekoblinger intervall"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Nullstill UPnP terskel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Klient adresse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Klient port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -81,7 +88,7 @@ msgstr "Kommentar"
 msgid "Delete"
 msgstr "Slett"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -90,128 +97,144 @@ msgstr ""
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Enhet UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Nedlinje"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Aktiver NAT-PMP funksjonalitet"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Aktiver UPnP funksjonalitet"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Skru på IGDv1-modus"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Aktiver tilleggs logging"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Aktiver sikker modus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Ekstern port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Generelle innstillinger"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
-#, fuzzy
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Innvilg tilgang til UPnP-muligheter"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Vert"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Informasjons intervall"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Presentasjon URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Setter ekstra debugging informasjon i systemloggen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Rapporter systemets oppetid istedenfor daemon oppetid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN-vert"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN-port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnP ACL'er"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP Innstillinger"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Generelle innstillinger"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP leie fil"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Start UPnP og NAT-PMP tjenesten"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Det finnes ingen aktive viderekoblinger"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP gjør at klientene i det lokale nettverket automatisk kan konfigurere "
-"ruteren."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Skru på UPnP IGDv1-modus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Ukjent"
 
@@ -219,11 +242,37 @@ msgstr "Ukjent"
 msgid "Upload speed"
 msgstr "Opplinje"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Bruk STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Verdi i KByte/sek, kun for informasjon"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL angir hvilke eksterne porter som kan bli viderekoblet, og til hvilke "
+#~ "interne adresser og porter."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Nullstill UPnP Viderekoblinger intervall"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Nullstill UPnP terskel"
+
+#~ msgid "Host"
+#~ msgstr "Vert"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP gjør at klientene i det lokale nettverket automatisk kan konfigurere "
+#~ "ruteren."
+
+#~ msgid "Use %s"
+#~ msgstr "Bruk %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Verdi i KByte/sek, kun for informasjon"

--- a/applications/luci-app-upnp/po/nl/upnp.po
+++ b/applications/luci-app-upnp/po/nl/upnp.po
@@ -12,66 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Actie"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Toestaan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr ""
 
@@ -81,7 +90,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -90,125 +99,144 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -216,11 +244,7 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/pl/upnp.po
+++ b/applications/luci-app-upnp/po/pl/upnp.po
@@ -13,69 +13,75 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Listy kontroli dostępu (ACL) określają, które porty zewnętrzne mogą być "
-"przekazywane do jakich adresów i portów klientów, przy czym protokół IPv6 "
-"jest zawsze dozwolony."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Akcja"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
 msgstr "Aktywne przekierowania portów"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Rozgłaszaj jako urządzenie UPnP IGDv1 (bez IPv6) zamiast IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Zezwól"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Zezwól na dodawanie przekazywań tylko do odpytujących adresów IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Rozgłaszany numer modelu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Rozgłaszany numer seryjny"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Interwał czyszczenia reguł"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Próg czyszczenia reguł"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Adres klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -85,7 +91,7 @@ msgstr "Komentarz"
 msgid "Delete"
 msgstr "Usuń"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Odmów"
 
@@ -94,129 +100,145 @@ msgstr "Odmów"
 msgid "Description"
 msgstr "Opis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID urządzenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Prędkość pobierania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Włącz protokół PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr "Włącz protokół UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Włącz tryb UPnP IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Włącz dodatkowe rejestrowanie"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Włącz tryb bezpieczny"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Port zewnętrzny"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Ustawienia główne"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Udziel dostępu do UPnP IGD i PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Interwał powiadamiania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Adres URL prezentacji"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokół"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 "Umieszcza dodatkowe informacje dotyczące debugowania w dzienniku systemowym"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Zgłaszaj czas pracy systemu zamiast czasu pracy usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Port STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "Listy kontroli dostępu (ACL) usługi"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr "Ustawienia usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Ustawienia główne"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
 msgstr "Plik dzierżawy usługi"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr "Uruchom usługę"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Nie ma aktywnych przekierowań portów."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD i PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD i PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Usługa UPnP IGD i PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP IGD i PCP/NAT-PMP umożliwia klientom w sieci lokalnej automatyczną "
-"konfigurację przekierowania portów na routerze. Nazywane także Universal "
-"Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Włącz tryb UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -224,11 +246,39 @@ msgstr "Nieznany"
 msgid "Upload speed"
 msgstr "Prędkość wysyłania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Użyj STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Wartość w KB/s, tylko informacyjna"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Listy kontroli dostępu (ACL) określają, które porty zewnętrzne mogą być "
+#~ "przekazywane do jakich adresów i portów klientów, przy czym protokół IPv6 "
+#~ "jest zawsze dozwolony."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Interwał czyszczenia reguł"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Próg czyszczenia reguł"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP IGD i PCP/NAT-PMP umożliwia klientom w sieci lokalnej automatyczną "
+#~ "konfigurację przekierowania portów na routerze. Nazywane także Universal "
+#~ "Plug and Play."
+
+#~ msgid "Use %s"
+#~ msgstr "Użyj %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Wartość w KB/s, tylko informacyjna"

--- a/applications/luci-app-upnp/po/pl/upnp.po
+++ b/applications/luci-app-upnp/po/pl/upnp.po
@@ -250,35 +250,3 @@ msgstr "Prędkość wysyłania"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Listy kontroli dostępu (ACL) określają, które porty zewnętrzne mogą być "
-#~ "przekazywane do jakich adresów i portów klientów, przy czym protokół IPv6 "
-#~ "jest zawsze dozwolony."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interwał czyszczenia reguł"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Próg czyszczenia reguł"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP IGD i PCP/NAT-PMP umożliwia klientom w sieci lokalnej automatyczną "
-#~ "konfigurację przekierowania portów na routerze. Nazywane także Universal "
-#~ "Plug and Play."
-
-#~ msgid "Use %s"
-#~ msgstr "Użyj %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Wartość w KB/s, tylko informacyjna"

--- a/applications/luci-app-upnp/po/pt/upnp.po
+++ b/applications/luci-app-upnp/po/pt/upnp.po
@@ -251,33 +251,3 @@ msgstr "Ligação ascendente"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Os ACL especificam quais as portas externas que podem ser redirecionadas "
-#~ "para que endereços internos e portas"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Limpar intervalo de regras"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Limpar limiar de regras"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP permite que os clientes da rede local configurem o router "
-#~ "automaticamente."
-
-#~ msgid "Use %s"
-#~ msgstr "Utilizar %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valor em KByte/s, apenas informativo"

--- a/applications/luci-app-upnp/po/pt/upnp.po
+++ b/applications/luci-app-upnp/po/pt/upnp.po
@@ -14,69 +14,76 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Os ACL especificam quais as portas externas que podem ser redirecionadas "
-"para que endereços internos e portas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Redirecionamentos ativos da UPnP"
+msgid "Active Service Port Maps"
+msgstr "Redirecionamentos ativos da"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Anuncie como aparelho IGDv1 em vez de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Permitir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permitir a adição de encaminhamentos apenas para solicitar endereços IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Número modelo anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Número de série anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Limpar intervalo de regras"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Limpar limiar de regras"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Endereço do Cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Porta do Cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Comentário"
 
@@ -86,7 +93,7 @@ msgstr "Comentário"
 msgid "Delete"
 msgstr "Apagar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Negar"
 
@@ -95,127 +102,144 @@ msgstr "Negar"
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID do aparelho"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Download speed"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Ativar a funcionalidade NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Ativar a funcionalidade UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Ativar o modo IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Ativar log adicional"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Ativar o modo seguro"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Porta externa"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Configurações gerais"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Conceder UCI acesso aos procedimentos upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Intervalo de Notificação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Porta"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL de apresentação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Põe informações de depuração extras no log do sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Relata uptime do sistema ao invés da do daemon"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Porta"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Porta STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACLs MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Definições MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Configurações gerais"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Ficheiro de concessão UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Iniciar serviço UPnP e NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Não há redirecionamentos ativos."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Plug & Play Universal"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP permite que os clientes da rede local configurem o router "
-"automaticamente."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Ativar o modo UPnP IGDv1"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -223,11 +247,37 @@ msgstr "Desconhecido"
 msgid "Upload speed"
 msgstr "Ligação ascendente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Utilizar STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valor em KByte/s, apenas informativo"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Os ACL especificam quais as portas externas que podem ser redirecionadas "
+#~ "para que endereços internos e portas"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Limpar intervalo de regras"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Limpar limiar de regras"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP permite que os clientes da rede local configurem o router "
+#~ "automaticamente."
+
+#~ msgid "Use %s"
+#~ msgstr "Utilizar %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valor em KByte/s, apenas informativo"

--- a/applications/luci-app-upnp/po/pt_BR/upnp.po
+++ b/applications/luci-app-upnp/po/pt_BR/upnp.po
@@ -14,69 +14,76 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"As ACLs especificam quais portas externas podem ser encaminhadas para quais "
-"endereços e portas de clientes, com IPv6 sempre será permitido."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Redirecionamentos UPnP Ativos"
+msgid "Active Service Port Maps"
+msgstr "Redirecionamentos Ativos"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Anuncie-se como um dispositivo IGDv1 ao invés de um IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Permitir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permite adicionar encaminhamento apenas para o endereço IP requisitante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Número do modelo anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Número de série anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Intervalo de limpeza das regras"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Limiar de limpeza das regras"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Endereço do cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Porta do Cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Comentário"
 
@@ -86,7 +93,7 @@ msgstr "Comentário"
 msgid "Delete"
 msgstr "Apagar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Negar"
 
@@ -95,126 +102,144 @@ msgstr "Negar"
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID do Dispositivo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Velocidade de download"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Habilite a função NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Habilite a função UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Habilitar o modo IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Habilite registros adicionais"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Habilite modo seguro"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Porta externa"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Configurações gerais"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Conceda acesso UCI aos procedimentos upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Intervalo de notificação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Porta"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL de Apresentação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Envie informações extra de depuração ao registro do sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Informe o tempo de vida do sistema ao invés do tempo do processo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Porta"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Porta STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACLs do MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Configurações do MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Configurações gerais"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Arquivo de concessão do UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Dispare os serviços de UPnP e NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Não existe redirecionamentos ativos."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Plug & Play Universal"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP permite os clientes da rede local configurem automaticamente o roteador."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Habilitar o modo UPnP IGDv1"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -222,11 +247,37 @@ msgstr "Desconhecido"
 msgid "Upload speed"
 msgstr "Velocidade de envio (upload)"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Use o STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valores em KByte/s, apenas informativas"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "As ACLs especificam quais portas externas podem ser encaminhadas para "
+#~ "quais endereços e portas de clientes, com IPv6 sempre será permitido."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Intervalo de limpeza das regras"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Limiar de limpeza das regras"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP permite os clientes da rede local configurem automaticamente o "
+#~ "roteador."
+
+#~ msgid "Use %s"
+#~ msgstr "Use o %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valores em KByte/s, apenas informativas"

--- a/applications/luci-app-upnp/po/pt_BR/upnp.po
+++ b/applications/luci-app-upnp/po/pt_BR/upnp.po
@@ -251,33 +251,3 @@ msgstr "Velocidade de envio (upload)"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "As ACLs especificam quais portas externas podem ser encaminhadas para "
-#~ "quais endereços e portas de clientes, com IPv6 sempre será permitido."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalo de limpeza das regras"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Limiar de limpeza das regras"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP permite os clientes da rede local configurem automaticamente o "
-#~ "roteador."
-
-#~ msgid "Use %s"
-#~ msgstr "Use o %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valores em KByte/s, apenas informativas"

--- a/applications/luci-app-upnp/po/ro/upnp.po
+++ b/applications/luci-app-upnp/po/ro/upnp.po
@@ -249,33 +249,3 @@ msgstr "Legătură ascendentă"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL-urile specifica porturile externe care pot fi redirectate si spre ce "
-#~ "adrese si porturi interne"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalul de curatare reguli"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Limita de curatare reguli"
-
-#~ msgid "Host"
-#~ msgstr "Gazdă"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPNP permite clientulor din reteaua locala sa configureze automat "
-#~ "routerul."
-
-#~ msgid "Use %s"
-#~ msgstr "Utilizați %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valorea in KOcteti/s , doar informational"

--- a/applications/luci-app-upnp/po/ro/upnp.po
+++ b/applications/luci-app-upnp/po/ro/upnp.po
@@ -13,68 +13,75 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL-urile specifica porturile externe care pot fi redirectate si spre ce "
-"adrese si porturi interne"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Acțiune"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Redirecturi active UPnP"
+msgid "Active Service Port Maps"
+msgstr "Redirecturi active"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Setări avansate"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Publicitate ca dispozitiv IGDv1 în loc de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Permite adaugarea forward-urilor doar catre adresele ip solicitante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Numărul modelului anunțat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Număr de serie anunțat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Intervalul de curatare reguli"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Limita de curatare reguli"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Adresa client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Comentariu"
 
@@ -84,7 +91,7 @@ msgstr "Comentariu"
 msgid "Delete"
 msgstr "Ștergeți"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -93,126 +100,144 @@ msgstr ""
 msgid "Description"
 msgstr "Descriere"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID al dispozitivului"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Link în jos"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Activeaza functionalitatea NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Activeaza functionalitatea UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Activează modul IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Activeaza log-area aditionala"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Activeaza modul securizat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Port extern"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Setări generale"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Acordarea accesului la procedurile upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Gazdă"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Interval de notificare"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Adresa de prezentare"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protocol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Pune informatii utile suplimentare in log-ul de sistem"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Raporteaza timpul de functionare de sistem in loc de serviciu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Gazda STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Portul STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "Liste de acces mini UPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Setari mini UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Setări generale"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Fisierul de conexiuni UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Porniți UPnP și serviciul NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Nu exista redirecturi active."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Plug & Play universal"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPNP permite clientulor din reteaua locala sa configureze automat routerul."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Activează modul UPnP IGDv1"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Necunoscut"
 
@@ -220,11 +245,37 @@ msgstr "Necunoscut"
 msgid "Upload speed"
 msgstr "Legătură ascendentă"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Utilizați STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Valorea in KOcteti/s , doar informational"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL-urile specifica porturile externe care pot fi redirectate si spre ce "
+#~ "adrese si porturi interne"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Intervalul de curatare reguli"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Limita de curatare reguli"
+
+#~ msgid "Host"
+#~ msgstr "Gazdă"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPNP permite clientulor din reteaua locala sa configureze automat "
+#~ "routerul."
+
+#~ msgid "Use %s"
+#~ msgstr "Utilizați %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Valorea in KOcteti/s , doar informational"

--- a/applications/luci-app-upnp/po/ru/upnp.po
+++ b/applications/luci-app-upnp/po/ru/upnp.po
@@ -252,33 +252,3 @@ msgstr "Внешнее соединение"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL определяет, какие внешние порты могут быть перенаправлены на те или "
-#~ "иные клиентские адреса и порты, IPv6 всегда разрешен."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Интервал очистки правил"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Порог очистки правил"
-
-#~ msgid "Host"
-#~ msgstr "Устройство"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP позволяет клиентам в локальной сети автоматически настраивать "
-#~ "маршрутизатор."
-
-#~ msgid "Use %s"
-#~ msgstr "Используйте %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Значение в КБ/с, только для информации"

--- a/applications/luci-app-upnp/po/ru/upnp.po
+++ b/applications/luci-app-upnp/po/ru/upnp.po
@@ -16,68 +16,75 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL определяет, какие внешние порты могут быть перенаправлены на те или иные "
-"клиентские адреса и порты, IPv6 всегда разрешен."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Действие"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Активные UPnP-переадресации"
+msgid "Active Service Port Maps"
+msgstr "Активные переадресации"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Объявить как IGDv1 устройство вместо IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Разрешить"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Разрешить перенаправление только для запрашивающих IP-адресов"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Объявить номер модели"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Объявить серийный номер"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Интервал очистки правил"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Порог очистки правил"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Адрес клиента"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Порт клиента"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -87,7 +94,7 @@ msgstr "Комментарий"
 msgid "Delete"
 msgstr "Удалить"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Отказать"
 
@@ -96,127 +103,144 @@ msgstr "Отказать"
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID устройства"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Внутреннее соединение"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Включить NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Включить UPnP"
+msgstr "Включить UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "IGDv1 режим"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Дополнительное журналирование"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Защищённый режим"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Внешний порт"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Основные Настройки"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Предоставить доступ к процедурам UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Устройство"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Интервал уведомления"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Порт"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Задать URL-адрес"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Добавлять дополнительную отладочную информацию в системный журнал"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Сообщать время работы системы вместо службы"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Порт"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Хост STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Порт STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "Список доступа MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Настройки MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Основные Настройки"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Файл аренды UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Запустить службы<br />UPnP и NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Активные переадресации отсутствуют."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD и PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD и PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Сервис UPnP IGD и PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP позволяет клиентам в локальной сети автоматически настраивать "
-"маршрутизатор."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "UPnP IGDv1 режим"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Неизвестный"
 
@@ -224,11 +248,37 @@ msgstr "Неизвестный"
 msgid "Upload speed"
 msgstr "Внешнее соединение"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Используйте STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Значение в КБ/с, только для информации"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL определяет, какие внешние порты могут быть перенаправлены на те или "
+#~ "иные клиентские адреса и порты, IPv6 всегда разрешен."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Интервал очистки правил"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Порог очистки правил"
+
+#~ msgid "Host"
+#~ msgstr "Устройство"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP позволяет клиентам в локальной сети автоматически настраивать "
+#~ "маршрутизатор."
+
+#~ msgid "Use %s"
+#~ msgstr "Используйте %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Значение в КБ/с, только для информации"

--- a/applications/luci-app-upnp/po/sk/upnp.po
+++ b/applications/luci-app-upnp/po/sk/upnp.po
@@ -12,66 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Akcia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktívne presmerovania UPnP"
+msgid "Active Service Port Maps"
+msgstr "Aktívne presmerovania"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Pokročilé nastavenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Umožniť pridanie preposielaní iba požadovaným adresám IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Ohlásené číslo modelu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Ohlásené sériové číslo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Vymazať interval pravidiel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Vymazať prah pravidiel"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Adresa klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Port klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Komentár"
 
@@ -81,7 +90,7 @@ msgstr "Komentár"
 msgid "Delete"
 msgstr "Odstrániť"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -90,125 +99,144 @@ msgstr ""
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID zariadenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Povoliť funkcionalitu NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Povoliť funkcionalitu UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Povoliť režim IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Povoliť dodatočné zaznamenávanie"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Povoliť zabezpečený režim"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Externý port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Všeobecné nastavenia"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Hostiteľ"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Interval upozornení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Prezentačná URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Nastavenia MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Všeobecné nastavenia"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Spustiť službu UPnP a NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Neexistujú žiadne aktívne presmerovania."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr "UPnP umožňuje klientom v miestnej sieti automaticky nastaviť smerovač."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Povoliť režim UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Neznáme"
 
@@ -216,11 +244,26 @@ msgstr "Neznáme"
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Hodnota v KBajtoch za sekundu, iba informatívne"
+#~ msgid "Clean rules interval"
+#~ msgstr "Vymazať interval pravidiel"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Vymazať prah pravidiel"
+
+#~ msgid "Host"
+#~ msgstr "Hostiteľ"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP umožňuje klientom v miestnej sieti automaticky nastaviť smerovač."
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Hodnota v KBajtoch za sekundu, iba informatívne"

--- a/applications/luci-app-upnp/po/sk/upnp.po
+++ b/applications/luci-app-upnp/po/sk/upnp.po
@@ -248,22 +248,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Vymazať interval pravidiel"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Vymazať prah pravidiel"
-
-#~ msgid "Host"
-#~ msgstr "Hostiteľ"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP umožňuje klientom v miestnej sieti automaticky nastaviť smerovač."
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Hodnota v KBajtoch za sekundu, iba informatívne"

--- a/applications/luci-app-upnp/po/sv/upnp.po
+++ b/applications/luci-app-upnp/po/sv/upnp.po
@@ -248,27 +248,3 @@ msgstr "Upplänk"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL:er anger vilka externa portar som ska omdirigeras till vilka interna "
-#~ "adresser och portar"
-
-#~ msgid "Host"
-#~ msgstr "Värd"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP tillåter klienter i det lokala nätverket att automatiskt ställa in "
-#~ "routern."
-
-#~ msgid "Use %s"
-#~ msgstr "Använd %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Värde i KByte/s, endast informell"

--- a/applications/luci-app-upnp/po/sv/upnp.po
+++ b/applications/luci-app-upnp/po/sv/upnp.po
@@ -12,68 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5.4\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL:er anger vilka externa portar som ska omdirigeras till vilka interna "
-"adresser och portar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Åtgärd"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktivera UPnP-omdirigeringar"
+msgid "Active Service Port Maps"
+msgstr "Aktivera omdirigeringar"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annonsera som UPnP IGDv1-enhet (ingen IPv6) istället för IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Tillåt"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Aviserat modellnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Aviserat serienummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr ""
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
+msgstr "Klient-adress"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr "Klient-adress"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Klient-port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -83,7 +90,7 @@ msgstr "Kommentar"
 msgid "Delete"
 msgstr "Ta bort"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Neka"
 
@@ -92,127 +99,144 @@ msgstr "Neka"
 msgid "Description"
 msgstr "Beskrivning"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Enhetens UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Nerlänk"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Aktivera NAT-PMP-funktionalitet"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Aktivera UPnP-funktionalitet"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Aktivera UPnP IGDv1-läge"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Aktivera ytterligare loggning"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Aktivera säkert läge"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Extern port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Generella inställningar"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Tillåt åtkomst till UPnP IGD & PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Värd"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Intervall för avisering"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Port"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Presentationens URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Lägger extra felsökningsinformation till system-loggen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Rapportera systemet iställer för demonens upptid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "SOAP/HTTP port"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN-värd"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN-port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "ACL:er för MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Inställningar för MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Generella inställningar"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Hyr-fil för UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Starta UPnP och NAT-PMP-tjänsten"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Det finns inga aktiva omdirigeringar."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Universiell Plug & Play"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP tillåter klienter i det lokala nätverket att automatiskt ställa in "
-"routern."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Aktivera UPnP IGDv1-läge"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Okänd"
 
@@ -220,11 +244,31 @@ msgstr "Okänd"
 msgid "Upload speed"
 msgstr "Upplänk"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Använd STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Värde i KByte/s, endast informell"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL:er anger vilka externa portar som ska omdirigeras till vilka interna "
+#~ "adresser och portar"
+
+#~ msgid "Host"
+#~ msgstr "Värd"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP tillåter klienter i det lokala nätverket att automatiskt ställa in "
+#~ "routern."
+
+#~ msgid "Use %s"
+#~ msgstr "Använd %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Värde i KByte/s, endast informell"

--- a/applications/luci-app-upnp/po/templates/upnp.pot
+++ b/applications/luci-app-upnp/po/templates/upnp.pot
@@ -1,66 +1,75 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr ""
 
@@ -70,7 +79,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -79,125 +88,144 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -205,11 +233,7 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/tr/upnp.po
+++ b/applications/luci-app-upnp/po/tr/upnp.po
@@ -248,33 +248,3 @@ msgstr "Yükleme hızı"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACL'ler, hangi harici bağlantı noktalarının hangi dahili adreslere ve "
-#~ "bağlantı noktalarına yeniden yönlendirilebileceğini belirtir."
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Temiz kurallar aralığı"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Temiz kural eşiği"
-
-#~ msgid "Host"
-#~ msgstr "Ana bilgisayar"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP, yerel ağdaki istemcilerin yönlendiriciyi otomatik olarak "
-#~ "yapılandırmasına izin verir."
-
-#~ msgid "Use %s"
-#~ msgstr "%s kullan"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "KBayt/sn cinsinden değer, yalnızca bilgi amaçlı"

--- a/applications/luci-app-upnp/po/tr/upnp.po
+++ b/applications/luci-app-upnp/po/tr/upnp.po
@@ -12,68 +12,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACL'ler, hangi harici bağlantı noktalarının hangi dahili adreslere ve "
-"bağlantı noktalarına yeniden yönlendirilebileceğini belirtir."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Eylem"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Aktif UPnP Yönlendirmeleri"
+msgid "Active Service Port Maps"
+msgstr "Aktif Yönlendirmeleri"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Gelişmiş Ayarlar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "IGDv2 yerine IGDv1 cihazı olarak duyuru yap"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "İzin ver"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Yalnızca istekte bulunan ip adreslerine yönlendirme eklemeye izin ver"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Açıklanan model numarası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Açıklanan seri numarası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Temiz kurallar aralığı"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Temiz kural eşiği"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "İstemci Adresi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "İstemci Bağlantı Noktası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Yorum"
 
@@ -83,7 +90,7 @@ msgstr "Yorum"
 msgid "Delete"
 msgstr "Sil"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "Reddet"
 
@@ -92,127 +99,144 @@ msgstr "Reddet"
 msgid "Description"
 msgstr "Açıklama"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Cihaz UUID'si"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "İndirme hızı"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "NAT-PMP işlevselliğini etkinleştirin"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "UPnP işlevselliğini etkinleştirin"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "IGDv1 modunu etkinleştir"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Ek günlük kaydını etkinleştir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Güvenli modu etkinleştir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Harici Bağlantı Noktası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Genel Ayarlar"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Upnp prosedürlerine erişim izni verin"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Ana bilgisayar"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Bildirme aralığı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Bağlantı noktası"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Sunum URL'si"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Sistem günlüğüne fazladan hata ayıklama bilgisi koyar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Arka plan programı çalışma süresi yerine sistemi rapor et"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Bağlantı noktası"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN Ana Bilgisayarı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN Bağlantı Noktası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnP ACL'leri"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP ayarları"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Genel Ayarlar"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP kira dosyası"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "UPnP ve NAT-PMP hizmetini başlatın"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Etkin yönlendirme yok."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD ve PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD ve PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "Evrensel Tak ve Çalıştır"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
 msgstr ""
-"UPnP, yerel ağdaki istemcilerin yönlendiriciyi otomatik olarak "
-"yapılandırmasına izin verir."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "UPnP IGDv1 modunu etkinleştir"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -220,11 +244,37 @@ msgstr "Bilinmiyor"
 msgid "Upload speed"
 msgstr "Yükleme hızı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "STUN kullan"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "KBayt/sn cinsinden değer, yalnızca bilgi amaçlı"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACL'ler, hangi harici bağlantı noktalarının hangi dahili adreslere ve "
+#~ "bağlantı noktalarına yeniden yönlendirilebileceğini belirtir."
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Temiz kurallar aralığı"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Temiz kural eşiği"
+
+#~ msgid "Host"
+#~ msgstr "Ana bilgisayar"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP, yerel ağdaki istemcilerin yönlendiriciyi otomatik olarak "
+#~ "yapılandırmasına izin verir."
+
+#~ msgid "Use %s"
+#~ msgstr "%s kullan"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "KBayt/sn cinsinden değer, yalnızca bilgi amaçlı"

--- a/applications/luci-app-upnp/po/uk/upnp.po
+++ b/applications/luci-app-upnp/po/uk/upnp.po
@@ -250,33 +250,3 @@ msgstr "Висхідне з'єднання"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "Списки контролю доступу (ACL) визначають, які зовнішні порти можуть бути "
-#~ "переспрямовані на які внутрішні адреси й порти"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Інтервал очищення правил"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Поріг очищення правил"
-
-#~ msgid "Host"
-#~ msgstr "Вузол"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP надає клієнтам у локальній мережі змогу автоматично настроювати "
-#~ "маршрутизатор."
-
-#~ msgid "Use %s"
-#~ msgstr "Використовувати %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Значення (КБ/с), тільки для інформації"

--- a/applications/luci-app-upnp/po/uk/upnp.po
+++ b/applications/luci-app-upnp/po/uk/upnp.po
@@ -13,69 +13,76 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"Списки контролю доступу (ACL) визначають, які зовнішні порти можуть бути "
-"переспрямовані на які внутрішні адреси й порти"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Дія"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Активні переспрямування UPnP"
+msgid "Active Service Port Maps"
+msgstr "Активні переспрямування"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Розширені налаштування"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Оголошувати як пристрій IGDv1 замість IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "Дозволити"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Дозволити додавання переспрямування тільки для IP-адрес, що надсилають запити"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Оголошуваний номер моделі"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Оголошуваний серійний номер"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Інтервал очищення правил"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Поріг очищення правил"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Адреса клієнта"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Порт клієнта"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Примітка"
 
@@ -85,7 +92,7 @@ msgstr "Примітка"
 msgid "Delete"
 msgstr "Видалити"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -94,127 +101,144 @@ msgstr ""
 msgid "Description"
 msgstr "Опис"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "UUID пристрою"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Низхідне з'єднання"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Увімкнути функцію NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Увімкнути функцію UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Увімкнути режим IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Увімкнути додаткове журналювання"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Увімкнути захищений режим"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Зовнішній порт"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Загальні налаштування"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Надати доступ до процедур upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Вузол"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Інтервал сповіщення"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Порт"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "URL презентації"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Включати додаткові відомості для налагодження до системного журналу"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Повідомляти час безвідмовної роботи системи, а не сервісу"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Порт"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "Хост STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "Порт STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "Список контролю доступу MiniUPnP"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Настройки MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Загальні налаштування"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Файл оренд UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "Запускати служби UPnP та NAT-PMP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Немає активних переспрямувань."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP надає клієнтам у локальній мережі змогу автоматично настроювати "
-"маршрутизатор."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Увімкнути режим UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Невідомо"
 
@@ -222,11 +246,37 @@ msgstr "Невідомо"
 msgid "Upload speed"
 msgstr "Висхідне з'єднання"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Використовувати STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Значення (КБ/с), тільки для інформації"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "Списки контролю доступу (ACL) визначають, які зовнішні порти можуть бути "
+#~ "переспрямовані на які внутрішні адреси й порти"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Інтервал очищення правил"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Поріг очищення правил"
+
+#~ msgid "Host"
+#~ msgstr "Вузол"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP надає клієнтам у локальній мережі змогу автоматично настроювати "
+#~ "маршрутизатор."
+
+#~ msgid "Use %s"
+#~ msgstr "Використовувати %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Значення (КБ/с), тільки для інформації"

--- a/applications/luci-app-upnp/po/vi/upnp.po
+++ b/applications/luci-app-upnp/po/vi/upnp.po
@@ -252,33 +252,3 @@ msgstr "Tuyến lên"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "ACLs chỉ định cổng bên ngoài nào có thể được chuyển hướng đến địa chỉ và "
-#~ "cổng nội bộ nào"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Khoảng thời gian quy tắc sạch"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Clean rules threshold"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP cho phép các máy khách trong mạng cục bộ tự động cấu hình bộ định "
-#~ "tuyến."
-
-#~ msgid "Use %s"
-#~ msgstr "Sử dụng %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Giá trị tính bằng KByte/s, chỉ mang tính thông tin"

--- a/applications/luci-app-upnp/po/vi/upnp.po
+++ b/applications/luci-app-upnp/po/vi/upnp.po
@@ -16,68 +16,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"ACLs chỉ định cổng bên ngoài nào có thể được chuyển hướng đến địa chỉ và "
-"cổng nội bộ nào"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "Hành động"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "Chuyển hướng UPnP đang hoạt động"
+msgid "Active Service Port Maps"
+msgstr "Chuyển hướng đang hoạt động"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "Cài đặt Nâng cao"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Quảng cáo dưới dạng thiết bị IGDv1 thay vì IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Chỉ cho phép thêm chuyển tiếp để yêu cầu địa chỉ IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "Announced model number"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "Announced serial number"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "Khoảng thời gian quy tắc sạch"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "Clean rules threshold"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "Client Address"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "Client Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "Bình luận"
 
@@ -87,7 +94,7 @@ msgstr "Bình luận"
 msgid "Delete"
 msgstr "Xoá"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -96,126 +103,144 @@ msgstr ""
 msgid "Description"
 msgstr "Mô tả"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "Device UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "Download speed"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "Bật chức năng NAT-PMP"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "Bật chức năng UPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "Kích hoạt chế độ IGDv1"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "Bật ghi nhật ký bổ sung"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "Kích hoạt chế độ an toàn"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "Cổng bên ngoài"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "Các cài đặt chung"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "Cấp quyền truy cập vào thủ tục upnp"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "Host"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "Vòng lặp thông báo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "Cổng"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "Presentation URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "Giao thức"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "Đưa thông tin sửa lỗi bổ sung vào nhật ký hệ thống"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "Hệ thống báo cáo thay vì thời gian hoạt động của daemon"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "Cổng"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN Host"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr "Service Access Control List"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "Cài đặt MiniUPnP"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "Các cài đặt chung"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "Tệp cho thuê UPnP"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
-msgstr "The report system instead of daemon time active"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "Không có chuyển hướng đang hoạt động."
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr ""
-"UPnP cho phép các máy khách trong mạng cục bộ tự động cấu hình bộ định tuyến."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "Kích hoạt chế độ UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "Không xác định"
 
@@ -223,11 +248,37 @@ msgstr "Không xác định"
 msgid "Upload speed"
 msgstr "Tuyến lên"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "Sử dụng STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "Giá trị tính bằng KByte/s, chỉ mang tính thông tin"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "ACLs chỉ định cổng bên ngoài nào có thể được chuyển hướng đến địa chỉ và "
+#~ "cổng nội bộ nào"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "Khoảng thời gian quy tắc sạch"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "Clean rules threshold"
+
+#~ msgid "Host"
+#~ msgstr "Host"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP cho phép các máy khách trong mạng cục bộ tự động cấu hình bộ định "
+#~ "tuyến."
+
+#~ msgid "Use %s"
+#~ msgstr "Sử dụng %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "Giá trị tính bằng KByte/s, chỉ mang tính thông tin"

--- a/applications/luci-app-upnp/po/yua/upnp.po
+++ b/applications/luci-app-upnp/po/yua/upnp.po
@@ -13,66 +13,75 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.3-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-msgid "Client Address"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr ""
 
@@ -82,7 +91,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr ""
 
@@ -91,125 +100,144 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr ""
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr ""
 
@@ -217,11 +245,7 @@ msgstr ""
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr ""
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/zh_Hans/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hans/upnp.po
@@ -18,66 +18,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
-msgstr "访问控制列表指定哪些外部端口可以被重定向至哪些内部地址及端口，支持使用 IPv6。"
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "操作"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
+msgid "Active Service Port Maps"
 msgstr "活跃的端口转发"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "广播为 IGDv1 设备（无 IPv6），而不是 IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "允许"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "仅允许添加对请求 IP 地址自己的端口转发"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "通告的设备型号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "通告的设备序列号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "定时清除规则"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "清除规则阈值"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "客户端地址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "客户端端口"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "注释"
 
@@ -87,7 +96,7 @@ msgstr "注释"
 msgid "Delete"
 msgstr "删除"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "拒绝"
 
@@ -96,126 +105,144 @@ msgstr "拒绝"
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "设备 UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "下载速度"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
 msgstr "启用 PCP/NAT-PMP 协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
 msgstr "启用 UPnP IGD 协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "启用 UPnP IGDv1 模式"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "启用额外的日志"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "启用安全模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "外部端口"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "常规设置"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "授予访问 UPnP IGD 及 PCP/NAT-PMP 的权限"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "主机"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "通知的时间间隔"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "端口"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "服务网址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "将额外的调试信息输出到系统日志中"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "用系统运行时间代替进程运行时间"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "端口"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN 主机"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN 端口"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
 msgstr "服务访问控制列表"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
 msgstr "服务设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "常规设置"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
 msgstr "服务租约文件"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr "启动服务"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "没有活跃的端口转发。"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD 和 PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD 和 PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "UPnP IGD 和 PCP/NAT-PMP 服务"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr "UPnP IGD 和 PCP/NAT-PMP "
-"允许局域网内客户端自动设置路由器上的端口转发。也被称作通用即插即用。"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "启用 UPnP IGDv1 模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "未知"
 
@@ -223,11 +250,37 @@ msgstr "未知"
 msgid "Upload speed"
 msgstr "上传速度"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "使用 STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "单位为 KByte/s，仅供参考"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "访问控制列表指定哪些外部端口可以被重定向至哪些内部地址及端口，支持使用 "
+#~ "IPv6。"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "定时清除规则"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "清除规则阈值"
+
+#~ msgid "Host"
+#~ msgstr "主机"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP IGD 和 PCP/NAT-PMP 允许局域网内客户端自动设置路由器上的端口转发。也被"
+#~ "称作通用即插即用。"
+
+#~ msgid "Use %s"
+#~ msgstr "使用 %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "单位为 KByte/s，仅供参考"

--- a/applications/luci-app-upnp/po/zh_Hans/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hans/upnp.po
@@ -254,33 +254,3 @@ msgstr "上传速度"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "访问控制列表指定哪些外部端口可以被重定向至哪些内部地址及端口，支持使用 "
-#~ "IPv6。"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "定时清除规则"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "清除规则阈值"
-
-#~ msgid "Host"
-#~ msgstr "主机"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP IGD 和 PCP/NAT-PMP 允许局域网内客户端自动设置路由器上的端口转发。也被"
-#~ "称作通用即插即用。"
-
-#~ msgid "Use %s"
-#~ msgstr "使用 %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "单位为 KByte/s，仅供参考"

--- a/applications/luci-app-upnp/po/zh_Hant/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hant/upnp.po
@@ -15,68 +15,75 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+msgctxt ""
+"A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
+"max-age of 1800s"
 msgid ""
-"ACLs specify which external ports can be forwarded to which client addresses "
-"and ports, IPv6 always allowed."
+"A 900s interval will result in %s notifications with the minimum max-age of "
+"1800s"
 msgstr ""
-"您可以使用 ACL（存取控制串列）來規定哪些「外部埠」可被重新導向到哪些「內部位"
-"址」和「內部埠」"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+msgid ""
+"ACL specify which client addresses and ports can be mapped, IPv6 always "
+"allowed."
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
 msgid "Action"
 msgstr "操作"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-msgid "Active Port Forwards"
-msgstr "動態 UPnP 重新導向"
+msgid "Active Service Port Maps"
+msgstr "動態重新導向"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
 msgstr "進階設定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:131
-msgid "Advertise as UPnP IGDv1 device (no IPv6) instead of IGDv2"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "宣傳為 IGDv1 裝置，而非 IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
 msgid "Allow"
 msgstr "允許"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-msgid "Allow adding port forwards only to requesting IP addresses"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "只容許向請求的IP位址新增轉發"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
 msgstr "發布的型號"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:149
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
 msgid "Announced serial number"
 msgstr "發布的序列號"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
-msgid "Clean rules interval"
-msgstr "清除規則間隔"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
-msgid "Clean rules threshold"
-msgstr "清除規則門檻值"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
 msgid "Client Address"
 msgstr "用戶端位址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+msgid "Client Name"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Client Port"
 msgstr "用戶端埠"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
 msgid "Comment"
 msgstr "註解"
 
@@ -86,7 +93,7 @@ msgstr "註解"
 msgid "Delete"
 msgstr "刪除"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
 msgid "Deny"
 msgstr "拒絕"
 
@@ -95,125 +102,144 @@ msgstr "拒絕"
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
 msgid "Device UUID"
 msgstr "裝置 UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Download speed"
 msgstr "下行鏈路"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+msgid "Enable PCP/NAT-PMP protocols"
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-msgid "Enable PCP/NAT-PMP protocol"
-msgstr "啓用 NAT-PMP 功能"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:124
 msgid "Enable UPnP IGD protocol"
-msgstr "啓用 UPnP 功能"
+msgstr "启用 UPnP IGD 协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
-msgid "Enable UPnP IGDv1 mode"
-msgstr "啟用 IGDv1 模式"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:133
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
 msgstr "啓用附加日誌"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
 msgid "Enable secure mode"
 msgstr "啓用安全模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
 msgid "External Port"
 msgstr "外部埠"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
-msgid "General Settings"
-msgstr "一般設定"
-
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "授予存取 UPnP 程序的權限"
+msgstr "授予访问 UPnP IGD 及 PCP/NAT-PMP 的权限"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-msgid "Host"
-msgstr "主機"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
 msgstr "通知時間間隔"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-msgid "Port"
-msgstr "連接埠"
-
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
 msgid "Presentation URL"
 msgstr "存在 URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "Protocol"
 msgstr "協定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
 msgid "Puts extra debugging information into the system log"
 msgstr "將額外的除錯資訊寫入系統日誌"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+msgid "Report custom router web interface (presentation) URL"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+msgid "Report maximum download speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+msgid "Report maximum upload speed in kByte/s"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
 msgid "Report system instead of service uptime"
 msgstr "報告使用系統上線時間，而非程序上線時間"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+msgid "SOAP/HTTP port"
+msgstr "連接埠"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
 msgid "STUN Host"
 msgstr "STUN 主機"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
 msgid "STUN Port"
 msgstr "STUN 埠"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-msgid "Service ACLs"
-msgstr "MiniUPnP ACL"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+msgid "Service Access Control List"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
 msgid "Service Settings"
-msgstr "MiniUPnP 設定"
+msgstr "服务设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:167
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+msgid "Service Setup"
+msgstr "一般設定"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Service lease file"
-msgstr "UPnP 租約檔"
+msgstr "服务租约文件"
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+msgid "Start autonomous port mapping service"
+msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
 msgid "Start service"
 msgstr "啟動服務"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+msgctxt ""
+"The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
+"network to configure port maps/forwards on the router autonomously."
+msgid ""
+"The %s protocols allow clients on the local network to configure port maps/"
+"forwards on the router autonomously."
+msgstr ""
+
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
-msgid "There are no active port forwards."
+msgid "There are no active port maps."
 msgstr "沒有活躍的重新導向。"
 
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+msgid ""
+"To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
+msgstr ""
+
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
-msgid "UPnP IGD & PCP/NAT-PMP"
-msgstr "UPnP IGD & PCP/NAT-PMP"
+msgid "UPnP IGD & PCP"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "通用隨插即用 (UPnP)"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
-msgid ""
-"UPnP IGD & PCP/NAT-PMP allows clients on the local network to automatically "
-"configure port forwards on the router. Also called Universal Plug and Play."
-msgstr "UPnP（通用隨插即用）允許本地網絡中的用戶端自動設定路由器埠的重新導向。"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+msgid "UPnP IGDv1 compatibility mode"
+msgstr "啟用 UPnP IGDv1 模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:60
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:56
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
 msgid "Unknown"
 msgstr "未知"
 
@@ -221,11 +247,36 @@ msgstr "未知"
 msgid "Upload speed"
 msgstr "上行鏈路"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:170
-msgid "Use STUN"
-msgstr "使用 STUN"
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+msgctxt "Use %s (%s = STUN)"
+msgid "Use %s"
+msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
-msgid "Value in KByte/s, informational only"
-msgstr "值 (KByte/s) 僅供參考"
+#~ msgid ""
+#~ "ACLs specify which external ports can be forwarded to which client "
+#~ "addresses and ports, IPv6 always allowed."
+#~ msgstr ""
+#~ "您可以使用 ACL（存取控制串列）來規定哪些「外部埠」可被重新導向到哪些「內部"
+#~ "位址」和「內部埠」"
+
+#~ msgid "Clean rules interval"
+#~ msgstr "清除規則間隔"
+
+#~ msgid "Clean rules threshold"
+#~ msgstr "清除規則門檻值"
+
+#~ msgid "Host"
+#~ msgstr "主機"
+
+#~ msgid ""
+#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
+#~ "automatically configure port forwards on the router. Also called "
+#~ "Universal Plug and Play."
+#~ msgstr ""
+#~ "UPnP（通用隨插即用）允許本地網絡中的用戶端自動設定路由器埠的重新導向。"
+
+#~ msgid "Use %s"
+#~ msgstr "使用 %s"
+
+#~ msgid "Value in KByte/s, informational only"
+#~ msgstr "值 (KByte/s) 僅供參考"

--- a/applications/luci-app-upnp/po/zh_Hant/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hant/upnp.po
@@ -251,32 +251,3 @@ msgstr "上行鏈路"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid ""
-#~ "ACLs specify which external ports can be forwarded to which client "
-#~ "addresses and ports, IPv6 always allowed."
-#~ msgstr ""
-#~ "您可以使用 ACL（存取控制串列）來規定哪些「外部埠」可被重新導向到哪些「內部"
-#~ "位址」和「內部埠」"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "清除規則間隔"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "清除規則門檻值"
-
-#~ msgid "Host"
-#~ msgstr "主機"
-
-#~ msgid ""
-#~ "UPnP IGD & PCP/NAT-PMP allows clients on the local network to "
-#~ "automatically configure port forwards on the router. Also called "
-#~ "Universal Plug and Play."
-#~ msgstr ""
-#~ "UPnP（通用隨插即用）允許本地網絡中的用戶端自動設定路由器埠的重新導向。"
-
-#~ msgid "Use %s"
-#~ msgstr "使用 %s"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "值 (KByte/s) 僅供參考"

--- a/applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json
+++ b/applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json
@@ -1,6 +1,6 @@
 {
 	"admin/services/upnp": {
-		"title": "UPnP IGD & PCP/NAT-PMP",
+		"title": "UPnP IGD & PCP",
 		"action": {
 			"type": "view",
 			"path": "upnp/upnp"


### PR DESCRIPTION
- Complete plugin wording/UI revision
  Add missing protocol term in status/overview UI and shorten menu option to `UPnP IGD & PCP`, otherwise two lines, rearrange table columns, improve wording and add help texts and note upstream change miniupnp/miniupnp@9339f0e
- Simplify UI by moving rarely used options to advanced settings, rest to service setup and rearrangement
- Hide dependent UI fields if UPnP IGD protocol is disabled
- Remove `clean_ruleset_interval/threshold` UI options as not working
- Require client address and improve defaults in ACL entry UI
- Manual adaption of changed non-translatable protocol acronyms in translations, see #7175

This PR completes committed changes #6863 (merged in #6975) and continues #7217 for the UPnP IGD & PCP/NAT-PMP autonomous port mapping service.

### Service setup UI:

![openwrt-settings](https://github.com/user-attachments/assets/249959de-cb54-4c9e-886e-d34326097b52)
_[Screenshot 23.05 release](https://github.com/user-attachments/assets/38cbb287-e85d-4fd8-bed6-47a3a4a2cfbc)_

### Advanced settings UI:

![openwrt-advanced-settings](https://github.com/user-attachments/assets/c9156586-7c85-4c9e-91d1-c4d8b7c02206)
_[Screenshot 23.05 release](https://github.com/user-attachments/assets/d0b9bcfc-d3af-4941-af6a-19e5bfcd3f81)_

### ACL entry UI:

![openwrt-acl-entry](https://github.com/user-attachments/assets/9b9a9591-a67a-45f3-a306-f94e5f79289b)

### Status/overview UI:

![openwrt-status-overview](https://github.com/user-attachments/assets/34ef4738-933e-45b3-a169-c24414817568)

The **Port Control Protocol (PCP)** is the successor to NAT-PMP, has similar protocol concepts and packet formats, but adds support for **IPv6 port maps** and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2024 - About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview

Maintainer: @jow-