### PR TITLE
treewide: Add a link to Weblate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing Guidelines
 
+## Translations
+
+Use [Weblate](https://hosted.weblate.org/engage/openwrt/?utm_source=widget) instead of direct editing of the `*.po` files.
+
 ## Patches and Pull requests:
 
 If you want to contribute a change to LuCI, please either send a patch using git send-email

--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 ## Translation status
 
+Use [Weblate](https://hosted.weblate.org/engage/openwrt/?utm_source=widget) instead of direct editing of the `*.po` files.
+
 [![Translation status](https://hosted.weblate.org/widgets/openwrt/-/multi-auto.svg)](https://hosted.weblate.org/engage/openwrt/?utm_source=widget)


### PR DESCRIPTION
To help users to find a right place where to translate.

Because some users trying to edit the po files directly. This also should be acceptable because we shouldn't force users to register on a third party tool and learn it.

Ideally we should add a link to translations, github and dourm into the Luci itself. This must increase contributions from regular users.