### PR TITLE
luci-mod-system: use DirectInterface for bound dropbear interface

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js
@@ -17,7 +17,7 @@ return view.extend({
 		o = s.option(form.Flag, 'enable', _('Enable Instance'), _('Enable <abbr title="Secure Shell">SSH</abbr> service instance'));
 		o.default  = o.enabled;
 
-		o = s.option(widgets.NetworkSelect, 'Interface', _('Interface'), _('Listen only on the given interface or, if unspecified, on all'));
+		o = s.option(widgets.NetworkSelect, 'DirectInterface', _('Interface'), _('Listen only on the given interface or, if unspecified, on all'));
 		o.nocreate    = true;
 
 		o = s.option(form.Value, 'Port', _('Port'));


### PR DESCRIPTION
Since https://github.com/openwrt/openwrt/commit/3f96246e97215c4c76ca407a8bca8f3f5de32e1c the correct UCI option for specifying the bound interface is DirectInterface instead of Interface.

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile N/A
- [X] Tested on: (x86/64, 24.10.0-rc2, Firefox) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback @jow- 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
