### PR TITLE
luci-app-pbr: update to 1.1.8

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.1.7
-PKG_RELEASE:=47
+PKG_VERSION:=1.1.8
+PKG_RELEASE:=2
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-pbr/

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get ReadmeCompat() {
-		return "1.1.7-39";
+		return "1.1.8";
 	},
 	get URL() {
 		return (
@@ -32,37 +32,37 @@ var pkg = {
 	},
 };
 
-const getGateways = rpc.declare({
+var getGateways = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getGateways",
 	params: ["name"],
 });
 
-const getInitList = rpc.declare({
+var getInitList = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitList",
 	params: ["name"],
 });
 
-const getInitStatus = rpc.declare({
+var getInitStatus = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInitStatus",
 	params: ["name"],
 });
 
-const getInterfaces = rpc.declare({
+var getInterfaces = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getInterfaces",
 	params: ["name"],
 });
 
-const getPlatformSupport = rpc.declare({
+var getPlatformSupport = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "getPlatformSupport",
 	params: ["name"],
 });
 
-const _setInitAction = rpc.declare({
+var _setInitAction = rpc.declare({
 	object: "luci." + pkg.Name,
 	method: "setInitAction",
 	params: ["name", "action"],


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0-rc2
Run tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0-rc2

Description:
* match version with principal package
* update README version
* use var instead of const for RPCD objects
