### PR TITLE
CODEOWNERS with list of maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,131 @@
+applications/luci-app-acl @jow-
+applications/luci-app-acme @tohojo
+applications/luci-app-adblock @hnyman @dibdot
+applications/luci-app-adblock-fast @stangri
+applications/luci-app-advanced-reboot @stangri
+applications/luci-app-alist @1715173329
+applications/luci-app-apinger @jempatel
+applications/luci-app-aria2 @kuoruan
+applications/luci-app-attendedsysupgrade @aparcar
+applications/luci-app-babeld @PolynomialDivision
+applications/luci-app-banip @dibdot
+applications/luci-app-bcp38 @tohojo
+applications/luci-app-bmx7 @rogerpueyo @p4u
+applications/luci-app-clamav @ratkaj @lperkov
+applications/luci-app-cloudflared @animegasan @stokito
+applications/luci-app-commands @jow-
+applications/luci-app-coovachilli @sbyx @jow-
+applications/luci-app-crowdsec-firewall-bouncer @ne20002
+applications/luci-app-cshark @lperkov
+applications/luci-app-dawn @PolynomialDivision
+applications/luci-app-dcwapd @csonsino
+applications/luci-app-ddns @Ansuel
+applications/luci-app-dockerman @lisaac @feckert
+applications/luci-app-dump1090 @Noltari
+applications/luci-app-dynapoint @ascob
+applications/luci-app-email @stokito
+applications/luci-app-eoip @bogdik
+applications/luci-app-example @andibraeu @cricalix
+applications/luci-app-filebrowser @stokito
+applications/luci-app-filemanager @rdmitry0911
+applications/luci-app-firewall @jow-
+applications/luci-app-frpc @ysc3839
+applications/luci-app-frps @ysc3839
+applications/luci-app-fwknopd @jp-bennett
+applications/luci-app-hd-idle @jow-
+applications/luci-app-https-dns-proxy @stangri
+applications/luci-app-irqbalance @ElaineR02
+applications/luci-app-keepalived @jempatel
+applications/luci-app-ksmbd @ysc3839
+applications/luci-app-ledtrig-rssi @jow-
+applications/luci-app-ledtrig-switch @jow-
+applications/luci-app-ledtrig-usbport @jow-
+applications/luci-app-libreswan @jempatel
+applications/luci-app-lldpd @systemcrash @marek22k
+applications/luci-app-lorawan-basicstation @mars642
+applications/luci-app-ltqtapi @blogic
+applications/luci-app-lxc @dibdot
+applications/luci-app-minidlna @jow-
+applications/luci-app-mjpg-streamer @jow-
+applications/luci-app-mosquitto @karlp
+applications/luci-app-mwan3 @feckert
+applications/luci-app-natmap @ysc3839
+applications/luci-app-nextdns @rs
+applications/luci-app-nft-qos @rosysong
+applications/luci-app-nlbwmon @jow-
+applications/luci-app-nut @danielfdickinson
+applications/luci-app-ocserv @nmav
+applications/luci-app-olsr @mmunz @jow-
+applications/luci-app-olsr-services @andibraeu
+applications/luci-app-olsr-viz @znerol @Ayushmanwebdeveloper
+applications/luci-app-omcproxy @riverscn
+applications/luci-app-openvpn @sbyx @jow-
+applications/luci-app-openwisp @mips171
+applications/luci-app-p910nd @systemcrash @jow-
+applications/luci-app-package-manager @jow-
+applications/luci-app-pagekitec @karlp
+applications/luci-app-pbr @stangri
+applications/luci-app-privoxy @chris5560
+applications/luci-app-qos @sbyx
+applications/luci-app-radicale @chris5560
+applications/luci-app-radicale2 @danielfdickinson
+applications/luci-app-rp-pppoe-server @danielfdickinson
+applications/luci-app-samba4 @Andy2244
+applications/luci-app-ser2net @michyprima
+applications/luci-app-shadowsocks-libev @yousong @aa65535
+applications/luci-app-siitwizard @sbyx @jow-
+applications/luci-app-smartdns @pymumu
+applications/luci-app-snmpd @karlp
+applications/luci-app-softether @jow-
+applications/luci-app-splash @mmunz @jow-
+applications/luci-app-sqm @tohojo
+applications/luci-app-squid @ratkaj
+applications/luci-app-sshtunnel @stokito
+applications/luci-app-statistics @jow-
+applications/luci-app-strongswan-swanctl @mips171 @lvoegl
+applications/luci-app-tinyproxy @sbyx @jow-
+applications/luci-app-tor @stokito
+applications/luci-app-transmission @ysc3839
+applications/luci-app-travelmate @dibdot
+applications/luci-app-ttyd @dibdot
+applications/luci-app-udpxy @1715173329
+applications/luci-app-uhttpd @danielfdickinson
+applications/luci-app-unbound @EricLuehrsen
+applications/luci-app-upnp @jow-
+applications/luci-app-usteer @Ramon00
+applications/luci-app-v2raya @1715173329
+applications/luci-app-vnstat @jow-
+applications/luci-app-vnstat2 @janh
+applications/luci-app-watchcat @jow- @mips171
+applications/luci-app-wifischedule @newkit
+applications/luci-app-wol @jow-
+applications/luci-app-xfrpc @liudf0716
+applications/luci-app-xinetd @he-ma
+
+protocols/luci-proto-3g @jow-
+protocols/luci-proto-autoip @jow-
+protocols/luci-proto-batman-adv @onemarcfifty
+protocols/luci-proto-bonding @he-ma
+protocols/luci-proto-external @oskarirauta
+protocols/luci-proto-gre @mbargo23
+protocols/luci-proto-hnet @sbyx
+protocols/luci-proto-ipip @rogerpueyo
+protocols/luci-proto-ipv6 @jow-
+protocols/luci-proto-mbim @hyc
+protocols/luci-proto-modemmanager @mips171
+protocols/luci-proto-ncm @lucize
+protocols/luci-proto-nebula @stangri
+protocols/luci-proto-openconnect @jow-
+protocols/luci-proto-openfortivpn @aaronjg
+protocols/luci-proto-ppp @jow-
+protocols/luci-proto-pppossh @yousong
+protocols/luci-proto-qmi @thornley-touchstar
+protocols/luci-proto-relay @jow-
+protocols/luci-proto-sstp @rkkoszewski
+protocols/luci-proto-unet @hnyman
+protocols/luci-proto-vpnc @danielfdickinson
+protocols/luci-proto-vti @jempatel
+protocols/luci-proto-vxlan @wjowsa
+protocols/luci-proto-wireguard @danrl
+protocols/luci-proto-xfrm @hgl
+protocols/luci-proto-yggdrasil @wfleurant

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ MAY:
 - [ ] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
 - [ ] Incremented :up: any `PKG_VERSION` in the Makefile
 - [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
-- [ ] \( Preferred ) Mention: @ the original code author for feedback
+- [ ] \( Preferred ) Mention: @ the original code author for feedback. Check the [CODEOWNERS](https://github.com/stokito/luci/blob/codeowners/.github/CODEOWNERS) to find a GitHub username of a maintainer.
 - [ ] \( Preferred ) Screenshot or mp4 of changes:
 - [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
 - [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo

--- a/applications/luci-app-lldpd/Makefile
+++ b/applications/luci-app-lldpd/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for LLDP daemon
 LUCI_DEPENDS:=+lldpd +rpcd-mod-ucode
+PKG_MAINTAINER:=Paul Donald <newtwen+github@gmail.com>
 
 PKG_LICENSE:=MIT
 


### PR DESCRIPTION
The second attempt of the #6830 that was closed after a discussion.
My proposition is to add the CODEOWNERS file to help for contributors to quickly find a maintainer (as I did myself today). Even better, for those devs that already have a write access they'll automatically be assigned as reviewers for a PR for the particular app.

The other steps like creating `luci-dev` team as I described in my comment can be done later. But the CODEOWNERS can start helping us today and save time for contributors. We may add a link to it into the PR template.

It won't change anything in terms of security so the PR is safe to merge.