### PR TITLE
luci-app-attendedsysupgrade: make image selection consistent across all EFI targets

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -83,8 +83,9 @@ return view.extend({
 			return (e.filesystem == firmware.filesystem);
 		}
 		var typeFilter = function(e) {
-			if (firmware.target.indexOf("x86") != -1) {
-				// x86 images can be combined-efi (EFI) or combined (BIOS)
+			let efi_targets = ['armsr', 'loongarch', 'x86'];
+			let efi_capable = efi_targets.some((tgt) => firmware.target.startsWith(tgt));
+			if (efi_capable) {
 				if (data.efi) {
 					return (e.type == 'combined-efi');
 				} else {


### PR DESCRIPTION
Image selection for `armsr` and `loongarch` is currently broken, as they are not recognized as a "combined" image target.  Add a list of the appropriate targets to make maintenance easy.

The "depends on" below is only partial as 12963 is only needed for the `armsr` target.  The `loongarch` target will be fixed by this PR, regardless of the inclusion of 12963 (`armsr` is broken now and will remain so until that PR is merged).

Tested on: x86/64 snapshot
Depends on: openwrt/openwrt#12963
