### PR TITLE
luci-app-upnp: Add `Expires` to port map listing

### DIFF
--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -4,8 +4,6 @@
 'require rpc';
 'require uci';
 
-
-
 const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',
@@ -37,7 +35,6 @@ return baseclass.extend({
 	},
 
 	render: function(data) {
-
 		var table = E('table', { 'class': 'table', 'id': 'upnp_status_table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Client Name')),
@@ -45,6 +42,7 @@ return baseclass.extend({
 				E('th', { 'class': 'th' }, _('Client Port')),
 				E('th', { 'class': 'th' }, _('External Port')),
 				E('th', { 'class': 'th' }, _('Protocol')),
+				E('th', { 'class': 'th right' }, _('Expires')),
 				E('th', { 'class': 'th' }, _('Description')),
 				E('th', { 'class': 'th cbi-section-actions' }, '')
 			])
@@ -53,12 +51,24 @@ return baseclass.extend({
 		var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
 
 		var rows = rules.map(function(rule) {
+			const padnum = (num, length) => num.toString().padStart(length, "0");
+			const expires_sec = rule?.expires || 0;
+			const hour = Math.floor(expires_sec / 3600);
+			const minute = Math.floor((expires_sec % 3600) / 60);
+			const second = Math.floor(expires_sec % 60);
+			const expires_str =
+				hour > 0 ? `${hour}h ${padnum(minute, 2)}m ${padnum(second, 2)}s` :
+				minute > 0 ? `${minute}m ${padnum(second, 2)}s` :
+				expires_sec > 0 ? `${second}s` :
+				'';
+
 			return [
 				rule.host_hint || _('Unknown'),
 				rule.intaddr,
 				rule.intport,
 				rule.extport,
 				rule.proto,
+				expires_str,
 				rule.descr,
 				E('button', {
 					'class': 'btn cbi-button-remove',

--- a/applications/luci-app-upnp/po/ar/upnp.po
+++ b/applications/luci-app-upnp/po/ar/upnp.po
@@ -15,7 +15,7 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -24,111 +24,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "إجراء"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "إعدادات متقدمة"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "تعليق"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "احدف"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "الوصف"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -136,76 +141,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "البروتوكول"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "المنفذ"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "الاعدادات العامة"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -214,13 +219,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -229,25 +234,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "مجهول"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/bg/upnp.po
+++ b/applications/luci-app-upnp/po/bg/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Действие"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Разширени настройки"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Коментар"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Изтрий"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -135,76 +140,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Порт"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Общи настройки"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/bn_BD/upnp.po
+++ b/applications/luci-app-upnp/po/bn_BD/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "উন্নত সেটিংস"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "বর্ণনা"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -135,76 +140,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "প্রোটোকল"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "পোর্ট"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "সাধারণ সেটিংস"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "অজানা"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/ca/upnp.po
+++ b/applications/luci-app-upnp/po/ca/upnp.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -25,7 +25,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -33,105 +33,110 @@ msgstr ""
 "Els ACL especifiquen quins ports externs es poden redirigir a quines adreces "
 "i ports interns, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Acció"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Redireccions actives"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Configuració avançada"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Permet que s'afegeixin redireccions només a les adreces IP peticionant"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Número de model anunciat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Número de sèrie anunciat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Adreça de client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port de client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Commentari"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Descripció"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID de dispositiu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Enllaç de baixada"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Habilita el registre addicional"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Habilita mode segur"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Port extern"
 
@@ -139,76 +144,76 @@ msgstr "Port extern"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Interval de notificació"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Posa informació extra de depuració en el registre de sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Reporta el temps actiu del sistema en lloc del del dimoni"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Paràmetres generals"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -218,13 +223,13 @@ msgid ""
 msgstr ""
 "%s permet als clients de la xarxa local configurar automàticament el router."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "No hi ha redireccions actives."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -233,25 +238,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Enllaç de pujada"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/cs/upnp.po
+++ b/applications/luci-app-upnp/po/cs/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.8.2-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,7 +21,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -29,105 +29,110 @@ msgstr ""
 "ACL stanovují, které vnější porty by měly být přesměrovány na které vnitřní "
 "adresy a porty, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Akce"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktivní přesměrování"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Pokročilá nastavení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Inzerovat jako IGDv1 zařízení místo IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Povolit přesměrování pouze na dotazující IP adresy"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Oznámené číslo modelu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Oznámené sériové číslo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Adresa klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Komentář"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Odstranit"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID zařízení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Download speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Povolit přídavné logování"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Povolit bezpečný režim"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Vnější port"
 
@@ -135,76 +140,76 @@ msgstr "Vnější port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Interval oznamování"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Prezentační URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Vypisovat extra ladící informace do systémového záznamu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Hlásit uptime systému namísto uptime daemonu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN Hostitel"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Obecná nastavení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr "%s umožňuje klientům v místní síti automaticky nakonfigurovat router."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Neexistují žádná aktivní přesměrování."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Povolit režim UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Neznámé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Upload speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Použít %s"

--- a/applications/luci-app-upnp/po/da/upnp.po
+++ b/applications/luci-app-upnp/po/da/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9.1-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,105 +31,110 @@ msgstr ""
 "ACL'er angiver, hvilke eksterne porte der kan omdirigeres til hvilke interne "
 "adresser og porte, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Handling"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktive omdirigeringer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Avancerede indstillinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annoncerer som IGDv1-enhed i stedet for IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Tillad kun at tilføje viderestillinger til IP-adresser, der anmoder om"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Annonceret modelnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Annonceret serienummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Klient adresse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Klient port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Kommentar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Slet"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Enhedens UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Download speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Aktiver yderligere logning"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Aktiver sikker tilstand"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Ekstern port"
 
@@ -137,76 +142,76 @@ msgstr "Ekstern port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Underretningsinterval"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL til præsentation"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Sætter ekstra fejlfindingsoplysninger i systemloggen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Rapportere system i stedet for dæmonens oppetid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN vært"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Generelle indstillinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgstr ""
 "%s gør det muligt for klienter i det lokale netværk at konfigurere routeren "
 "automatisk."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Der er ingen aktive omdirigeringer."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Aktiver UPnP IGDv1-tilstand"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Upload speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Brug %s"

--- a/applications/luci-app-upnp/po/de/upnp.po
+++ b/applications/luci-app-upnp/po/de/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,105 +31,110 @@ msgstr ""
 "ACL definieren, welche externen Ports zu welchen internen Adressen und Ports "
 "weitergeleitet werden dürfen, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Aktion"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktive Weiterleitungen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Als IGDv1-Gerät anstelle von IGDv2 bekanntgeben"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Erlauben"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Nur Weiterleitungen zurück zum anfordernden Client zulassen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Angekündigte Modellnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Angekündigte Seriennummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Clientadresse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Clientport"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Kommentar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Löschen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Ablehnen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Beschreibung"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Geräte-UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Download-Bandbreite"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Erweiterte Protokollierung aktivieren"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Sicheren Modus aktivieren"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Externer Port"
 
@@ -137,76 +142,76 @@ msgstr "Externer Port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Benachrichtigungsintervall"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Präsentations-URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Schreibt zusätzliche Debug-Informationen in das Systemprotokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Systemlaufzeit statt Prozesslaufzeit melden"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN-Host"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN-Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgstr ""
 "%s erlaubt es Clients im lokalen Netzwerk automatisch Port-Weiterleitungen "
 "auf diesem Router einzurichten."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Es gibt keine aktiven Weiterleitungen."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "UPnP IGDv1 Modus aktivieren"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Upload speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "%s verwenden"

--- a/applications/luci-app-upnp/po/el/upnp.po
+++ b/applications/luci-app-upnp/po/el/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Δράση"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Ρυθμίσεις για προχωρημένους"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Σχόλιο"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -135,76 +140,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Πρωτόκολλο"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Θύρα"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Γενικές ρυθμίσεις"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Ταχύτητα μεταφόρτωσης"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/es/upnp.po
+++ b/applications/luci-app-upnp/po/es/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -25,7 +25,7 @@ msgstr ""
 "Un intervalo de 900 s dará lugar a %s notificaciones con una edad máxima "
 "mínima de 1800 s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -34,106 +34,111 @@ msgstr ""
 "pueden ser reenviados hacía las direcciones IP y puertos del cliente. Las "
 "direcciones IPv6 siempre son permitidas."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Acción"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Reenvíos de puertos activos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "Mapas de puertos UPnP IGD y PCP/NAT-PMP activos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Ajustes avanzados"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Anunciar como dispositivo UPnP IGDv1 (sin IPv6) en lugar de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Permitir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permitir agregar reenvíos de puertos solo a direcciones IP solicitantes"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Número de modelo anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Número de serie anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Dirección del cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "Nombre del cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Puerto del cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Comentario"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Eliminar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Denegar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Descripción"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID del dispositivo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Velocidad de descarga"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Activar protocolos PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "Activar protocolo UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Activar registro adicional"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Activar modo seguro"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Puerto externo"
 
@@ -141,77 +146,77 @@ msgstr "Puerto externo"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Conceder acceso a UPnP IGD y PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Intervalo de notificación"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL de presentación"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Coloca información de depuración adicional en el registro del sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 "URL de la interfaz web (presentación) del enrutador personalizado del informe"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "Informar de la velocidad máxima de descarga en kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "Informar de la velocidad máxima de subida en kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Informar tiempo de actividad del sistema en vez de la del servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Puerto"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Puerto STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Lista de control de acceso al servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "Ajustes del Servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Ajustes generales"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "Archivo de tiempo de concesión del servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "Iniciar el servicio de asignación de puertos autónomos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "Iniciar servicio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -222,13 +227,13 @@ msgstr ""
 "%s permiten a los clientes de la red local configurar automáticamente el "
 "reenvío de puertos en el enrutador."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "No hay reenvíos de puertos vigentes."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -239,25 +244,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD y PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Servicio UPnP IGD y PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Activar UPnP modo IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Velocidad de carga"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utilizar %s"

--- a/applications/luci-app-upnp/po/fi/upnp.po
+++ b/applications/luci-app-upnp/po/fi/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Toiminta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktiivise uudelleenohjaukset"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Kommentti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Poista"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Kuvaus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Laitteen UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Ulkoinen portti"
 
@@ -135,76 +140,76 @@ msgstr "Ulkoinen portti"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Ilmoitusväli"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokolla"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Portti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Yleiset asetukset"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Ei aktiivisia uudelleenohjauksia."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Käytä UPnP IGDv1-tilaa"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Lähetysyhteys"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Käytä %s:ia"

--- a/applications/luci-app-upnp/po/fr/upnp.po
+++ b/applications/luci-app-upnp/po/fr/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -25,8 +25,7 @@ msgstr ""
 "Un intervalle de 900s indique qu'il y aura %s notifications avec une valeur "
 "max-age ayant pour minimum 1800s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -34,132 +33,112 @@ msgstr ""
 "Les ACL définissent quels ports externes peuvent être redirigés, vers "
 "quelles adresses et ports internes, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Action"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Redirections actives"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:119
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:130
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annoncer comme dispositif IGDv1 au lieu de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:156
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permet d'ajouter des redirections seulement vers les adresses IP qui font "
 "des demandes"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Numéro de modèle annoncé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:182
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Numéro de série annoncé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:84
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:203
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Adresse du client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:83
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:85
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:207
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port du client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Commentaire"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:106
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Effacer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:217
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Description"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:176
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID du périphérique"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Liaison descendante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:127
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:189
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Activer la journalisation additionnelle"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:155
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Activer le mode sécurisé"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:86
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:211
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Port externe"
 
@@ -167,93 +146,77 @@ msgstr "Port externe"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:160
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Intervalle de notification"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:171
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL de présentation"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocole"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:190
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Rajoute des informations de debug dans le journal-système"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:172
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:140
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 "Indiquer la durée de fonctionnement du système plutôt que celle du démon UPnP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:166
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Hôte STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Port STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:195
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:116
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:118
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Réglages généraux"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:121
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -264,15 +227,13 @@ msgstr ""
 "%s permet à des clients du réseau local de configurer automatiquement le "
 "routeur."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:110
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Il n'y a pas de redirections actives."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -281,41 +242,34 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:75
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Activer le mode UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:97
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Inconnue"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:139
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Liaison montante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utiliser %s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
-msgid "STUN Host"
-msgstr "Hôte STUN"
+#~ msgid "STUN Host"
+#~ msgstr "Hôte STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
-msgid "STUN Port"
-msgstr "Port STUN"
+#~ msgid "STUN Port"
+#~ msgstr "Port STUN"
 
 #~ msgid "Clean rules interval"
 #~ msgstr "Intervalle des règles de nettoyage"

--- a/applications/luci-app-upnp/po/ga/upnp.po
+++ b/applications/luci-app-upnp/po/ga/upnp.po
@@ -15,7 +15,7 @@ msgstr ""
 "n>6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Mar thoradh ar eatramh 900s beidh %s fógraí leis an aois uasta íosta de 1800í"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -33,105 +33,110 @@ msgstr ""
 "Sonraíonn ACLanna cé na calafoirt sheachtracha is féidir a chur ar aghaidh "
 "chuig a seoltaí cliant agus calafoirt, IPv6 ceadaithe i gcónaí."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Gníomhaíocht"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Port Gníomhach ar Aghaidh"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "Léarscáileanna Gníomhacha UPnP IGD & PCP/NAT-PMP Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Socruithe chun cinn"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Fógairt mar ghléas UPnP IGDv1 (gan IPv6) in ionad IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Ceadaigh"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Ceadaigh port a chur ar aghaidh chuig seoltaí IP amháin a iarrtar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Uimhir mhúnla fógartha"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Sraithuimhir fógartha"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Seoladh Cliant"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "Ainm an Chliaint"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port Cliant"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Trácht"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Scrios"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Shéanadh"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Cur síos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID Gléas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Gá le luas a íoslódáil"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Cumasaigh prótacal PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "Cumasaigh prótacal UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Cumasaigh logáil bhreise"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Cumasaigh mód slán"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Port Seachtrach"
 
@@ -139,77 +144,77 @@ msgstr "Port Seachtrach"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Deonaigh rochtain ar UPnP IGD & PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Eatramh fógra"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL cur i láthair"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Prótacal"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Cuireann sé faisnéis bhreise dífhabhtaithe isteach i loga an chórais"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 "Tuairiscigh URL comhéadan gréasáin ródaire saincheaptha (cur i láthair)"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "Tuairiscigh an t-uasluas íoslódála i kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "Tuairiscigh an t-uasluas uaslódála i kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Córas tuairisce in ionad aga fónaimh seirbhíse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN Óstach"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Liosta Rialaithe Rochtana Seirbhíse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "Socruithe Seirbhíse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Socruithe Ginearálta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "Comhad léasa seirbhíse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "Cuir tús le seirbhís mapála calafoirt uathrialach"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "Tosaigh seirbhís"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -221,13 +226,13 @@ msgstr ""
 "ródaire a chumrú go huathoibríoch. Tugtar Breiseán Uilíoch agus Súgradh air "
 "freisin."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Níl aon phort gníomhach ar aghaidh."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -237,25 +242,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & Seirbhís PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Cumasaigh mód UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Anaithnid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Luas uaslódála"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Bain úsáid as %s"

--- a/applications/luci-app-upnp/po/he/upnp.po
+++ b/applications/luci-app-upnp/po/he/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,111 +21,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "פעולה"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "הגדרות מתקדמות"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "תגובה"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "תיאור"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -133,76 +138,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "פתחה"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -211,13 +216,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -226,25 +231,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/hi/upnp.po
+++ b/applications/luci-app-upnp/po/hi/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "उन्नत सेटिंग्स"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -135,76 +140,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "अज्ञात"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/hu/upnp.po
+++ b/applications/luci-app-upnp/po/hu/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,7 +21,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -29,107 +29,112 @@ msgstr ""
 "Az ACL-ek határozzák meg, hogy melyik külső portok melyik belső portokra és "
 "címekre kerülhetnek továbbításra, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Művelet"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktív átirányítások"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Haladó beállítások"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Hirdetés IGDv1 eszközként IGDv2 helyett"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Kizárólag a kérést küldő IP címre történő továbbítás hozzáadásának "
 "engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Bejelentett modellszám"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Bejelentett sorozatszám"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Megjegyzés"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Törlés"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Leírás"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Eszköz UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Befelé jövő kapcsolat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "További naplózás engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Biztonságos mód engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Külső port"
 
@@ -137,76 +142,76 @@ msgstr "Külső port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Értesítési időköz"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Bemutató URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "További hibakeresési információkat tesz a rendszernaplóba"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "A démon helyett a rendszer működési idejét jeleníti meg"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Általános beállítások"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgstr ""
 "Az %s lehetővé teszi a hálózatban lévő ügyfelek számára hogy automatikusan "
 "beállítsák a routert."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Nincsenek aktív átírányítások."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "UPnP IGDv1 mód engedélyezése"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Kifelé menő kapcsolat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/it/upnp.po
+++ b/applications/luci-app-upnp/po/it/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,105 +31,110 @@ msgstr ""
 "Le ACL specificano quali porte esterne possono essere ridirezionate a quali "
 "indirizzi e porte interni, IPv6 sempre consentito."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Azione"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Attiva reindirizzamento"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Impostazioni avanzate"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Pubblicizza come dispositivo IGDv1 anziché IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Permetti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Permetti l'aggiunta della mappatura solo agli indirizzi IP richiedenti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Numero modello annunciato"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Numero seriale annunciato"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Indirizzo IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Porta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Commento"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Elimina"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Nega"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Descrizione"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID del dispositivo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Velocità di download"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "Abilita il protocollo UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Abilita log addizionale"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Abilita la modalità sicura"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Porta Esterna"
 
@@ -137,76 +142,76 @@ msgstr "Porta Esterna"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Intervallo di notifica"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL di presentazione"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocollo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Scrivi nel log di sistema ulteriori informazioni di debug"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Mostra l'uptime del sistema invece del servizio"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Porta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Porta STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Servizi ACL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Impostazioni Generali"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgstr ""
 "%s permette ai dispositivi nella rete locale di configurare automaticamente "
 "l'apertura delle porte del router."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Non ci sono mappature attive."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD e PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Abilita modalità UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Velocità di upload"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Usa %s"

--- a/applications/luci-app-upnp/po/ja/upnp.po
+++ b/applications/luci-app-upnp/po/ja/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,105 +31,110 @@ msgstr ""
 "アクセス制御リスト（ACL）は、どの外部ポートからどの内部アドレス及びポートへリ"
 "ダイレクトするかを設定します。, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "アクション"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "稼働中のリダイレクト"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "IGDv2 ではなく IGDv1 デバイスとしてアドバタイズ"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "許可"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "要求元IPアドレスへの転送のみ、追加を許可します"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "通知するモデル番号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "通知するシリアル番号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "クライアント・アドレス"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "クライアント・ポート"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "コメント"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "削除"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "拒否"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "説明"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "デバイス UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "ダウンリンク"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "UPnP IGD機能を有効にする"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "ログ機能を有効にする"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "セキュアモードを有効にする"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "外部ポート"
 
@@ -137,76 +142,76 @@ msgstr "外部ポート"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "通知間隔"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "プレゼンテーションURL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "プロトコル"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "追加のデバッグ情報をシステムログへ挿入する"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "サービスの起動時間の代わりにシステムの起動時間を使用する"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "ポート"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN ホスト"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN ポート"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "一般設定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgstr ""
 "%sを使用することで、ローカルネットワーク内のクライアントが自動的にルータを構"
 "成することができます。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "有効なリダイレクトはありません。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGDとPCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "UPnP IGDv1 モードを有効化"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "不明"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "アップリンク"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "%s を使用"

--- a/applications/luci-app-upnp/po/ko/upnp.po
+++ b/applications/luci-app-upnp/po/ko/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.1-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "액션"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "고급 설정"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "메모"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "삭제"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "설명"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -135,76 +140,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "프로토콜"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "포트"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "기본 설정"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/lt/upnp.po
+++ b/applications/luci-app-upnp/po/lt/upnp.po
@@ -13,7 +13,7 @@ msgstr ""
 "n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -22,7 +22,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -30,107 +30,112 @@ msgstr ""
 "„ACL“ (dgs.) nurodo, į kuriuos išorinius prievadus galima persiųsti į "
 "nurodytus kliento adresus ir prievadus, IPv6 yra visada leidžiamas."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Veiksmas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktyvūs prievadų persiuntimai"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Pažangūs nustatymai"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Reklamuoti/Skelbti kaip – „IGDv1“ įrenginį (be IPv6), vietoj „IGDv2“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Leisti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Leisti pridėti prievadų persiuntimus tik į užklausų reikalaujančius IP "
 "adresus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Paskelbtas modelio numeris"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Paskelbtas serijos numeris"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Kliento adresas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Kliento prievadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Komentuoti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Ištrinti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Atmesti/Neprileisti"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Aprašas/-ymas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Įrenginio „UUID“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Atsisiuntimo greitis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Įjungti papildomą žurnalinimą"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Įjungti „saugiąją veikseną“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Išorinis prievadas"
 
@@ -138,76 +143,76 @@ msgstr "Išorinis prievadas"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Pranešimo intervalas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Pateikties „URL“ – saitas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokolas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Įdeda papildomą derinimo informaciją į sistemos žurnalą"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Pranešti apie sistemos veikimo laiką, o ne tarnybos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Prievadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "„STUN“ skleidėjas/vedėjas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "„STUN“ prievadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Bendri nustatymai"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "Tarnybos nuomos failas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -218,13 +223,13 @@ msgstr ""
 "„%s“ protokolai leidžia vietinio tinklo klientams savavaldiškai konfigūruoti "
 "prievado priskyrimus/persiuntimus maršrutizatoriuje."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Nėra aktyvių prievadų persiuntimų."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -233,25 +238,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "„UPnP“ – „IGD“ ir „PCP“"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "„UPnP“ – „IGD“ ir „PCP“ tarnyba"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Įjungti „UPnP IGDv1“ veikseną"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Nežinoma/-s/-i"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Įkėlimo greitis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Naudoti „%s“"

--- a/applications/luci-app-upnp/po/mr/upnp.po
+++ b/applications/luci-app-upnp/po/mr/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,111 +23,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "प्रगत सेटिंग्ज"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "टिप्पणी"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "हटवा"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "वर्णन"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -135,76 +140,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "प्रोटोकॉल"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "पोर्ट"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "सामान्य सेटिंग्ज"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "अज्ञात"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "अपलिंक"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/ms/upnp.po
+++ b/applications/luci-app-upnp/po/ms/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,111 +21,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Tindakan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Tetapan Lanjutan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Ulasan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Keterangan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -133,76 +138,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -211,13 +216,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -226,25 +231,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/nb_NO/upnp.po
+++ b/applications/luci-app-upnp/po/nb_NO/upnp.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -19,7 +19,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -27,105 +27,110 @@ msgstr ""
 "ACL angir hvilke eksterne porter som kan bli viderekoblet, og til hvilke "
 "interne adresser og porter, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Handling"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktive Viderekoblinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Avanserte innstillinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annonser som IGDv1-enhet istedenfor IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Tillat videkobling kun til IP adresser som ber om det"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Annonsert modellnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Annonsert serienummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Klient adresse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Klient port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Kommentar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Slett"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Enhet UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Nedlinje"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Aktiver tilleggs logging"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Aktiver sikker modus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Ekstern port"
 
@@ -133,76 +138,76 @@ msgstr "Ekstern port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Informasjons intervall"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Presentasjon URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Setter ekstra debugging informasjon i systemloggen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Rapporter systemets oppetid istedenfor daemon oppetid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN-vert"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN-port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Generelle innstillinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -213,13 +218,13 @@ msgstr ""
 "%s gjør at klientene i det lokale nettverket automatisk kan konfigurere "
 "ruteren."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Det finnes ingen aktive viderekoblinger"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -228,25 +233,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Skru på UPnP IGDv1-modus"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Opplinje"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Bruk %s"

--- a/applications/luci-app-upnp/po/nl/upnp.po
+++ b/applications/luci-app-upnp/po/nl/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,111 +21,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Actie"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Toestaan"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -133,76 +138,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -211,13 +216,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -226,25 +231,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/pl/upnp.po
+++ b/applications/luci-app-upnp/po/pl/upnp.po
@@ -13,7 +13,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgid ""
 msgstr ""
 "Interwał 900s doprowadzi do powiadomień %s z minimalnym czasem życia 1800s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,105 +31,110 @@ msgstr ""
 "Lista kontroli dostępu określa, które adresy i porty klientów mogą być "
 "przekierowane. Protokół IPv6 jest zawsze dozwolony."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Akcja"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktywne przekierowania portów"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "Aktywne przekierowania portów UPnP IGD i PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Rozgłaszaj jako urządzenie IGDv1 (bez IPv6) zamiast IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Zezwól"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Zezwól na dodawanie przekierowań tylko do odpytujących adresów IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Rozgłaszany numer modelu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Rozgłaszany numer seryjny"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Adres klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "Nazwa klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Komentarz"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Usuń"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Odmów"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Opis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID urządzenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Prędkość pobierania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Włącz protokół PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "Włącz protokół UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Włącz dodatkowe rejestrowanie"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Włącz tryb bezpieczny"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Port zewnętrzny"
 
@@ -137,78 +142,78 @@ msgstr "Port zewnętrzny"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Udziel dostępu do UPnP IGD i PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Interwał powiadamiania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Adres URL prezentacji"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokół"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 "Umieszcza dodatkowe informacje dotyczące debugowania w dzienniku systemowym"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 "Zgłaszaj niestandardowy adres URL interfejsu sieciowego (prezentacji) routera"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "Zgłaszaj maksymalną prędkość pobierania w kB/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "Zgłaszaj maksymalną prędkość wysyłania w kB/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Zgłaszaj czas pracy systemu zamiast czasu pracy usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Port SOAP/HTTP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Port STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Lista kontroli dostępu usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "Ustawienia usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Konfiguracja usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "Plik dzierżawy usługi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "Uruchom autonomiczną usługę przekierowania portów"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "Uruchom usługę"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -219,13 +224,13 @@ msgstr ""
 "Protokoły %s umożliwiają klientom w sieci lokalnej autonomiczne "
 "konfigurowanie przekierowania/przekazywania portów na routerze."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Nie ma aktywnych przekierowań portów."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -236,25 +241,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD i PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Usługa UPnP IGD i PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Włącz tryb UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Prędkość wysyłania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Użyj %s"

--- a/applications/luci-app-upnp/po/pt/upnp.po
+++ b/applications/luci-app-upnp/po/pt/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,106 +31,111 @@ msgstr ""
 "Os ACL especificam quais as portas externas que podem ser redirecionadas "
 "para que endereços internos e portas, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Redirecionamentos ativos da"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Anuncie como aparelho IGDv1 em vez de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Permitir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permitir a adição de encaminhamentos apenas para solicitar endereços IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Número modelo anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Número de série anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Endereço do Cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Porta do Cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Comentário"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Apagar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Negar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID do aparelho"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Download speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Ativar log adicional"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Ativar o modo seguro"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Porta externa"
 
@@ -138,76 +143,76 @@ msgstr "Porta externa"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Intervalo de Notificação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL de apresentação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Põe informações de depuração extras no log do sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Relata uptime do sistema ao invés da do daemon"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Porta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Porta STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgid ""
 msgstr ""
 "%s permite que os clientes da rede local configurem o router automaticamente."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Não há redirecionamentos ativos."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Ativar o modo UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Ligação ascendente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utilizar %s"

--- a/applications/luci-app-upnp/po/pt_BR/upnp.po
+++ b/applications/luci-app-upnp/po/pt_BR/upnp.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.9\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -25,7 +25,7 @@ msgstr ""
 "Um intervalo de 900s resultará em %s notificações com o max-age mínimo de "
 "1800s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -33,106 +33,111 @@ msgstr ""
 "As ACL especificam quais portas externas podem ser encaminhadas para quais "
 "endereços e portas de clientes, com IPv6 sempre será permitido."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Redirecionamentos Ativos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "Mapeamentos de portas UPnP IGD e PCP/NAT-PMP ativos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Anuncie-se como um dispositivo IGDv1 ao invés de um IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Permitir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Permite adicionar encaminhamento apenas para o endereço IP requisitante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Número do modelo anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Número de série anunciado"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Endereço do cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "Nome do cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Porta do Cliente"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Comentário"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Apagar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Negar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Descrição"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID do Dispositivo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Velocidade de download"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Habilitar protocolos PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "Habilitar protocolo UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Habilite registros adicionais"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Habilite modo seguro"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Porta externa"
 
@@ -140,76 +145,76 @@ msgstr "Porta externa"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Conceder acesso ao UPnP IGD e PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Intervalo de notificação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL de Apresentação"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Envie informações extra de depuração ao registro do sistema"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr "Relatar URL personalizada da interface web do roteador (apresentação)"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "Relatar a velocidade máxima de download em kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "Relatar a velocidade máxima de upload em kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Informe o tempo de vida do sistema ao invés do tempo do processo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Porta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Host STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Porta STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Lista de Controle de Acesso ao Serviço"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "Configurações do Serviço"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "Arquivo de concessão do serviço"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "Iniciar serviço de mapeamento de portas autônomo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "Iniciar serviço"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -219,13 +224,13 @@ msgid ""
 msgstr ""
 "%s permite os clientes da rede local configurem automaticamente o roteador."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Não existe redirecionamentos ativos."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -236,25 +241,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Serviço UPnP IGD e PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Habilitar o modo UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Velocidade de envio (upload)"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Use o %s"

--- a/applications/luci-app-upnp/po/ro/upnp.po
+++ b/applications/luci-app-upnp/po/ro/upnp.po
@@ -13,7 +13,7 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -22,7 +22,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -30,105 +30,110 @@ msgstr ""
 "ACL-urile specifica porturile externe care pot fi redirectate si spre ce "
 "adrese si porturi interne, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Acțiune"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Redirecturi active"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Setări avansate"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Publicitate ca dispozitiv IGDv1 în loc de IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Permite adaugarea forward-urilor doar catre adresele IP solicitante"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Numărul modelului anunțat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Număr de serie anunțat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Adresa client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port client"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Comentariu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Ștergeți"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Descriere"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID al dispozitivului"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Link în jos"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Activeaza log-area aditionala"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Activeaza modul securizat"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Port extern"
 
@@ -136,76 +141,76 @@ msgstr "Port extern"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Interval de notificare"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Adresa de prezentare"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protocol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Pune informatii utile suplimentare in log-ul de sistem"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Raporteaza timpul de functionare de sistem in loc de serviciu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Gazda STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Portul STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Setări generale"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -215,13 +220,13 @@ msgid ""
 msgstr ""
 "%s permite clientulor din reteaua locala sa configureze automat routerul."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Nu exista redirecturi active."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -230,25 +235,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Activează modul UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Legătură ascendentă"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Utilizați %s"

--- a/applications/luci-app-upnp/po/ru/upnp.po
+++ b/applications/luci-app-upnp/po/ru/upnp.po
@@ -16,7 +16,7 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -27,7 +27,7 @@ msgstr ""
 "Интервал 900 сек. приведет к появлению %s уведомлений с минимальным "
 "максимальным возрастом 1800 сек."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -35,105 +35,110 @@ msgstr ""
 "Список контроля доступа (ACL) определяет, какие клиентские адресы могут быть "
 "перенаправлены, IPv6 всегда разрешен."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Действие"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Активные переадресации"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "Активные карты портов UPnP IGD и PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Объявить как IGDv1 устройство вместо IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Разрешить"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Разрешить перенаправление только для запрашивающих IP-адресов"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Объявить номер модели"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Объявить серийный номер"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Адрес клиента"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "Имя клиента"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Порт клиента"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Комментарий"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Удалить"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Отказать"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Описание"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID устройства"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Внутреннее соединение"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "Включить протоколы PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "Включить UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Дополнительное журналирование"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Защищённый режим"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Внешний порт"
 
@@ -141,76 +146,77 @@ msgstr "Внешний порт"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Предоставить доступ к UPnP IGD и PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Интервал уведомления"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Задать URL-адрес"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Добавлять дополнительную отладочную информацию в системный журнал"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
-msgstr "URL-адрес веб-интерфейса (презентации) пользовательского маршрутизатора"
+msgstr ""
+"URL-адрес веб-интерфейса (презентации) пользовательского маршрутизатора"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "Сообщите максимальную скорость загрузки в кБайт/с"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "Сообщите максимальную скорость загрузки в кБайт/с"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Сообщать время работы системы вместо службы"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Порт"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Хост STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Порт STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Список контроля доступа к сервисам"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "Настройки сервиса"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Основные Настройки"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "Файл аренды сервиса"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "Запуск службы сопоставления автономных портов"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "Запустить сервис"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -221,13 +227,13 @@ msgstr ""
 "Протоколы %s позволяют клиентам в локальной сети автоматически настраивать "
 "маршрутизатор."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Активные переадресации отсутствуют."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -238,25 +244,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD и PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "Сервис UPnP IGD и PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "UPnP IGDv1 режим"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Неизвестный"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Внешнее соединение"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Использовать %s"

--- a/applications/luci-app-upnp/po/sk/upnp.po
+++ b/applications/luci-app-upnp/po/sk/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,111 +21,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Akcia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktívne presmerovania"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Pokročilé nastavenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Umožniť pridanie preposielaní iba požadovaným adresám IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Ohlásené číslo modelu"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Ohlásené sériové číslo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Adresa klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Port klienta"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Komentár"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Odstrániť"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Popis"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID zariadenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Povoliť dodatočné zaznamenávanie"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Povoliť zabezpečený režim"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Externý port"
 
@@ -133,76 +138,76 @@ msgstr "Externý port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Interval upozornení"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Prezentačná URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Všeobecné nastavenia"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -211,13 +216,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr "%s umožňuje klientom v miestnej sieti automaticky nastaviť smerovač."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Neexistujú žiadne aktívne presmerovania."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -226,25 +231,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Povoliť režim UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Neznáme"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/sv/upnp.po
+++ b/applications/luci-app-upnp/po/sv/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -23,7 +23,7 @@ msgstr ""
 "Ett 900s intervall kommer att resultera i %s notifieringar med minimum "
 "maxålder på 1800s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -31,105 +31,110 @@ msgstr ""
 "ACL:er anger vilka externa portar som ska omdirigeras till vilka interna "
 "adresser och portar, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Åtgärd"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktivera omdirigeringar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Annonsera som IGDv1-enhet (ingen IPv6) istället för IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Tillåt"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Aviserat modellnummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Aviserat serienummer"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Klient-adress"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Klient-port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Kommentar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Ta bort"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Neka"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Beskrivning"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Enhetens UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Nerlänk"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Aktivera ytterligare loggning"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Aktivera säkert läge"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Extern port"
 
@@ -137,76 +142,76 @@ msgstr "Extern port"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "Tillåt åtkomst till UPnP IGD & PCP/NAT-PMP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Intervall för avisering"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Presentationens URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Lägger extra felsökningsinformation till system-loggen"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Rapportera systemet iställer för demonens upptid"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN-värd"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN-port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -217,13 +222,13 @@ msgstr ""
 "%s tillåter klienter i det lokala nätverket att automatiskt ställa in "
 "routern."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Det finns inga aktiva omdirigeringar."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -232,25 +237,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Aktivera UPnP IGDv1-läge"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Okänd"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Upplänk"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Använd %s"

--- a/applications/luci-app-upnp/po/templates/upnp.pot
+++ b/applications/luci-app-upnp/po/templates/upnp.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -10,111 +10,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -122,76 +127,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -200,13 +205,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -215,25 +220,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/tr/upnp.po
+++ b/applications/luci-app-upnp/po/tr/upnp.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -21,7 +21,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -30,105 +30,110 @@ msgstr ""
 "bağlantı noktalarına yeniden yönlendirilebileceğini belirtir, IPv6 always "
 "allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Eylem"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Aktif Yönlendirmeleri"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Gelişmiş Ayarlar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "IGDv2 yerine IGDv1 cihazı olarak duyuru yap"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "İzin ver"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Yalnızca istekte bulunan IP adreslerine yönlendirme eklemeye izin ver"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Açıklanan model numarası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Açıklanan seri numarası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "İstemci Adresi"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "İstemci Bağlantı Noktası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Yorum"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Sil"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "Reddet"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Açıklama"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Cihaz UUID'si"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "İndirme hızı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Ek günlük kaydını etkinleştir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Güvenli modu etkinleştir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Harici Bağlantı Noktası"
 
@@ -136,76 +141,76 @@ msgstr "Harici Bağlantı Noktası"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Bildirme aralığı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Sunum URL'si"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Protokol"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Sistem günlüğüne fazladan hata ayıklama bilgisi koyar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Arka plan programı çalışma süresi yerine sistemi rapor et"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Bağlantı noktası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN Ana Bilgisayarı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN Bağlantı Noktası"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Genel Ayarlar"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -216,13 +221,13 @@ msgstr ""
 "%s, yerel ağdaki istemcilerin yönlendiriciyi otomatik olarak "
 "yapılandırmasına izin verir."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Etkin yönlendirme yok."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -231,25 +236,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD ve PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "UPnP IGDv1 modunu etkinleştir"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Yükleme hızı"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "%s kullan"

--- a/applications/luci-app-upnp/po/uk/upnp.po
+++ b/applications/luci-app-upnp/po/uk/upnp.po
@@ -13,7 +13,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.10-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -24,7 +24,7 @@ msgstr ""
 "Інтервал у 900 секунд призведе до %s сповіщень із мінімальним максимальним "
 "часом дії у 1800 секунд"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -32,106 +32,111 @@ msgstr ""
 "Список контролю доступу (ACL) визначає, які зовнішні порти можуть бути "
 "переспрямовані на які внутрішні адреси й порти, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Дія"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Активні переспрямування"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Розширені налаштування"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Оголошувати як пристрій IGDv1 замість IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "Дозволити"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 "Дозволити додавання переспрямування тільки для IP-адрес, що надсилають запити"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Оголошуваний номер моделі"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Оголошуваний серійний номер"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Адреса клієнта"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Порт клієнта"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Примітка"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Видалити"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Опис"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "UUID пристрою"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Низхідне з'єднання"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Увімкнути додаткове журналювання"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Увімкнути захищений режим"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Зовнішній порт"
 
@@ -139,76 +144,76 @@ msgstr "Зовнішній порт"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Інтервал сповіщення"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "URL презентації"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Протокол"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Включати додаткові відомості для налагодження до системного журналу"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Повідомляти час безвідмовної роботи системи, а не сервісу"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Порт"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "Хост STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "Порт STUN"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Загальні налаштування"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -219,13 +224,13 @@ msgstr ""
 "Протоколи %s дозволяють клієнтам у локальній мережі автоматично настроювати "
 "переспрямуванняна маршрутизаторі."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Немає активних переспрямувань."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -234,25 +239,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Увімкнути режим UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Висхідне з'єднання"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Використовувати %s"

--- a/applications/luci-app-upnp/po/vi/upnp.po
+++ b/applications/luci-app-upnp/po/vi/upnp.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -25,7 +25,7 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -33,105 +33,110 @@ msgstr ""
 "ACL chỉ định cổng bên ngoài nào có thể được chuyển hướng đến địa chỉ và cổng "
 "nội bộ nào, IPv6 always allowed."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "Hành động"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "Chuyển hướng đang hoạt động"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "Cài đặt Nâng cao"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "Quảng cáo dưới dạng thiết bị IGDv1 thay vì IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "Chỉ cho phép thêm chuyển tiếp để yêu cầu địa chỉ IP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "Announced model number"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "Announced serial number"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "Client Address"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "Client Port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "Bình luận"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "Xoá"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "Mô tả"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "Device UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "Download speed"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "Bật ghi nhật ký bổ sung"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "Kích hoạt chế độ an toàn"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "Cổng bên ngoài"
 
@@ -139,76 +144,76 @@ msgstr "Cổng bên ngoài"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "Vòng lặp thông báo"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "Presentation URL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "Giao thức"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "Đưa thông tin sửa lỗi bổ sung vào nhật ký hệ thống"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "Hệ thống báo cáo thay vì thời gian hoạt động của daemon"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "Cổng"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN host"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN port"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "Service Access Control List"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "Các cài đặt chung"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -218,13 +223,13 @@ msgid ""
 msgstr ""
 "%s cho phép các máy khách trong mạng cục bộ tự động cấu hình bộ định tuyến."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "Không có chuyển hướng đang hoạt động."
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -233,25 +238,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP Service"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "Kích hoạt chế độ UPnP IGDv1"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "Không xác định"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "Tuyến lên"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "Sử dụng %s"

--- a/applications/luci-app-upnp/po/yua/upnp.po
+++ b/applications/luci-app-upnp/po/yua/upnp.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.3-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -22,111 +22,116 @@ msgid ""
 "1800s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr ""
 
@@ -134,76 +139,76 @@ msgstr ""
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -212,13 +217,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr ""
@@ -227,25 +232,25 @@ msgstr ""
 msgid "UPnP IGD & PCP"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr ""
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr ""

--- a/applications/luci-app-upnp/po/zh_Hans/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hans/upnp.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -26,111 +26,116 @@ msgid ""
 "1800s"
 msgstr "一个 900 秒的时间间隔将导致 %s 通知的最小 max-age 为 1800 秒"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
 msgstr "ACL 指定了哪些客户端地址和端口可以被转发，IPv6 始终被允许。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "操作"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "活跃的端口转发"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "活跃的 UPnP IGD 和 PCP/NAT-PMP 端口转发"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "将设备标识为 IGDv1（仅IPv4）设备，而不是 IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "允许"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "仅允许为请求的 IP 地址添加端口转发"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "通告的设备型号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "通告的设备序列号"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "客户端地址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "客户端名称"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "客户端端口"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "注释"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "删除"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "拒绝"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "设备 UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "下载速度"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "启用 PCP/NAT-PMP 协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "启用 UPnP IGD 协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "启用额外的日志"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "启用安全模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "外部端口"
 
@@ -138,76 +143,76 @@ msgstr "外部端口"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "授予访问 UPnP IGD 及 PCP/NAT-PMP 的权限"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "通知的时间间隔"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "服务网址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "协议"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "将额外的调试信息输出到系统日志中"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr "自定义路由器网页界面（展示页面）网址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "最大下载速度 kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "最大上传速度 kByte/s"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "用系统运行时间代替进程运行时间"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "SOAP/HTTP 端口"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN 主机"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN 端口"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "服务访问控制列表"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "服务设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "常规设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "服务租约文件"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "启动自动端口转发服务"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "启动服务"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -216,13 +221,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr "%s 协议允许本地网络上的客户端自主配置路由器上的端口映射/转发。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "当前没有活跃的端口转发。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr "检测公网 IPv4 地址，以便用于不受限制的全锥形/一对一 NAT"
@@ -231,25 +236,25 @@ msgstr "检测公网 IPv4 地址，以便用于不受限制的全锥形/一对�
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD 和 PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD 和 PCP/NAT-PMP 服务"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "UPnP IGDv1 兼容模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "未知"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "上传速度"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "使用 %s"

--- a/applications/luci-app-upnp/po/zh_Hant/upnp.po
+++ b/applications/luci-app-upnp/po/zh_Hant/upnp.po
@@ -15,7 +15,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
 msgctxt ""
 "A 900s interval will result in %s (%s = SSDP) notifications with the minimum "
 "max-age of 1800s"
@@ -24,7 +24,7 @@ msgid ""
 "1800s"
 msgstr "900秒間隔將產生%s條通知，通知最大存留期的最小值為1800秒"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
 msgid ""
 "ACL specify which client addresses and ports can be mapped, IPv6 always "
 "allowed."
@@ -32,105 +32,110 @@ msgstr ""
 "您可以使用ACL（存取控制串列）來規定哪些「外部埠」可被重新導向到哪些「內部位"
 "址」和「內部埠」"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:224
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:235
 msgid "Action"
 msgstr "操作"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:120
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
 msgid "Active Service Port Maps"
 msgstr "活動的連接埠轉發"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:31
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:29
 msgid "Active UPnP IGD & PCP/NAT-PMP Port Maps"
 msgstr "活動的UPnP IGD & PCP/NAT-PMP連接埠轉發"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:135
 msgid "Advanced Settings"
 msgstr "進階設定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:148
 msgid "Advertise as IGDv1 (IPv4 only) device instead of IGDv2"
 msgstr "宣告為IGDv1裝置，而非IGDv2"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:225
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:236
 msgid "Allow"
 msgstr "允許"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:164
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
 msgid "Allow adding port maps for requesting IP addresses only"
 msgstr "只容許向請求的IP位址新增轉發"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:188
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
 msgid "Announced model number"
 msgstr "宣告的型號"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:202
 msgid "Announced serial number"
 msgstr "宣告的序列號"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:91
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:41
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:99
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:223
 msgid "Client Address"
 msgstr "用戶端位址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:90
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:40
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:98
 msgid "Client Name"
 msgstr "用戶端名稱"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:92
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:216
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:42
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:100
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:227
 msgid "Client Port"
 msgstr "用戶端埠"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:221
 msgid "Comment"
 msgstr "註解"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:72
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:122
 msgid "Delete"
 msgstr "刪除"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:226
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:237
 msgid "Deny"
 msgstr "拒絕"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:48
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:95
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
 msgid "Description"
 msgstr "描述"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:185
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:196
 msgid "Device UUID"
 msgstr "裝置UUID"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:142
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:153
 msgid "Download speed"
 msgstr "下行鏈路"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:144
 msgid "Enable PCP/NAT-PMP protocols"
 msgstr "啓用PCP/NAT-PMP功能"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:141
 msgid "Enable UPnP IGD protocol"
 msgstr "啟用UPnP IGD"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:198
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:209
 msgid "Enable additional logging"
 msgstr "啓用附加日誌"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:174
 msgid "Enable secure mode"
 msgstr "啓用安全模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:46
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:93
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:220
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:45
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:103
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:43
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:101
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:231
 msgid "External Port"
 msgstr "外部埠"
 
@@ -138,76 +143,76 @@ msgstr "外部埠"
 msgid "Grant access to UPnP IGD & PCP/NAT-PMP"
 msgstr "授予存取UPnP IGD & PCP/NAT-PMP的權限"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:168
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:179
 msgid "Notify interval"
 msgstr "通知時間間隔"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:180
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:191
 msgid "Presentation URL"
 msgstr "簡報網址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:47
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:94
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:44
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:102
 msgid "Protocol"
 msgstr "協定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:199
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:210
 msgid "Puts extra debugging information into the system log"
 msgstr "將額外的除錯資訊寫入系統日誌"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:181
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:192
 msgid "Report custom router web interface (presentation) URL"
 msgstr "設定路由器web介面自訂（簡報）網址"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:143
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
 msgid "Report maximum download speed in kByte/s"
 msgstr "設定最大下載速率(kByte/s)"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
 msgid "Report maximum upload speed in kByte/s"
 msgstr "設定最大上傳速率(kByte/s)"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:194
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:205
 msgid "Report system instead of service uptime"
 msgstr "報告使用系統上線時間，而非程序上線時間"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:175
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:186
 msgid "SOAP/HTTP port"
 msgstr "連接埠"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:154
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:165
 msgid "STUN host"
 msgstr "STUN主機"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:158
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:169
 msgid "STUN port"
 msgstr "STUN埠"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:204
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:215
 msgid "Service Access Control List"
 msgstr "ACL"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:123
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:132
 msgid "Service Settings"
 msgstr "服务设置"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:125
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:134
 msgid "Service Setup"
 msgstr "一般設定"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:201
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:212
 msgid "Service lease file"
 msgstr "服务租约文件"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:129
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:138
 msgid "Start autonomous port mapping service"
 msgstr "啟動連接埠轉發服務"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:128
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:137
 msgid "Start service"
 msgstr "啟動服務"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:88
 msgctxt ""
 "The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local "
 "network to configure port maps/forwards on the router autonomously."
@@ -216,13 +221,13 @@ msgid ""
 "forwards on the router autonomously."
 msgstr "%s（通用隨插即用）允許本地網絡中的用戶端自動設定路由器埠的重新導向。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:70
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:66
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:117
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:80
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:76
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:126
 msgid "There are no active port maps."
 msgstr "沒有活動的連接埠轉發。"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:152
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:163
 msgid ""
 "To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs"
 msgstr "偵測不受限制的全錐/一對一NAT的公共IPv4位址"
@@ -231,25 +236,25 @@ msgstr "偵測不受限制的全錐/一對一NAT的公共IPv4位址"
 msgid "UPnP IGD & PCP"
 msgstr "UPnP IGD & PCP"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:79
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:87
 msgid "UPnP IGD & PCP/NAT-PMP Service"
 msgstr "UPnP IGD & PCP/NAT-PMP服務"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:136
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:147
 msgid "UPnP IGDv1 compatibility mode"
 msgstr "啟用UPnP IGDv1模式"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:57
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:53
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:104
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js:66
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:62
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:113
 msgid "Unknown"
 msgstr "未知"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:146
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:157
 msgid "Upload speed"
 msgstr "上行鏈路"
 
-#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:150
+#: applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js:161
 msgctxt "Use %s (%s = STUN)"
 msgid "Use %s"
 msgstr "使用%s"

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -33,7 +33,7 @@ const methods = {
 							extport: +record[1],
 							intaddr: arrtoip(iptoarr(record[2])),
 							intport: +record[3],
-							expiry: +record[4],
+							expires: record[4] - timelocal(localtime()),
 							description: trim(record[5])
 						});
 					}
@@ -95,6 +95,7 @@ const methods = {
 						    lease.extport == rule.extport)
 						{
 							rule.descr = lease.description;
+							rule.expires = lease.expires;
 							break;
 						}
 					}
@@ -135,5 +136,3 @@ const methods = {
 };
 
 return { 'luci.upnp': methods };
-
-


### PR DESCRIPTION
### Status/overview UI:

![openwrt-status-overview](https://github.com/user-attachments/assets/fcec91ba-22f3-4307-98e5-c68f038810bd)
_[Screenshot 23.05 release](https://github.com/user-attachments/assets/4a9748fb-6a4b-420b-bfee-1ec4cce88d67)_

The **Port Control Protocol (PCP)** is the successor to NAT-PMP, has similar protocol concepts and packet formats, but adds support for **IPv6 port maps** and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2024: About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview

Maintainer: @jow-

Previous improvement: #7407