### PR TITLE
luci-proto-wireguard: fixed a vulnerability in the checkPeerHost method

### DIFF
--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -16,7 +16,7 @@ function command(cmd) {
 }
 
 function checkPeerHost(configHost, configPort, wgHost) {
-	const ips = popen(`resolveip ${configHost} 2>/dev/null`);
+	const ips = popen(`resolveip ${shellquote(configHost)} 2>/dev/null`);
 	const hostIp = replace(wgHost, /\[|\]/g, "");
 	if (ips) {
 		for (let line = ips.read('line'); length(line); line = ips.read('line')) {

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -20,10 +20,10 @@ function checkPeerHost(configHost, configPort, wgHost) {
 	const hostIp = replace(wgHost, /\[|\]/g, "");
 	if (ips) {
 		for (let line = ips.read('line'); length(line); line = ips.read('line')) {
-			const ip =  rtrim(line, '\n');
+			const ip = rtrim(line, '\n');
 			if (configPort && (ip + ":" + configPort == hostIp)) {
 				return true;
-			} else if (ip == substr(hostIp, 0, index(hostIp, ":"))) {
+			} else if (ip == substr(hostIp, 0, rindex(hostIp, ":"))) {
 				return true;
 			}
 		}

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -21,14 +21,15 @@ function checkPeerHost(configHost, configPort, wgHost) {
 	if (ips) {
 		for (let line = ips.read('line'); length(line); line = ips.read('line')) {
 			const ip =  rtrim(line, '\n');
-			if (ip + ":" + configPort == hostIp) {
+			if (configPort && (ip + ":" + configPort == hostIp)) {
+				return true;
+			} else if (ip == substr(hostIp, 0, index(hostIp, ":"))) {
 				return true;
 			}
 		}
 	}
 	return false;
 }
-
 
 const methods = {
 	generatePsk: {


### PR DESCRIPTION
This PR fixes a vulnerability when a random code can be passed into the `configHost` variable and then it will be executed by  the `popen` command.
To fix the issue the variable is sanitized via `shellquote` method.

For a more detailed description please refer to #7452 

Signed-off-by: Tom Haley <this_username_has_been_taken2@proton.me>

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile. **Not applicable: luci-proto-wireguard does not have `PKG_VERSION` in the Makefile**
- [X] Tested on: live OpwnWrt system, aarch64_cortex-a53, SNAPSHOT as of 2024-12-10, Firefox :white_check_mark:
- [X] \( Preferred ) Mention: @systemcrash , @jow- 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: e.g. openwrt/luci#7452
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: See above
