### PR TITLE
luci-compat: CBI skip fields that do not satisfy depends

### DIFF
--- a/modules/luci-compat/luasrc/cbi.lua
+++ b/modules/luci-compat/luasrc/cbi.lua
@@ -1443,7 +1443,7 @@ function AbstractValue.parse(self, section, novld)
 				--luci.util.append(self.map.events, self.events)
 			end
 		end
-	else							-- Unset the UCI or error
+	elseif fvalue ~= nil then			-- Unset the UCI or error
 		if self.rmempty or self.optional then
 			if not self.alias or
 			   not self.section.aliased or


### PR DESCRIPTION
If depends is not satisfied, the fvalue will be nil.

@jow- 

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (aarch64, openwrt 22.03, chrome) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)

A simple test code (`model/cbi/abc.lua`):

```lua
local m, s, o

m = Map("floatip", translate("FloatingGateway"))

s=m:section(NamedSection, "main", translate("Global settings"))
s.anonymous=true

o = s:option(Flag, "enabled", translate("Enable"))
o.rmempty = false

o = s:option(ListValue, "role", translate("Node Role"))
o.rmempty = false
o.widget = "select"
o:value("main", translate("Preempt Node"))
o:value("fallback", translate("Fallback Node"))

o = s:option(Value, "set_ip", translate("Floating Gateway IP"))
o.rmempty = false
o.datatype = "or(ip4addr,cidr4)"

o = s:option(Value, "check_ip", translate("Preempt Node IP"))
o.rmempty = false
o.datatype = "ip4addr"
o:depends("role", "fallback")

return m
```

Without this patch, when "role" changes from "fallback" to "main", save will failed with 'missing' error (`One or more required fields have no value!`).
