### PR TITLE
luci-app-acme: `cfgvalue` does not receive the `set_value` parameter when it is called in `CBIValue.render`.

### DIFF
--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -484,12 +484,7 @@ return view.extend({
 		o.rmempty = false;
 		o.optional = true;
 		o.modalonly = true;
-		o.cfgvalue = function(section_id, set_value) {
-			if (set_value != null) {
-				// no migration required, need to store data
-				this.data = this.data || {};
-				this.data[section_id] = set_value;
-			}
+		o.cfgvalue = function(section_id) {
 			var keylength = uci.get('acme', section_id, 'keylength');
 			if (keylength) {
 				// migrate the old keylength to a new keytype
@@ -502,7 +497,7 @@ return view.extend({
 					default: return ''; // bad value
 				}
 			}
-			return this.data ? this.data[section_id] : null;
+			return this.super.apply(this, ['cfgvalue'].concat(arguments));
 		};
 		o.write = function(section_id, value) {
 			// remove old keylength

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -497,7 +497,7 @@ return view.extend({
 					default: return ''; // bad value
 				}
 			}
-			return this.super.apply(this, ['cfgvalue'].concat(arguments));
+			return this.super('cfgvalue', arguments);
 		};
 		o.write = function(section_id, value) {
 			// remove old keylength

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -485,6 +485,11 @@ return view.extend({
 		o.optional = true;
 		o.modalonly = true;
 		o.cfgvalue = function(section_id, set_value) {
+			if (set_value != null) {
+				// no migration required, need to store data
+				this.data = this.data || {};
+				this.data[section_id] = set_value;
+			}
 			var keylength = uci.get('acme', section_id, 'keylength');
 			if (keylength) {
 				// migrate the old keylength to a new keytype
@@ -497,7 +502,7 @@ return view.extend({
 					default: return ''; // bad value
 				}
 			}
-			return set_value;
+			return this.data ? this.data[section_id] : null;
 		};
 		o.write = function(section_id, value) {
 			// remove old keylength


### PR DESCRIPTION
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86_64, v24.10-SNAPSHOT, Edge 132.0.2957.11) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: The value of "Key type" will be overwritten to `undefined` when the drop-box after rendering. (except the first migration from the old `keylength` config parameter)
