### PR TITLE
luci-app-hd-idle: Check disk opt value

### DIFF
--- a/applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js
+++ b/applications/luci-app-hd-idle/htdocs/luci-static/resources/view/hd_idle.js
@@ -9,7 +9,7 @@ function disk(devs, options, section_id) {
 	var disk = devs.find(function(itm){ return itm.name == v; });
 	var out = '';
 	if(disk != undefined){
-		out = options.map(function(opt){ return disk[opt].trim(); });
+		out = options.map(function(opt){ return disk[opt]?.trim() || null; });
 		out = out.filter(function(o){ return o != ''; });
 		out = out.join(' ');
 	}


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: x86_64, OpenWrt23.05.5, Chrome/Edge/Vivaldi :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

Result of `lsblk` may have some null values, check it before trim.
```
[root@OpenWrt ~]# /usr/bin/lsblk -n -J -do "NAME,TRAN,ROTA,RM,VENDOR,MODEL"
{
  "blockdevices": [
    {
      "name": "sda",
      "tran": null,
      "rota": true,
      "rm": false,
      "vendor": "QEMU      ",
      "model": "QEMU HARDDISK   "
    },
    {
      "name": "zram0",
      "tran": null,
      "rota": false,
      "rm": false,
      "vendor": null,
      "model": null
    }
  ]
}
```

