### PR TITLE
collections: select package manager for SSL collections

### DIFF
--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -14,7 +14,10 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
  OpenSSL cmd tools (openssl-util) are used by uhttpd for SSL key generation \
  instead of the default px5g. (If px5g is installed, uhttpd will prefer that.)
 
-LUCI_DEPENDS:=+luci-light +libustream-openssl +openssl-util
+LUCI_DEPENDS:=+luci-light \
+	+libustream-openssl \
+	+openssl-util \
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,10 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=LuCI with HTTPS support (mbedtls as SSL backend)
-LUCI_DEPENDS:=+luci-light +libustream-mbedtls +px5g-mbedtls
+LUCI_DEPENDS:=+luci-light \
+	+libustream-mbedtls \
+	+px5g-mbedtls \
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (qualcommax/ipq807x, main) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)

Currently, the regular and nginx collections include package manager by default but SSL collections dont, so lets include package manager on SSL collections as well.
