### PR TITLE
declare rpc calls with const

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -200,7 +200,7 @@ return view.extend({
 			}
 		}
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('rpcd', _('LuCI Logins'));
 

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -20,7 +20,7 @@ return view.extend({
 	render: function (certs) {
 		let wikiUrl = 'https://github.com/acmesh-official/acme.sh/wiki/';
 		var wikiInstructionUrl = wikiUrl + 'dnsapi';
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map("acme", _("ACME certificates"),
 			_("This configures ACME (Letsencrypt) automatic certificate installation. " +

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -27,31 +27,31 @@ var pkg = {
 	},
 };
 
-var getFileUrlFilesizes = rpc.declare({
+const getFileUrlFilesizes = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getFileUrlFilesizes",
 	params: ["name", "url"],
 });
 
-var getInitList = rpc.declare({
+const getInitList = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitList",
 	params: ["name"],
 });
 
-var getInitStatus = rpc.declare({
+const getInitStatus = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitStatus",
 	params: ["name"],
 });
 
-var getPlatformSupport = rpc.declare({
+const getPlatformSupport = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getPlatformSupport",
 	params: ["name"],
 });
 
-var _setInitAction = rpc.declare({
+const _setInitAction = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "setInitAction",
 	params: ["name", "action"],

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -131,7 +131,7 @@ return view.extend({
 	},
 
 	render: function(result) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('adblock', 'Adblock', _('Configuration of the adblock package to block ad/abuse domains by using DNS. \
 			For further information <a href="https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md" target="_blank" rel="noreferrer noopener" >check the online documentation</a>'));

--- a/applications/luci-app-alist/htdocs/luci-static/resources/view/alist/config.js
+++ b/applications/luci-app-alist/htdocs/luci-static/resources/view/alist/config.js
@@ -8,7 +8,7 @@
 'require validation';
 'require view';
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-alist/htdocs/luci-static/resources/view/alist/config.js
+++ b/applications/luci-app-alist/htdocs/luci-static/resources/view/alist/config.js
@@ -60,7 +60,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 		var webport = uci.get(data[0], 'config', 'listen_http_port') || '5244';
 
 		m = new form.Map('alist', _('AList'),

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('apinger', _('Apinger - Delay Alarms'), 
 			 ('This alarm will be fired when target responses are delayed more than "Delay High"') + '<br />' +

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('apinger', _('Apinger - Down Alarm'),
 			_('This alarm will be fired when target does not respond for "Time"'));

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('apinger', _('Apinger - Loss Alarms'),
 			_('This alarm will be fired when packet loss goes over "Loss High"') + '<br />' +

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('apinger', _('Apinger - Interfaces'),
 			_('Names must match the interface name found in /etc/config/network.'));

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js
@@ -4,7 +4,7 @@
 'require form';
 'require poll';
 
-var callApingerStatus = rpc.declare({
+const callApingerStatus = rpc.declare({
 	object: 'apinger',
 	method: 'status',
 	expect: {  },

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js
@@ -11,7 +11,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 		var a_ifaces, a_down, a_delay, a_loss;
 
 		a_ifaces = uci.sections('apinger', 'interface');

--- a/applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js
+++ b/applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js
@@ -183,7 +183,7 @@ return view.extend({
 	},
 
 	render: function(aria2) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('aria2', '%s - %s'.format(_('Aria2'), _('Settings')), '<p>%s</p><p>%s</p>'.format(
 			_('Aria2 is a lightweight multi-protocol &amp; multi-source, cross platform download utility.'),

--- a/applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js
+++ b/applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js
@@ -8,9 +8,9 @@
 'require ui';
 'require view';
 
-var callServiceList, CBIAria2Status, CBIRpcSecret, CBIRpcUrl;
+var CBIAria2Status, CBIRpcSecret, CBIRpcUrl;
 
-callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: [ 'name' ],

--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -9,17 +9,17 @@
 'require dom';
 'require fs';
 
-let callPackagelist = rpc.declare({
+const callPackagelist = rpc.declare({
 	object: 'rpc-sys',
 	method: 'packagelist',
 });
 
-let callSystemBoard = rpc.declare({
+const callSystemBoard = rpc.declare({
 	object: 'system',
 	method: 'board',
 });
 
-let callUpgradeStart = rpc.declare({
+const callUpgradeStart = rpc.declare({
 	object: 'rpc-sys',
 	method: 'upgrade_start',
 	params: ['keep'],

--- a/applications/luci-app-bcp38/htdocs/luci-static/resources/view/bcp38/form.js
+++ b/applications/luci-app-bcp38/htdocs/luci-static/resources/view/bcp38/form.js
@@ -5,7 +5,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('bcp38', _('BCP38'),
 			_('This function blocks packets with private address destinations ' +

--- a/applications/luci-app-clamav/htdocs/luci-static/resources/view/clamav/clamav-milter.js
+++ b/applications/luci-app-clamav/htdocs/luci-static/resources/view/clamav/clamav-milter.js
@@ -10,7 +10,7 @@ return view.extend({
 	},
 
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('clamav-milter', _('ClamAV Milter'), _('Configuration'));
 

--- a/applications/luci-app-clamav/htdocs/luci-static/resources/view/clamav/clamav.js
+++ b/applications/luci-app-clamav/htdocs/luci-static/resources/view/clamav/clamav.js
@@ -11,7 +11,7 @@ return view.extend({
 	},
 
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('clamav', _('ClamAV'), _('Configuration'));
 

--- a/applications/luci-app-clamav/htdocs/luci-static/resources/view/clamav/freshclam.js
+++ b/applications/luci-app-clamav/htdocs/luci-static/resources/view/clamav/freshclam.js
@@ -10,7 +10,7 @@ return view.extend({
 	},
 
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('freshclam', _('Freshclam'), _('Configuration'));
 

--- a/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js
+++ b/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js
@@ -34,7 +34,7 @@ return view.extend({
 
 	render: function (data) {
 		let isRunning = data[0];
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('cloudflared', _('Cloudflare Zero Trust Tunnel'),
 			_('Cloudflare Zero Trust Security services help you get maximum security both from outside and within the network.') + '<br />' +

--- a/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js
+++ b/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js
@@ -8,7 +8,7 @@
 'require rpc';
 'require view';
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js
+++ b/applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js
@@ -5,7 +5,7 @@
 
 return view.extend({
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('luci', _('Custom Commands'),
 			_('This page allows you to configure custom shell commands which can be easily invoked from the web interface.'));

--- a/applications/luci-app-crowdsec-firewall-bouncer/htdocs/luci-static/resources/view/crowdsec-firewall-bouncer/form.js
+++ b/applications/luci-app-crowdsec-firewall-bouncer/htdocs/luci-static/resources/view/crowdsec-firewall-bouncer/form.js
@@ -5,7 +5,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('crowdsec', _('CrowdSec'),
 			_('Gain <a href="http://www.crowdsec.net">crowd-sourced</a> protection against malicious IPs. ' +

--- a/applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js
+++ b/applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js
@@ -2,21 +2,19 @@
 'require baseclass';
 'require rpc';
 
-let callDawnGetNetwork, callDawnGetHearingMap, callHostHints;
-
-callDawnGetNetwork = rpc.declare({
+const callDawnGetNetwork = rpc.declare({
 	object: 'dawn',
 	method: 'get_network',
 	expect: { }
 });
 
-callDawnGetHearingMap = rpc.declare({
+const callDawnGetHearingMap = rpc.declare({
 	object: 'dawn',
 	method: 'get_hearing_map',
 	expect: { }
 });
 
-callHostHints = rpc.declare({
+const callHostHints = rpc.declare({
 	object: 'luci-rpc',
 	method: 'getHostHints',
 	expect: { }

--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -255,7 +255,7 @@ return view.extend({
 
 		var _this = this;
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('ddns', _('Dynamic DNS'));
 

--- a/applications/luci-app-dump1090/htdocs/luci-static/resources/view/dump1090/dump1090.js
+++ b/applications/luci-app-dump1090/htdocs/luci-static/resources/view/dump1090/dump1090.js
@@ -3,7 +3,7 @@
 
 return L.view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('dump1090', _('dump1090'), 
 			_('dump1090 is a Mode S decoder specifically designed for RTLSDR devices. Here you can configure the settings.'));

--- a/applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js
+++ b/applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js
@@ -5,7 +5,7 @@
 return view.extend({
 	render: function () {
 		var docsRefAttrs = 'target="_blank" rel="noreferrer" href="https://emailrelay.sourceforge.net/';
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('emailrelay', _('Email Server Configuration'),
 			_('E-MailRelay Server Configuration.') + '<br />' +

--- a/applications/luci-app-example/YAML.md
+++ b/applications/luci-app-example/YAML.md
@@ -63,7 +63,7 @@ These are the changes you need in the `rpc.js` file.
 Declare the RPC call
 
 ```js
-var load_sample_yaml = rpc.declare({
+const load_sample_yaml = rpc.declare({
     object: 'luci.example',
     method: 'get_yaml_file_sample'
 });

--- a/applications/luci-app-example/htdocs/luci-static/resources/view/example/form.js
+++ b/applications/luci-app-example/htdocs/luci-static/resources/view/example/form.js
@@ -5,7 +5,7 @@
 // Project code format is tabs, not spaces
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		/*
 		The first argument to form.Map() maps to the configuration file available

--- a/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-tablesection.js
+++ b/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-tablesection.js
@@ -45,7 +45,7 @@ return view.extend({
 		}
 
 		// Variables you'll usually see declared in LuCI JS apps; forM, Section, Option
-		var m, s, o;
+		let m, s, o;
 
 		/*
 		LuCI has the concept of a JSONMap. This will map a structured object to

--- a/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-tablesection.js
+++ b/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-tablesection.js
@@ -15,7 +15,7 @@ in that directory will be the value for the object key in the declared map.
 Permissions to make these calls must be granted in /usr/share/rpcd/acl.d
 via a file named the same as the application package name (luci-app-example)
 */
-var load_sample2 = rpc.declare({
+const load_sample2 = rpc.declare({
 	object: 'luci.example',
 	method: 'get_sample2'
 });

--- a/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-typedsection.js
+++ b/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-typedsection.js
@@ -45,7 +45,7 @@ return view.extend({
 		}
 
 		// Variables you'll usually see declared in LuCI JS apps; forM, Section, Option
-		var m, s, o;
+		let m, s, o;
 
 		/*
 		LuCI has the concept of a JSONMap. This will map a structured object to

--- a/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-typedsection.js
+++ b/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc-jsonmap-typedsection.js
@@ -15,7 +15,7 @@ in that directory will be the value for the object key in the declared map.
 Permissions to make these calls must be granted in /usr/share/rpcd/acl.d
 via a file named the same as the application package name (luci-app-example)
 */
-var load_sample2 = rpc.declare({
+const load_sample2 = rpc.declare({
 	object: 'luci.example',
 	method: 'get_sample2'
 });

--- a/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc.js
+++ b/applications/luci-app-example/htdocs/luci-static/resources/view/example/rpc.js
@@ -15,13 +15,13 @@ in that directory will be the value for the object key in the declared map.
 Permissions to make these calls must be granted in /usr/share/rpcd/acl.d
 via a file named the same as the application package name (luci-app-example)
 */
-var load_sample1 = rpc.declare({
+const load_sample1 = rpc.declare({
 	object: 'luci.example',
 	method: 'get_sample1'
 });
 // Out of the box, this one will be blocked by the framework because there is
 // no ACL granting permission.
-var load_sample3 = rpc.declare({
+const load_sample3 = rpc.declare({
 	object: 'luci.example',
 	method: 'get_sample3'
 });

--- a/applications/luci-app-filebrowser/htdocs/luci-static/resources/view/system/filebrowser.js
+++ b/applications/luci-app-filebrowser/htdocs/luci-static/resources/view/system/filebrowser.js
@@ -11,7 +11,7 @@ var formData = {
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.JSONMap(formData, _('File Browser'), '');
 

--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/ipsets.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/ipsets.js
@@ -15,7 +15,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('firewall', _('Firewall - IP sets'),
 			_('firewall4 supports referencing and creating IP sets to simplify matching of large address lists without the need to create one rule per item to match. Port ranges in ipsets are unsupported by firewall4.<br />'));

--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -138,7 +138,7 @@ function defOpts(s, opts, params) {
 	}
 }
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -170,7 +170,7 @@ function renderStatus(isRunning) {
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('frpc', _('frp Client'));
 

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -91,7 +91,7 @@ function defOpts(s, opts, params) {
 	}
 }
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -123,7 +123,7 @@ function renderStatus(isRunning) {
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('frps', _('frp Server'));
 

--- a/applications/luci-app-fwknopd/htdocs/luci-static/resources/view/fwknopd.js
+++ b/applications/luci-app-fwknopd/htdocs/luci-static/resources/view/fwknopd.js
@@ -406,7 +406,7 @@ var ParseButton = form.Button.extend({
 		var config = {};
 		config.access = stanzas;
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.JSONMap(config, null, _('Custom configuration read from /etc/fwknop/access.conf.'));
 		m.readonly = true;
@@ -469,7 +469,7 @@ return view.extend({
 
 	render: function(results) {
 		var has_access_conf = results[0];
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('fwknopd', _('Firewall Knock Operator Daemon'));
 

--- a/applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js
+++ b/applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js
@@ -33,7 +33,7 @@ return view.extend({
 	},
 
 	render: function(devs) {
-		var m, s, o;
+		let m, s, o;
 		m = new form.Map('hd-idle', _('HDD Idle'), _('HDD Idle is a utility program for spinning-down disks after a period of idle time.'));
 
 		s = m.section(form.GridSection, 'hd-idle', _('Settings'));

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
@@ -43,37 +43,37 @@ var pkg = {
 	},
 };
 
-var getInitList = rpc.declare({
+const getInitList = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitList",
 	params: ["name"],
 });
 
-var getInitStatus = rpc.declare({
+const getInitStatus = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitStatus",
 	params: ["name"],
 });
 
-var getPlatformSupport = rpc.declare({
+const getPlatformSupport = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getPlatformSupport",
 	params: ["name"],
 });
 
-var getProviders = rpc.declare({
+const getProviders = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getProviders",
 	params: ["name"],
 });
 
-var getRuntime = rpc.declare({
+const getRuntime = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getRuntime",
 	params: ["name"],
 });
 
-var _setInitAction = rpc.declare({
+const _setInitAction = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "setInitAction",
 	params: ["name", "action"],

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/globals.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/globals.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('keepalived');
 

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
@@ -5,7 +5,7 @@
 'require rpc';
 'require poll';
 
-var callKeepalivedStatus = rpc.declare({
+const callKeepalivedStatus = rpc.declare({
 	object: 'keepalived',
 	method: 'dump',
 	expect: {  },

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/peers.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/peers.js
@@ -18,7 +18,7 @@ return view.extend({
 
 	render: function(data) {
 		var hosts = data[0];
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('keepalived');
 

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/track_interface.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/track_interface.js
@@ -6,7 +6,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('keepalived');
 

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/url.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/url.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('keepalived');
 

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/vrrp_instance.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/vrrp_instance.js
@@ -283,7 +283,7 @@ return view.extend({
 
 	render: function(data) {
 		var netDevs = data[0];
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('keepalived');
 

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/vrrp_sync_group.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/vrrp_sync_group.js
@@ -12,7 +12,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 		var instances;
 
 		instances = uci.sections('keepalived', 'vrrp_instance');

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/status/include/35_keepalived.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/status/include/35_keepalived.js
@@ -3,7 +3,7 @@
 'require uci';
 'require rpc';
 
-var callKeepalivedStatus = rpc.declare({
+const callKeepalivedStatus = rpc.declare({
 	object: 'keepalived',
 	method: 'dump',
 	expect: {  },

--- a/applications/luci-app-ledtrig-usbport/htdocs/luci-static/resources/view/system/led-trigger/usbport.js
+++ b/applications/luci-app-ledtrig-usbport/htdocs/luci-static/resources/view/system/led-trigger/usbport.js
@@ -4,7 +4,7 @@
 'require uci';
 'require form';
 
-var callUSB = rpc.declare({
+const callUSB = rpc.declare({
 	object: 'luci',
 	method: 'getUSBDevices',
 	expect: { 'ports': [] }

--- a/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js
+++ b/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js
@@ -13,7 +13,7 @@ return view.extend({
 
 	render: function(data) {
 		var netDevs = data[0];
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('libreswan', _('IPSec Global Settings'));
 

--- a/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js
+++ b/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js
@@ -4,7 +4,7 @@
 'require form';
 'require poll';
 
-var callLibreswanStatus = rpc.declare({
+const callLibreswanStatus = rpc.declare({
 	object: 'libreswan',
 	method: 'status',
 	expect: {  },

--- a/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js
+++ b/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js
@@ -6,7 +6,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('libreswan', _('IPSec Proposals'));
 

--- a/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js
+++ b/applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js
@@ -31,7 +31,7 @@ return view.extend({
 
 	render: function(data) {
 		var netDevs = data[0];
-		var m, s, o;
+		let m, s, o;
 		var proposals;
 
 		proposals = uci.sections('libreswan', 'crypto_proposal');

--- a/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/config.js
+++ b/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/config.js
@@ -13,7 +13,7 @@
 'require uci';
 'require tools.widgets as widgets';
 
-var callInitList = rpc.declare({
+const callInitList = rpc.declare({
 	object: 'luci',
 	method: 'getInitList',
 	params: [ 'name' ],
@@ -25,7 +25,7 @@ var callInitList = rpc.declare({
 	}
 });
 
-var callInitAction = rpc.declare({
+const callInitAction = rpc.declare({
 	object: 'luci',
 	method: 'setInitAction',
 	params: [ 'name', 'action' ],

--- a/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/status.js
+++ b/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/status.js
@@ -12,7 +12,7 @@
 'require dom';
 'require poll';
 
-var callLLDPStatus = rpc.declare({
+const callLLDPStatus = rpc.declare({
 	object: 'luci.lldpd',
 	method: 'getStatus',
 	expect: {}

--- a/applications/luci-app-lorawan-basicstation/htdocs/luci-static/resources/view/lorawan-basicstation/general.js
+++ b/applications/luci-app-lorawan-basicstation/htdocs/luci-static/resources/view/lorawan-basicstation/general.js
@@ -14,7 +14,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 
 		/* General Settings */
 		m = new form.Map('basicstation', _('General Settings'));

--- a/applications/luci-app-minidlna/htdocs/luci-static/resources/view/minidlna.js
+++ b/applications/luci-app-minidlna/htdocs/luci-static/resources/view/minidlna.js
@@ -31,7 +31,7 @@ var CBIMiniDLNAStatus = form.DummyValue.extend({
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('minidlna', _('miniDLNA'), _('MiniDLNA is server software with the aim of being fully compliant with DLNA/UPnP-AV clients.'));
 

--- a/applications/luci-app-mjpg-streamer/htdocs/luci-static/resources/view/mjpg-streamer/mjpg-streamer.js
+++ b/applications/luci-app-mjpg-streamer/htdocs/luci-static/resources/view/mjpg-streamer/mjpg-streamer.js
@@ -26,7 +26,7 @@ return view.extend({
 		return Promise.all([uci.load('mjpg-streamer')]);
 	},
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('mjpg-streamer', 'MJPG-streamer', _('mjpg streamer is a streaming application for Linux-UVC compatible webcams'));
 

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/globals.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/globals.js
@@ -5,7 +5,7 @@
 return view.extend({
 
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('mwan3', _('MultiWAN Manager - Globals'));
 

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/interface.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/interface.js
@@ -16,7 +16,7 @@ return view.extend({
 	},
 
 	render: function (stats) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('mwan3', _('MultiWAN Manager - Interfaces'),
 			_('Mwan3 requires that all interfaces have a unique metric configured in /etc/config/network.') + '<br />' +

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/member.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/member.js
@@ -12,7 +12,7 @@ return view.extend({
 	},
 
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('mwan3', _('MultiWAN Manager - Members'),
 			_('Members are profiles attaching a metric and weight to an MWAN interface.') + '<br />' +

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/policy.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/policy.js
@@ -12,7 +12,7 @@ return view.extend({
 	},
 
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('mwan3', _('MultiWAN Manager - Policies'),
 			_('Policies are profiles grouping one or more members controlling how Mwan3 distributes traffic.') + '<br />' +

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/rule.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/rule.js
@@ -14,7 +14,7 @@ return view.extend({
 	},
 
 	render: function (data) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('mwan3', _('MultiWAN Manager - Rules'),
 			_('Rules specify which traffic will use a particular MWAN policy.') + '<br />' +

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/status/overview.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/status/overview.js
@@ -3,7 +3,7 @@
 'require view';
 'require rpc';
 
-var callMwan3Status = rpc.declare({
+const callMwan3Status = rpc.declare({
 	object: 'mwan3',
 	method: 'status',
 	expect: {  },

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/status/include/90_mwan3.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/status/include/90_mwan3.js
@@ -2,7 +2,7 @@
 'require baseclass';
 'require rpc';
 
-var callMwan3Status = rpc.declare({
+const callMwan3Status = rpc.declare({
 	object: 'mwan3',
 	method: 'status',
 	expect: {  },

--- a/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
+++ b/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
@@ -5,7 +5,7 @@
 'require view';
 'require tools.widgets as widgets';
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
+++ b/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
@@ -45,7 +45,7 @@ return view.extend({
 		return getStatus();
 	},
 	render: function(status) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('natmap', _('NATMap'));
 		s = m.section(form.GridSection, 'natmap');

--- a/applications/luci-app-nextdns/htdocs/luci-static/resources/view/nextdns/overview.js
+++ b/applications/luci-app-nextdns/htdocs/luci-static/resources/view/nextdns/overview.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 		
 		m = new form.Map('nextdns', _('NextDNS'),
 			_('NextDNS Configuration.')

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/config.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/config.js
@@ -47,7 +47,7 @@ return view.extend({
 	},
 
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('nlbwmon', _('Netlink Bandwidth Monitor - Configuration'),
 			_('The Netlink Bandwidth Monitor (nlbwmon) is a lightweight, efficient traffic accounting program keeping track of bandwidth usage per host and protocol.'));

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -7,7 +7,7 @@
 'require rpc';
 'require dom';
 
-var callNetworkRrdnsLookup = rpc.declare({
+const callNetworkRrdnsLookup = rpc.declare({
 	object: 'network.rrdns',
 	method: 'lookup',
 	params: [ 'addrs', 'timeout', 'limit' ],

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js
@@ -8,7 +8,7 @@ return view.extend({
 	},
 
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('nut_cgi', _('NUT CGI'),
 			_('Network UPS Tools CGI Configuration') + '<br />' +

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
@@ -31,7 +31,7 @@ return view.extend({
 	},
 
 	render: function(loaded_promises) {
-		var m, s, o;
+		let m, s, o;
 		const have_ssl_support = loaded_promises[0];
 
 		m = new form.Map('nut_monitor', _('NUT Monitor'),

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -27,7 +27,7 @@ return view.extend({
 	},
 
 	render: function(loaded_promises) {
-		var m, s, o;
+		let m, s, o;
 		const have_ssl_support = loaded_promises[0];
 		const driver_list = loaded_promises[1];
 

--- a/applications/luci-app-olsr-services/htdocs/luci-static/resources/view/freifunk-services/services.js
+++ b/applications/luci-app-olsr-services/htdocs/luci-static/resources/view/freifunk-services/services.js
@@ -3,13 +3,13 @@
 'require view';
 'require poll';
 
-var getOlsrd4Services = rpc.declare({
+const getOlsrd4Services = rpc.declare({
     object: 'olsr-services',
     method: 'services4',
     expect: {}
 });
 
-var getOlsrd6Services = rpc.declare({
+const getOlsrd6Services = rpc.declare({
     object: 'olsr-services',
     method: 'services6',
     expect: {}

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd.js
@@ -26,7 +26,7 @@ return view.extend({
 		})]);
 	},
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		var has_ipip;
 

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd6.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd6.js
@@ -26,7 +26,7 @@ return view.extend({
 		})]);
 	},
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		var has_ipip;
 

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrddisplay.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrddisplay.js
@@ -9,7 +9,7 @@ return view.extend({
 		return Promise.all([uci.load('luci_olsr')]);
 	},
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('luci_olsr', _('OLSR - Display Options'));
 

--- a/applications/luci-app-omcproxy/htdocs/luci-static/resources/view/omcproxy.js
+++ b/applications/luci-app-omcproxy/htdocs/luci-static/resources/view/omcproxy.js
@@ -8,7 +8,7 @@
 
 return view.extend({
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('omcproxy', _('omcproxy'), _('Embedded IGMPv3 and MLDv2 proxy'));
 

--- a/applications/luci-app-openwisp/htdocs/luci-static/resources/view/openwisp.js
+++ b/applications/luci-app-openwisp/htdocs/luci-static/resources/view/openwisp.js
@@ -5,7 +5,7 @@
 
 return view.extend({
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('openwisp',
 			_('OpenWISP'),

--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -87,7 +87,7 @@ var css = '								\
 
 var isReadonlyView = !L.hasViewPermission() || null;
 
-var callMountPoints = rpc.declare({
+const callMountPoints = rpc.declare({
 	object: 'luci',
 	method: 'getMountPoints',
 	expect: { result: [] }

--- a/applications/luci-app-pagekitec/htdocs/luci-static/resources/view/pagekitec.js
+++ b/applications/luci-app-pagekitec/htdocs/luci-static/resources/view/pagekitec.js
@@ -12,7 +12,7 @@ var desc = _(""
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('pagekitec', _('PageKite'), desc);
 

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
@@ -32,37 +32,37 @@ var pkg = {
 	},
 };
 
-var getGateways = rpc.declare({
+const getGateways = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getGateways",
 	params: ["name"],
 });
 
-var getInitList = rpc.declare({
+const getInitList = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitList",
 	params: ["name"],
 });
 
-var getInitStatus = rpc.declare({
+const getInitStatus = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitStatus",
 	params: ["name"],
 });
 
-var getInterfaces = rpc.declare({
+const getInterfaces = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInterfaces",
 	params: ["name"],
 });
 
-var getPlatformSupport = rpc.declare({
+const getPlatformSupport = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getPlatformSupport",
 	params: ["name"],
 });
 
-var _setInitAction = rpc.declare({
+const _setInitAction = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "setInitAction",
 	params: ["name", "action"],

--- a/applications/luci-app-qos/htdocs/luci-static/resources/view/qos/qos.js
+++ b/applications/luci-app-qos/htdocs/luci-static/resources/view/qos/qos.js
@@ -5,7 +5,7 @@
 'require tools.widgets as widgets';
 'require view';
 
-var callHostHints = rpc.declare({
+const callHostHints = rpc.declare({
 	object: 'luci-rpc',
 	method: 'getHostHints',
 	expect: { '': {} }

--- a/applications/luci-app-qos/htdocs/luci-static/resources/view/qos/qos.js
+++ b/applications/luci-app-qos/htdocs/luci-static/resources/view/qos/qos.js
@@ -20,7 +20,7 @@ return view.extend({
 	},
 
 	render: function (loaded_promises) {
-		var m, s, o;
+		let m, s, o;
 		const networks = loaded_promises[0];
 		const hosts = loaded_promises[1];
 

--- a/applications/luci-app-rp-pppoe-server/htdocs/luci-static/resources/view/pppoe/rp-pppoe-relay.js
+++ b/applications/luci-app-rp-pppoe-server/htdocs/luci-static/resources/view/pppoe/rp-pppoe-relay.js
@@ -12,7 +12,7 @@ return view.extend({
 	},
 
 	render: function (loaded_promises) {
-		var m, s, o;
+		let m, s, o;
 		const networks = loaded_promises[0];
 
 		m = new form.Map('pppoe', _('Roaring Penguin PPPoE Relay'),

--- a/applications/luci-app-rp-pppoe-server/htdocs/luci-static/resources/view/pppoe/rp-pppoe-server.js
+++ b/applications/luci-app-rp-pppoe-server/htdocs/luci-static/resources/view/pppoe/rp-pppoe-server.js
@@ -12,7 +12,7 @@ return view.extend({
 	},
 
 	render: function (loaded_promises) {
-		var m, s, o;
+		let m, s, o;
 		const networks = loaded_promises[0];
 
 		m = new form.Map('pppoe', _('Roaring Penguin PPPoE Server'),

--- a/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js
+++ b/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('ser2net', 'ser2net');
 

--- a/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/proxies.js
+++ b/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/proxies.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('ser2net', 'ser2net');
 

--- a/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/settings.js
+++ b/applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/settings.js
@@ -4,7 +4,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('ser2net', 'ser2net');
 

--- a/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -27,7 +27,7 @@
 'require ui';
 
 var conf = 'smartdns';
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -88,7 +88,7 @@ return view.extend({
 		]);
 	},
 	render: function (stats) {
-		var m, s, o;
+		let m, s, o;
 		var ss, so;
 		var servers, download_files;
 

--- a/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
+++ b/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
@@ -15,7 +15,7 @@ var desc = _(""
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map("snmpd", _("net-snmp's SNMPD"), desc);
 

--- a/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
+++ b/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
@@ -59,7 +59,7 @@ return view.extend({
 			]));
 		}
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('sqm', _('Smart Queue Management'));
 		m.description = _("With <abbr title=\"Smart Queue Management\">SQM</abbr> you " +

--- a/applications/luci-app-squid/htdocs/luci-static/resources/view/squid.js
+++ b/applications/luci-app-squid/htdocs/luci-static/resources/view/squid.js
@@ -6,7 +6,7 @@
 'require uci';
 'require view';
 
-var getCompileTimeOptions = rpc.declare({
+const getCompileTimeOptions = rpc.declare({
 	object: 'luci.squid',
 	method: 'getCompileTimeOptions',
 	expect: { options: [] }

--- a/applications/luci-app-squid/htdocs/luci-static/resources/view/squid.js
+++ b/applications/luci-app-squid/htdocs/luci-static/resources/view/squid.js
@@ -38,7 +38,7 @@ return view.extend({
 		var { config_file, mime_table } = data[0];
 		var options = data[1];
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('squid', _('Squid'));
 

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js
@@ -19,7 +19,7 @@ return view.extend({
 	render: function (data) {
 		var knownHosts = data[0];
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
 			_('This configures <a %s>SSH Tunnels</a>.')

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
@@ -34,7 +34,7 @@ return view.extend({
 		hasSshKeygen = data[0].type === 'file';
 		var sshKeys = _splitSshKeys(data.splice(1));
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
 			_('This configures <a %s>SSH Tunnels</a>.')

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
@@ -19,7 +19,7 @@ return view.extend({
 			ui.addNotification(null, E('p', _('No SSH keys found, <a %s>generate a new one</a>').format('href="./ssh_keys"')), 'warning');
 		}
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
 			_('This configures <a %s>SSH Tunnels</a>.')

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js
@@ -13,7 +13,7 @@ return view.extend({
 	},
 
 	render: function (data) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
 			_('This configures <a %s>SSH Tunnels</a>.')

--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
@@ -29,7 +29,7 @@ return view.extend({
 	},
 
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('ipsec', _('strongSwan Configuration'),
 			_('Configure strongSwan for secure VPN connections.'));

--- a/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor-hs.js
+++ b/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor-hs.js
@@ -4,7 +4,7 @@
 'require rpc';
 'require uci';
 
-var callTorHsList = rpc.declare({
+const callTorHsList = rpc.declare({
 	object: 'tor-hs-rpc',
 	method: 'list-hs',
 });

--- a/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor-hs.js
+++ b/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor-hs.js
@@ -27,7 +27,7 @@ return view.extend({
 			hsMap.set(hs.name, hs.hostname);
 		});
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('tor-hs', _('Tor Onion Services'),
 			_('Tor Onion (Hidden) Services are proxy tunnels to your local website, SSH and other services.') + '<br />' +

--- a/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor.js
+++ b/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor.js
@@ -6,7 +6,7 @@
 
 return view.extend({
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('tor', _('Tor onion router'),
 			_('For further information <a %s>check the documentation</a>')

--- a/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
+++ b/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
@@ -37,7 +37,7 @@ return view.extend({
 		if (running && webinstalled)
 			button = '&#160;<a class="btn" href="http://' + window.location.hostname + ':' + port + '" target="_blank" rel="noreferrer noopener">' + _('Open Web Interface') + '</a>';
 
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('transmission', 'Transmission', _('Transmission daemon is a simple bittorrent client, here you can configure the settings.') + button);
 

--- a/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
+++ b/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
@@ -6,7 +6,7 @@
 'require form';
 'require tools.widgets as widgets';
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: [ 'name' ],

--- a/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
+++ b/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
@@ -143,7 +143,7 @@ return view.extend({
 	},
 
 	render: function (result) {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('travelmate', 'Travelmate', _('Configuration of the travelmate package to enable travel router functionality. \
 			For further information <a href="https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md" target="_blank" rel="noreferrer noopener" >check the online documentation</a>. <br /> \

--- a/applications/luci-app-ttyd/htdocs/luci-static/resources/view/ttyd/config.js
+++ b/applications/luci-app-ttyd/htdocs/luci-static/resources/view/ttyd/config.js
@@ -5,7 +5,7 @@
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('ttyd');
 

--- a/applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js
+++ b/applications/luci-app-udpxy/htdocs/luci-static/resources/view/udpxy.js
@@ -151,7 +151,7 @@ var CBIBindSelect = form.ListValue.extend({
 
 return view.extend({
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('udpxy', _('udpxy'),
 			_('udpxy is an IPTV stream relay, a UDP-to-HTTP multicast traffic relay daemon which forwards multicast UDP streams to HTTP clients.'));

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -4,28 +4,26 @@
 'require rpc';
 'require uci';
 
-var callUpnpGetStatus, callUpnpDeleteRule, handleDelRule;
-
-callUpnpGetStatus = rpc.declare({
+const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',
 	expect: {  }
 });
 
-callUpnpDeleteRule = rpc.declare({
+const callUpnpDeleteRule = rpc.declare({
 	object: 'luci.upnp',
 	method: 'delete_rule',
 	params: [ 'token' ],
 	expect: { result : "OK" },
 });
 
-handleDelRule = function(num, ev) {
+function handleDelRule(num, ev) {
 	dom.parent(ev.currentTarget, '.tr').style.opacity = 0.5;
 	ev.currentTarget.classList.add('spinning');
 	ev.currentTarget.disabled = true;
 	ev.currentTarget.blur();
 	callUpnpDeleteRule(num);
-};
+}
 
 return baseclass.extend({
 	title: _('Active UPnP IGD & PCP/NAT-PMP Port Maps'),

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -6,35 +6,33 @@
 'require rpc';
 'require form';
 
-var callInitAction, callUpnpGetStatus, callUpnpDeleteRule, handleDelRule;
-
-callInitAction = rpc.declare({
+const callInitAction = rpc.declare({
 	object: 'luci',
 	method: 'setInitAction',
 	params: [ 'name', 'action' ],
 	expect: { result: false }
 });
 
-callUpnpGetStatus = rpc.declare({
+const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',
 	expect: {  }
 });
 
-callUpnpDeleteRule = rpc.declare({
+const callUpnpDeleteRule = rpc.declare({
 	object: 'luci.upnp',
 	method: 'delete_rule',
 	params: [ 'token' ],
 	expect: { result : "OK" },
 });
 
-handleDelRule = function(num, ev) {
+function handleDelRule(num, ev) {
 	dom.parent(ev.currentTarget, '.tr').style.opacity = 0.5;
 	ev.currentTarget.classList.add('spinning');
 	ev.currentTarget.disabled = true;
 	ev.currentTarget.blur();
 	callUpnpDeleteRule(num);
-};
+}
 
 return view.extend({
 	load: function() {

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -62,7 +62,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 
 		var protocols = '%s & %s/%s'.format(
 			'<a href="https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol" target="_blank" rel="noreferrer"><abbr title="UPnP Internet Gateway Device (Control Protocol)">UPnP IGD</abbr></a>',

--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -170,7 +170,7 @@ function collectWlanAPInfos(compactconnectioninfo_table_entries, wlanAPInfos) {
 	}
 };
 
-var callNetworkRrdnsLookup = rpc.declare({
+const callNetworkRrdnsLookup = rpc.declare({
 	object: 'network.rrdns',
 	method: 'lookup',
 	params: [ 'addrs', 'timeout', 'limit' ],

--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -364,7 +364,7 @@ return view.extend({
 	},
 
 	render: function (data) {
-		var m, s, o;
+		let m, s, o;
 
 		if (!('usteer' in data[0])) {
 			m = new form.Map('usteer', _('Usteer'),

--- a/applications/luci-app-v2raya/htdocs/luci-static/resources/view/v2raya/config.js
+++ b/applications/luci-app-v2raya/htdocs/luci-static/resources/view/v2raya/config.js
@@ -44,7 +44,7 @@ return view.extend({
 	},
 
 	render: function(data) {
-		var m, s, o;
+		let m, s, o;
 		var webport = (uci.get(data[0], 'config', 'address') || '0.0.0.0:2017').split(':').slice(-1)[0];
 
 		m = new form.Map('v2raya', _('v2rayA'),

--- a/applications/luci-app-v2raya/htdocs/luci-static/resources/view/v2raya/config.js
+++ b/applications/luci-app-v2raya/htdocs/luci-static/resources/view/v2raya/config.js
@@ -5,7 +5,7 @@
 'require uci';
 'require view';
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
+++ b/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
@@ -38,7 +38,7 @@ return view.extend({
 	},
 
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('vnstat', _('vnStat'), _('vnStat is a network traffic monitor for Linux that keeps a log of network traffic for the selected interface(s).'));
 

--- a/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js
+++ b/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/graphs.js
@@ -11,7 +11,7 @@
 var RefreshIfaces = "";
 var RefreshTabs = ['s', 't', '5', 'h', 'd', 'm', 'y'];
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: [ 'name' ],

--- a/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
+++ b/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
@@ -5,7 +5,7 @@
 
 return view.extend({
 	render: function () {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('watchcat', 
 			_('Watchcat'), 

--- a/applications/luci-app-xfrpc/htdocs/luci-static/resources/view/xfrpc.js
+++ b/applications/luci-app-xfrpc/htdocs/luci-static/resources/view/xfrpc.js
@@ -37,7 +37,7 @@ function renderStatus(isRunning) {
 
 return view.extend({
 	render: function() {
-		var m, s, o;
+		let m, s, o;
 
 		m = new form.Map('xfrpc', _('xfrpc'));
 		m.description = _("xfrpc is a c language frp client for frps.");

--- a/applications/luci-app-xfrpc/htdocs/luci-static/resources/view/xfrpc.js
+++ b/applications/luci-app-xfrpc/htdocs/luci-static/resources/view/xfrpc.js
@@ -5,7 +5,7 @@
 'require rpc';
 'require tools.widgets as widgets';
 
-var callServiceList = rpc.declare({
+const callServiceList = rpc.declare({
 	object: 'service',
 	method: 'list',
 	params: ['name'],

--- a/applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js
+++ b/applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js
@@ -24,7 +24,7 @@ return view.extend({
 	},
 
 	render: function(promises) {
-		var m, s, o;
+		let m, s, o;
 		var networks = promises[0];
 
 		m = new form.Map('xinetd', _('Xinetd Settings'), _('Here you can configure Xinetd services'));


### PR DESCRIPTION
This is a code style change in order to migrate to the ES6 syntax. 
I'll prose to gradually convert without no rush. Tools like the IntelliJ can reformat almost everything but results needs to be checked. For example we can replace `for (var i = 0;;)` with the `for (let i = 0;;)` but actually we may have a code after the `for` that checks for the `i` var value. On the other side almost all such indexed `for` loops can be replaced with `for of` (foreach).

But here I wish to start from the quick win and replace the most common problem of declaring with `var`. 

The `var rpcCall = rpc.declare({})` can be always unambiguously converted to `const` since they are never changed.
In the same time the `var m, s, o` can be always converted to the `let m, s, o`.

When new devs will start to copy-paste code they'll use the new version.

I made a command to see most popular usages of the `var`:
```sh
grep -h --include=*.js -r  "var " applications/ | tr -d ' \t' | sort | uniq -c | sort
```