### PR TITLE
luci-proto-ipv6: add missing extendprefix option for DHCPv6 client

### DIFF
--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -2703,7 +2703,11 @@ msgid ""
 "packets."
 msgstr ""
 
-#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:33
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:34
+msgid "Extend prefix"
+msgstr ""
+
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:36
 msgid "Do not send a Release when restarting"
 msgstr ""
 
@@ -3187,6 +3191,10 @@ msgid "Enable this network"
 msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:34
+msgid "Extend 3GPP WAN interface /64 prefix via PD to LAN (RFC 7278)"
+msgstr ""
+
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:37
 msgid "Enable to minimise the chance of prefix change after a restart"
 msgstr ""
 

--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
@@ -30,6 +30,9 @@ return network.registerProtocol('dhcpv6', {
 		o.value('60');
 		o.value('64');
 		o.default = 'auto';
+
+		o = s.taboption('general', form.Flag, 'extendprefix', _('Extend prefix'), _('Extend 3GPP WAN interface /64 prefix via PD to LAN (RFC 7278)'));
+
 		o = s.taboption('general', form.Flag, 'norelease', _('Do not send a Release when restarting'),
 						_('Enable to minimise the chance of prefix change after a restart'));
 		o.default = '1';


### PR DESCRIPTION
add missing `extendprefix` option for DHCPv6 client (see https://openwrt.org/docs/guide-user/network/ipv6/configuration#protocol_dhcpv6)
Allow the DHCPv6 client to accept /64 prefix via SLAAC and extend it on downstream interface (RFC 7278) 
useful for ISPs that only distribute /64 IPv6 prefixes through SLAAC:
```
Internet Control Message Protocol v6
    Type: Router Advertisement (134)
    Code: 0
    Checksum: 0x453d [correct]
    [Checksum Status: Good]
    Cur hop limit: 64
    Flags: 0x40, Other configuration, Prf (Default Router Preference): Medium
    Router lifetime (s): 1800
    Reachable time (ms): 300000
    Retrans timer (ms): 10000
    ICMPv6 Option (Source link-layer address : **:**:**:**:**:**)
    ICMPv6 Option (Prefix information : 240b:10:****:****::/64)
        Type: Prefix information (3)
        Length: 4 (32 bytes)
        Prefix Length: 64
        Flag: 0xc0, On-link flag(L), Autonomous address-configuration flag(A)
        Valid Lifetime: 2592000 (30 days)
        Preferred Lifetime: 604800 (7 days)
        Reserved
        Prefix: 240b:10:****:****::

```
![1](https://github.com/user-attachments/assets/cfc99427-c116-491e-9b0f-92d6d1f3656d)


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
