### PR TITLE
luci-proto-wireguard: Fix incorrect peer detection for IP v6

### DIFF
--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -17,10 +17,11 @@ function command(cmd) {
 
 function checkPeerHost(configHost, configPort, wgHost) {
 	const ips = popen(`resolveip ${configHost} 2>/dev/null`);
+	const hostIp = replace(wgHost, /\[|\]/g, "");
 	if (ips) {
 		for (let line = ips.read('line'); length(line); line = ips.read('line')) {
 			const ip =  rtrim(line, '\n');
-			if (ip + ":" + configPort == wgHost) {
+			if (ip + ":" + configPort == hostIp) {
 				return true;
 			}
 		}


### PR DESCRIPTION
This commit fixes incorrect peer detection when using IP v6 by deleting all the square the square brackets from the wgHost variable.

Signed-off-by: Tom Haley <this_username_has_been_taken2@proton.me>

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile **Not applicable: luci-proto-wireguard does not have `PKG_VERSION` in the Makefile**
- [X] Tested on: x86/64, OpenWrt 23.05.5, Chrome :white_check_mark:
- [X] \( Preferred ) Mention: @systemcrash
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: openwrt/luci#7436
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
