### PR TITLE
luci-app-upnp: Critical hotfix revert 7a7f9ec and fix old translations

### DIFF
--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -37,6 +37,7 @@ return baseclass.extend({
 	},
 
 	render: function(data) {
+
 		var table = E('table', { 'class': 'table', 'id': 'upnp_status_table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Client Name')),
@@ -50,6 +51,7 @@ return baseclass.extend({
 		]);
 
 		var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
+
 		var rows = rules.map(function(rule) {
 			return [
 				rule.host_hint || _('Unknown'),
@@ -64,7 +66,9 @@ return baseclass.extend({
 				}, [ _('Delete') ])
 			];
 		});
+
 		cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
+
 		return table;
 	}
 });

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -45,7 +45,9 @@ return view.extend({
 	},
 
 	poll_status: function(nodes, data) {
+
 		var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
+
 		var rows = rules.map(function(rule) {
 			return [
 				rule.host_hint || _('Unknown'),
@@ -60,21 +62,18 @@ return view.extend({
 				}, [ _('Delete') ])
 			];
 		});
+
 		cbi_update_table(nodes.querySelector('#upnp_status_table'), rows, E('em', _('There are no active port maps.')));
+
+		return;
 	},
 
 	render: function(data) {
+
 		var m, s, o;
 
-		var protocols = '%s & %s/%s'.format(
-			'<a href="https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol" target="_blank" rel="noreferrer"><abbr title="UPnP Internet Gateway Device (Control Protocol)">UPnP IGD</abbr></a>',
-			'<a href="https://en.wikipedia.org/wiki/Port_Control_Protocol" target="_blank" rel="noreferrer"><abbr title="Port Control Protocol">PCP</abbr></a>',
-			'<a href="https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol" target="_blank" rel="noreferrer"><abbr title="NAT Port Mapping Protocol">NAT-PMP</abbr></a>');
 		m = new form.Map('upnpd', [_('UPnP IGD & PCP/NAT-PMP Service')],
-			_('The %s protocols allow clients on the local network to configure port maps/forwards on the router autonomously.',
-				'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local network to configure port maps/forwards on the router autonomously.')
-				.format(protocols)
-		);
+			_('The %s protocols allow clients on the local network to configure port maps/forwards on the router autonomously.', 'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local network to configure port maps/forwards on the router autonomously.').format('%s & %s/%s').format('<a href="https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol" target="_blank" rel="noreferrer"><abbr title="UPnP Internet Gateway Device (Control Protocol)">UPnP IGD</abbr></a>', '<a href="https://en.wikipedia.org/wiki/Port_Control_Protocol" target="_blank" rel="noreferrer"><abbr title="Port Control Protocol">PCP</abbr></a>', '<a href="https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol" target="_blank" rel="noreferrer"><abbr title="NAT Port Mapping Protocol">NAT-PMP</abbr></a>'));
 
 		s = m.section(form.GridSection, '_active_rules');
 
@@ -92,6 +91,7 @@ return view.extend({
 			]);
 
 			var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
+
 			var rows = rules.map(function(rule) {
 				return [
 					rule.host_hint || _('Unknown'),
@@ -106,7 +106,9 @@ return view.extend({
 					}, [ _('Delete') ])
 				];
 			});
+
 			cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
+
 			return E('div', { 'class': 'cbi-section cbi-tblsection' }, [
 					E('h3', _('Active Service Port Maps')), table ]);
 		}, o, this);
@@ -120,11 +122,9 @@ return view.extend({
 			_('Start autonomous port mapping service'));
 		o.rmempty = false;
 
-		s.taboption('setup', form.Flag, 'enable_upnp', _('Enable UPnP IGD protocol'))
-		s.default = '1';
+		s.taboption('setup', form.Flag, 'enable_upnp', _('Enable UPnP IGD protocol')).default = '1';
 
-		s.taboption('setup', form.Flag, 'enable_natpmp', _('Enable PCP/NAT-PMP protocols'))
-		s.default = '1';
+		s.taboption('setup', form.Flag, 'enable_natpmp', _('Enable PCP/NAT-PMP protocols')).default = '1';
 
 		o = s.taboption('setup', form.Flag, 'igdv1', _('UPnP IGDv1 compatibility mode'),
 			_('Advertise as IGDv1 (IPv4 only) device instead of IGDv2'));
@@ -140,8 +140,7 @@ return view.extend({
 			_('Report maximum upload speed in kByte/s'));
 		o.depends('enable_upnp', '1');
 
-		s.taboption('advanced', form.Flag, 'use_stun', _('Use %s', 'Use %s (%s = STUN)')
-				.format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
+		s.taboption('advanced', form.Flag, 'use_stun', _('Use %s', 'Use %s (%s = STUN)').format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
 			_('To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs'));
 
 		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN Host'));
@@ -159,8 +158,7 @@ return view.extend({
 		o.depends('enable_upnp', '1');
 
 		o = s.taboption('advanced', form.Value, 'notify_interval', _('Notify interval'),
-			_('A 900s interval will result in %s notifications with the minimum max-age of 1800s', 'A 900s interval will result in %s (%s = SSDP) notifications with the minimum max-age of 1800s')
-				.format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>'));
+			_('A 900s interval will result in %s notifications with the minimum max-age of 1800s', 'A 900s interval will result in %s (%s = SSDP) notifications with the minimum max-age of 1800s').format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>'));
 		o.datatype = 'uinteger';
 		o.placeholder = '900';
 		o.depends('enable_upnp', '1');

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -143,11 +143,11 @@ return view.extend({
 		s.taboption('advanced', form.Flag, 'use_stun', _('Use %s', 'Use %s (%s = STUN)').format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
 			_('To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs'));
 
-		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN Host'));
+		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN host'));
 		o.depends('use_stun', '1');
 		o.datatype = 'host';
 
-		o = s.taboption('advanced', form.Value, 'stun_port', _('STUN Port'));
+		o = s.taboption('advanced', form.Value, 'stun_port', _('STUN port'));
 		o.depends('use_stun', '1');
 		o.datatype = 'port';
 		o.placeholder = '3478';

--- a/applications/luci-app-upnp/po/ar/upnp.po
+++ b/applications/luci-app-upnp/po/ar/upnp.po
@@ -174,11 +174,11 @@ msgid "SOAP/HTTP port"
 msgstr "المنفذ"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -251,6 +251,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "ضيف"

--- a/applications/luci-app-upnp/po/bg/upnp.po
+++ b/applications/luci-app-upnp/po/bg/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "Порт"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -250,6 +250,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "Хост"

--- a/applications/luci-app-upnp/po/bn_BD/upnp.po
+++ b/applications/luci-app-upnp/po/bn_BD/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "পোর্ট"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/ca/upnp.po
+++ b/applications/luci-app-upnp/po/ca/upnp.po
@@ -31,7 +31,7 @@ msgid ""
 "allowed."
 msgstr ""
 "Els ACL especifiquen quins ports externs es poden redirigir a quines "
-"adreces i ports interns"
+"adreces i ports interns, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -177,11 +177,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -256,15 +256,3 @@ msgstr "Enllaç de pujada"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interval de neteja de regles"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Llindar de neteja de regles"
-
-#~ msgid "Host"
-#~ msgstr "Amfitrió"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valor en KByte/s, només per informació"

--- a/applications/luci-app-upnp/po/cs/upnp.po
+++ b/applications/luci-app-upnp/po/cs/upnp.po
@@ -27,7 +27,7 @@ msgid ""
 "allowed."
 msgstr ""
 "ACL stanovují, které vnější porty by měly být přesměrovány na které "
-"vnitřní adresy a porty"
+"vnitřní adresy a porty, IPv6 always allowed."
 
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
@@ -56,7 +56,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
 msgid "Allow adding port maps for requesting IP addresses only"
-msgstr "Povolit přesměrování pouze na dotazující ip adresy"
+msgstr "Povolit přesměrování pouze na dotazující IP adresy"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
@@ -174,12 +174,12 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN Hostitel"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
-msgstr "STUN Port"
+msgid "STUN port"
+msgstr "STUN port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
 msgid "Service Access Control List"
@@ -252,15 +252,3 @@ msgstr "Upload speed"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Použít %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interval čištění pravidel"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Práh čištění pravidel"
-
-#~ msgid "Host"
-#~ msgstr "Hostitel"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Pouze informační hodnoty (v KByte/s)"

--- a/applications/luci-app-upnp/po/da/upnp.po
+++ b/applications/luci-app-upnp/po/da/upnp.po
@@ -29,7 +29,7 @@ msgid ""
 "allowed."
 msgstr ""
 "ACL'er angiver, hvilke eksterne porte der kan omdirigeres til hvilke "
-"interne adresser og porte"
+"interne adresser og porte, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -57,7 +57,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
 msgid "Allow adding port maps for requesting IP addresses only"
-msgstr "Tillad kun at tilføje viderestillinger til ip-adresser, der anmoder om"
+msgstr "Tillad kun at tilføje viderestillinger til IP-adresser, der anmoder om"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
@@ -175,12 +175,12 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN vært"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
-msgstr "STUN Port"
+msgid "STUN port"
+msgstr "STUN port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
 msgid "Service Access Control List"
@@ -254,15 +254,3 @@ msgstr "Upload speed"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Brug %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interval for rene regler"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Tærskel for rene regler"
-
-#~ msgid "Host"
-#~ msgstr "Vært"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Værdi i KByte/s, kun til information"

--- a/applications/luci-app-upnp/po/de/upnp.po
+++ b/applications/luci-app-upnp/po/de/upnp.po
@@ -28,8 +28,8 @@ msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
-"ACLs definieren, welche externen Ports zu welchen internen Adressen und "
-"Ports weitergeleitet werden dürfen"
+"ACL definieren, welche externen Ports zu welchen internen Adressen und "
+"Ports weitergeleitet werden dürfen, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -175,11 +175,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN-Host"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN-Port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -254,15 +254,3 @@ msgstr "Upload speed"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "%s verwenden"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Aufräumintervall für Weiterleitungen"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Aufräumschwellenwert für Weiterleitungen"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Wert in Kilobyte/s, nur informativ"

--- a/applications/luci-app-upnp/po/el/upnp.po
+++ b/applications/luci-app-upnp/po/el/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "Θύρα"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/es/upnp.po
+++ b/applications/luci-app-upnp/po/es/upnp.po
@@ -177,11 +177,11 @@ msgid "SOAP/HTTP port"
 msgstr "Puerto"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Host STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Puerto STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -258,15 +258,3 @@ msgstr "Velocidad de carga"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utilizar %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalo de borrado de reglas"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Umbral de borrado de reglas"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valor en KBytes/s, sólo informativo"

--- a/applications/luci-app-upnp/po/fi/upnp.po
+++ b/applications/luci-app-upnp/po/fi/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "Portti"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -250,6 +250,3 @@ msgstr "Lähetysyhteys"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Käytä %s:ia"
-
-#~ msgid "Host"
-#~ msgstr "Palvelin"

--- a/applications/luci-app-upnp/po/fr/upnp.po
+++ b/applications/luci-app-upnp/po/fr/upnp.po
@@ -28,8 +28,8 @@ msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
-"Les ACLs définissent quels ports externes peuvent être redirigés, vers "
-"quelles adresses et ports internes"
+"Les ACL définissent quels ports externes peuvent être redirigés, vers "
+"quelles adresses et ports internes, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -178,11 +178,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Hôte STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Port STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -258,15 +258,3 @@ msgstr "Liaison montante"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utiliser %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalle des règles de nettoyage"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Niveau des règles de nettoyage"
-
-#~ msgid "Host"
-#~ msgstr "Hôte"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valeur en Ko/s, pour information seulement"

--- a/applications/luci-app-upnp/po/ga/upnp.po
+++ b/applications/luci-app-upnp/po/ga/upnp.po
@@ -177,12 +177,12 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN Óstach"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
-msgstr "STUN Port"
+msgid "STUN port"
+msgstr "STUN port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
 msgid "Service Access Control List"
@@ -258,15 +258,3 @@ msgstr "Luas uaslódála"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Bain úsáid as %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Eatramh rialacha glan"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Táirseach rialacha glan"
-
-#~ msgid "Host"
-#~ msgstr "Óstach"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Luach i KByte/s, eolasach amháin"

--- a/applications/luci-app-upnp/po/he/upnp.po
+++ b/applications/luci-app-upnp/po/he/upnp.po
@@ -171,11 +171,11 @@ msgid "SOAP/HTTP port"
 msgstr "פתחה"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/hi/upnp.po
+++ b/applications/luci-app-upnp/po/hi/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/hu/upnp.po
+++ b/applications/luci-app-upnp/po/hu/upnp.po
@@ -27,7 +27,7 @@ msgid ""
 "allowed."
 msgstr ""
 "Az ACL-ek határozzák meg, hogy melyik külső portok melyik belső portokra "
-"és címekre kerülhetnek továbbításra"
+"és címekre kerülhetnek továbbításra, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -175,11 +175,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -255,15 +255,3 @@ msgstr "Kifelé menő kapcsolat"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Szabály törlési időköz"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Szabály törlési küszöbérték"
-
-#~ msgid "Host"
-#~ msgstr "Gép"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Érték KByte/s-ban, csak tájékoztató jellegű"

--- a/applications/luci-app-upnp/po/it/upnp.po
+++ b/applications/luci-app-upnp/po/it/upnp.po
@@ -175,11 +175,11 @@ msgid "SOAP/HTTP port"
 msgstr "Porta"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Host STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Porta STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -254,15 +254,3 @@ msgstr "Velocità di upload"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Usa %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Cancella le regole"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Pulisci le regole degli eventi"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valori in KByte/s (informativo)"

--- a/applications/luci-app-upnp/po/ja/upnp.po
+++ b/applications/luci-app-upnp/po/ja/upnp.po
@@ -29,7 +29,7 @@ msgid ""
 "allowed."
 msgstr ""
 "アクセス制御リスト（ACL）は、どの外部ポートからどの内部アドレス及びポート"
-"へリダイレクトするかを設定します。"
+"へリダイレクトするかを設定します。, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -175,11 +175,11 @@ msgid "SOAP/HTTP port"
 msgstr "ポート"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN ホスト"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN ポート"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -254,15 +254,3 @@ msgstr "アップリンク"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "%s を使用"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "ルール消去間隔"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "ルール消去しきい値"
-
-#~ msgid "Host"
-#~ msgstr "ホスト"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "クライアントへの情報提供のみに使用される、KByte/sの値です"

--- a/applications/luci-app-upnp/po/ko/upnp.po
+++ b/applications/luci-app-upnp/po/ko/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "포트"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -250,6 +250,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "호스트"

--- a/applications/luci-app-upnp/po/lt/upnp.po
+++ b/applications/luci-app-upnp/po/lt/upnp.po
@@ -49,7 +49,7 @@ msgstr "Pažangūs nustatymai"
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
-"Reklamuoti/Skelbti kaip – „UPnP IGDv1“ įrenginį (be IPv6), vietoj „IGDv2“"
+"Reklamuoti/Skelbti kaip – „IGDv1“ įrenginį (be IPv6), vietoj „IGDv2“"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid "Allow"
@@ -177,11 +177,11 @@ msgid "SOAP/HTTP port"
 msgstr "Prievadas"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "„STUN“ skleidėjas/vedėjas"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "„STUN“ prievadas"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -232,7 +232,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json:3
 msgid "UPnP IGD & PCP"
-msgstr "„UPnP IGD & PCP“"
+msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
@@ -256,15 +256,3 @@ msgstr "Įkėlimo greitis"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Naudoti „%s“"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Išvalyti taisyklių intervalus"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Išvalyti taisyklių slenksčius"
-
-#~ msgid "Host"
-#~ msgstr "Skleidėjas/Vedėjas"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Reikšmė kilobaitais per sekundę (KB/s), tik informacinis"

--- a/applications/luci-app-upnp/po/mr/upnp.po
+++ b/applications/luci-app-upnp/po/mr/upnp.po
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "पोर्ट"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/ms/upnp.po
+++ b/applications/luci-app-upnp/po/ms/upnp.po
@@ -171,11 +171,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -248,6 +248,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Host"
-#~ msgstr "Hos"

--- a/applications/luci-app-upnp/po/nb_NO/upnp.po
+++ b/applications/luci-app-upnp/po/nb_NO/upnp.po
@@ -25,7 +25,7 @@ msgid ""
 "allowed."
 msgstr ""
 "ACL angir hvilke eksterne porter som kan bli viderekoblet, og til hvilke "
-"interne adresser og porter."
+"interne adresser og porter, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -171,11 +171,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN-vert"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN-port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -250,15 +250,3 @@ msgstr "Opplinje"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Bruk %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Nullstill UPnP Viderekoblinger intervall"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Nullstill UPnP terskel"
-
-#~ msgid "Host"
-#~ msgstr "Vert"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Verdi i KByte/sek, kun for informasjon"

--- a/applications/luci-app-upnp/po/nl/upnp.po
+++ b/applications/luci-app-upnp/po/nl/upnp.po
@@ -171,11 +171,11 @@ msgid "SOAP/HTTP port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/pl/upnp.po
+++ b/applications/luci-app-upnp/po/pl/upnp.po
@@ -49,7 +49,7 @@ msgstr "Ustawienia zaawansowane"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
-msgstr "Rozgłaszaj jako urządzenie UPnP IGDv1 (bez IPv6) zamiast IGDv2"
+msgstr "Rozgłaszaj jako urządzenie IGDv1 (bez IPv6) zamiast IGDv2"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid "Allow"
@@ -177,11 +177,11 @@ msgid "SOAP/HTTP port"
 msgstr "Port SOAP/HTTP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Host STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Port STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -258,15 +258,3 @@ msgstr "Prędkość wysyłania"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Użyj %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Interwał czyszczenia reguł"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Próg czyszczenia reguł"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Wartość w KB/s, tylko informacyjna"

--- a/applications/luci-app-upnp/po/pt/upnp.po
+++ b/applications/luci-app-upnp/po/pt/upnp.po
@@ -29,7 +29,7 @@ msgid ""
 "allowed."
 msgstr ""
 "Os ACL especificam quais as portas externas que podem ser redirecionadas "
-"para que endereços internos e portas"
+"para que endereços internos e portas, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -176,11 +176,11 @@ msgid "SOAP/HTTP port"
 msgstr "Porta"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Host STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Porta STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -255,15 +255,3 @@ msgstr "Ligação ascendente"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utilizar %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Limpar intervalo de regras"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Limpar limiar de regras"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valor em KByte/s, apenas informativo"

--- a/applications/luci-app-upnp/po/pt_BR/upnp.po
+++ b/applications/luci-app-upnp/po/pt_BR/upnp.po
@@ -28,7 +28,7 @@ msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
-"As ACLs especificam quais portas externas podem ser encaminhadas para "
+"As ACL especificam quais portas externas podem ser encaminhadas para "
 "quais endereços e portas de clientes, com IPv6 sempre será permitido."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
@@ -176,11 +176,11 @@ msgid "SOAP/HTTP port"
 msgstr "Porta"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Host STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Porta STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -255,15 +255,3 @@ msgstr "Velocidade de envio (upload)"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Use o %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalo de limpeza das regras"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Limiar de limpeza das regras"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valores em KByte/s, apenas informativas"

--- a/applications/luci-app-upnp/po/ro/upnp.po
+++ b/applications/luci-app-upnp/po/ro/upnp.po
@@ -28,7 +28,7 @@ msgid ""
 "allowed."
 msgstr ""
 "ACL-urile specifica porturile externe care pot fi redirectate si spre ce "
-"adrese si porturi interne"
+"adrese si porturi interne, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -56,7 +56,7 @@ msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
 msgid "Allow adding port maps for requesting IP addresses only"
-msgstr "Permite adaugarea forward-urilor doar catre adresele ip solicitante"
+msgstr "Permite adaugarea forward-urilor doar catre adresele IP solicitante"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
@@ -174,11 +174,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Gazda STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Portul STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -253,15 +253,3 @@ msgstr "Legătură ascendentă"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utilizați %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Intervalul de curatare reguli"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Limita de curatare reguli"
-
-#~ msgid "Host"
-#~ msgstr "Gazdă"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Valorea in KOcteti/s , doar informational"

--- a/applications/luci-app-upnp/po/ru/upnp.po
+++ b/applications/luci-app-upnp/po/ru/upnp.po
@@ -176,11 +176,11 @@ msgid "SOAP/HTTP port"
 msgstr "Порт"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Хост STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Порт STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -255,15 +255,3 @@ msgstr "Внешнее соединение"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Использовать %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Интервал очистки правил"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Порог очистки правил"
-
-#~ msgid "Host"
-#~ msgstr "Устройство"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Значение в КБ/с, только для информации"

--- a/applications/luci-app-upnp/po/sk/upnp.po
+++ b/applications/luci-app-upnp/po/sk/upnp.po
@@ -171,11 +171,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -249,15 +249,3 @@ msgstr ""
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Vymazať interval pravidiel"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Vymazať prah pravidiel"
-
-#~ msgid "Host"
-#~ msgstr "Hostiteľ"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Hodnota v KBajtoch za sekundu, iba informatívne"

--- a/applications/luci-app-upnp/po/sv/upnp.po
+++ b/applications/luci-app-upnp/po/sv/upnp.po
@@ -29,7 +29,7 @@ msgid ""
 "allowed."
 msgstr ""
 "ACL:er anger vilka externa portar som ska omdirigeras till vilka interna "
-"adresser och portar"
+"adresser och portar, IPv6 always allowed."
 
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
@@ -50,7 +50,7 @@ msgstr "Avancerade inställningar"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
-msgstr "Annonsera som UPnP IGDv1-enhet (ingen IPv6) istället för IGDv2"
+msgstr "Annonsera som IGDv1-enhet (ingen IPv6) istället för IGDv2"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid "Allow"
@@ -176,11 +176,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN-värd"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN-port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -255,9 +255,3 @@ msgstr "Upplänk"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Använd %s"
-
-#~ msgid "Host"
-#~ msgstr "Värd"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Värde i KByte/s, endast informell"

--- a/applications/luci-app-upnp/po/templates/upnp.pot
+++ b/applications/luci-app-upnp/po/templates/upnp.pot
@@ -160,11 +160,11 @@ msgid "SOAP/HTTP port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/tr/upnp.po
+++ b/applications/luci-app-upnp/po/tr/upnp.po
@@ -27,7 +27,7 @@ msgid ""
 "allowed."
 msgstr ""
 "ACL'ler, hangi harici bağlantı noktalarının hangi dahili adreslere ve "
-"bağlantı noktalarına yeniden yönlendirilebileceğini belirtir."
+"bağlantı noktalarına yeniden yönlendirilebileceğini belirtir, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -55,7 +55,7 @@ msgstr "İzin ver"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
 msgid "Allow adding port maps for requesting IP addresses only"
-msgstr "Yalnızca istekte bulunan ip adreslerine yönlendirme eklemeye izin ver"
+msgstr "Yalnızca istekte bulunan IP adreslerine yönlendirme eklemeye izin ver"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Announced model number"
@@ -173,11 +173,11 @@ msgid "SOAP/HTTP port"
 msgstr "Bağlantı noktası"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN Ana Bilgisayarı"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN Bağlantı Noktası"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -252,15 +252,3 @@ msgstr "Yükleme hızı"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "%s kullan"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Temiz kurallar aralığı"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Temiz kural eşiği"
-
-#~ msgid "Host"
-#~ msgstr "Ana bilgisayar"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "KBayt/sn cinsinden değer, yalnızca bilgi amaçlı"

--- a/applications/luci-app-upnp/po/uk/upnp.po
+++ b/applications/luci-app-upnp/po/uk/upnp.po
@@ -28,7 +28,7 @@ msgid ""
 "allowed."
 msgstr ""
 "Список контролю доступу (ACL) визначає, які зовнішні порти можуть бути "
-"переспрямовані на які внутрішні адреси й порти"
+"переспрямовані на які внутрішні адреси й порти, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -175,11 +175,11 @@ msgid "SOAP/HTTP port"
 msgstr "Порт"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "Хост STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "Порт STUN"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -254,15 +254,3 @@ msgstr "Висхідне з'єднання"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Використовувати %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Інтервал очищення правил"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Поріг очищення правил"
-
-#~ msgid "Host"
-#~ msgstr "Вузол"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Значення (КБ/с), тільки для інформації"

--- a/applications/luci-app-upnp/po/vi/upnp.po
+++ b/applications/luci-app-upnp/po/vi/upnp.po
@@ -30,8 +30,8 @@ msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
-"ACLs chỉ định cổng bên ngoài nào có thể được chuyển hướng đến địa chỉ và "
-"cổng nội bộ nào"
+"ACL chỉ định cổng bên ngoài nào có thể được chuyển hướng đến địa chỉ và "
+"cổng nội bộ nào, IPv6 always allowed."
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Action"
@@ -177,12 +177,12 @@ msgid "SOAP/HTTP port"
 msgstr "Cổng"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
-msgstr "STUN Host"
+msgid "STUN host"
+msgstr "STUN host"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
-msgstr "STUN Port"
+msgid "STUN port"
+msgstr "STUN port"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
 msgid "Service Access Control List"
@@ -256,15 +256,3 @@ msgstr "Tuyến lên"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Sử dụng %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "Khoảng thời gian quy tắc sạch"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "Clean rules threshold"
-
-#~ msgid "Host"
-#~ msgstr "Host"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "Giá trị tính bằng KByte/s, chỉ mang tính thông tin"

--- a/applications/luci-app-upnp/po/yua/upnp.po
+++ b/applications/luci-app-upnp/po/yua/upnp.po
@@ -172,11 +172,11 @@ msgid "SOAP/HTTP port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr ""
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195

--- a/applications/luci-app-upnp/po/zh_Hans/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hans/upnp.po
@@ -176,11 +176,11 @@ msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP 端口"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN 主机"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN 端口"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -253,15 +253,3 @@ msgstr "上传速度"
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "使用 %s"
-
-#~ msgid "Clean rules interval"
-#~ msgstr "定时清除规则"
-
-#~ msgid "Clean rules threshold"
-#~ msgstr "清除规则阈值"
-
-#~ msgid "Host"
-#~ msgstr "主机"
-
-#~ msgid "Value in KByte/s, informational only"
-#~ msgstr "单位为 KByte/s，仅供参考"

--- a/applications/luci-app-upnp/po/zh_Hant/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hant/upnp.po
@@ -41,7 +41,7 @@ msgstr "活動的連接埠轉發"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
-msgstr "活動的UPnP & PCP/NAT-PMP連接埠轉發"
+msgstr "活動的UPnP IGD & PCP/NAT-PMP連接埠轉發"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
 msgid "Advanced Settings"
@@ -117,7 +117,7 @@ msgstr "啓用PCP/NAT-PMP功能"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
 msgid "Enable UPnP IGD protocol"
-msgstr "启用UPnP"
+msgstr "启用UPnP IGD"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
 msgid "Enable additional logging"
@@ -135,7 +135,7 @@ msgstr "外部埠"
 
 #: applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json:3
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
-msgstr "授予存取UPnP的權限"
+msgstr "授予存取UPnP IGD & PCP/NAT-PMP的權限"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
 msgid "Notify interval"
@@ -175,11 +175,11 @@ msgid "SOAP/HTTP port"
 msgstr "連接埠"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
+msgid "STUN host"
 msgstr "STUN主機"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
+msgid "STUN port"
 msgstr "STUN埠"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
@@ -233,7 +233,7 @@ msgstr "UPnP IGD & PCP"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
 msgid "UPnP IGD & PCP/NAT-PMP Service"
-msgstr "UPnP & PCP/NAT-PMP服務"
+msgstr "UPnP IGD & PCP/NAT-PMP服務"
 
 #: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "UPnP IGDv1 compatibility mode"


### PR DESCRIPTION
- Hotfix that reverts commit 7a7f9ec, which seemed cosmetic and unimportant, but changes defaults and disables both protocols/(service) on next save/apply
- Manually add the `IPv6 always allowed` note (in english) to the translations, as this is important, and fix the old texts that were not intended to be carried over but were committed in 9c403f5 and 2e46cfc, and re-remove the obsolete translations restored by the additional commits

For the intro/ACL texts (and some others), the consideration was that the original text was already old, had been changed several times by developers rather than translators, and had undergone four changes since the 23.05 release (missing IPv6 hint, ACLs->ACL, redirected->mapped, shortened sentence), so I decided to have them retranslated to maintain the meaning and integrity of the translations. I think there should be a policy that if e.g. security relevant or the meaning or multiple parts of a sentence have changed, a new translation should be enforced.

IMHO, it was not worth the effort/trouble (the 2nd time) of the additional hasty untested code/commits shortly after merging PR #7407, also because it introduced buggy code that caused a regression and added old text that should have been retranslated, also when I see how fast the translation works. The newly added strings were translated into chinese in less than 6 hours after the PR was merged, now 100% in four languages.

I think we can say that the LuCi plugin is now in good shape after this latest hotfix, except for the 24.10 daemon package which has the issue that the nftable rules are not deleted correctly and the port map listing functions always return a port of `0`, see miniupnp/miniupnp#768, miniupnp/miniupnp@d07b0a1 and point 4 in https://github.com/openwrt/luci/pull/7407#issuecomment-2493345487. A fix can be added as a separate commit to openwrt/packages#24988 if desired.