### PR TITLE
luci-base: follow-up fix for ES6 changes

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/uci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/uci.js
@@ -637,7 +637,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 			}
 
 			/* only delete existing options */
-			if (v[conf]?.[sid].hasOwnProperty(opt)) {
+			if (v[conf]?.[sid]?.hasOwnProperty(opt)) {
 				d[conf] ??= { };
 				d[conf][sid] ??= { };
 


### PR DESCRIPTION
follow-up for c2fc96cc4c6b35f19638f8c54599041ce6e39da4

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (aarch64, HEAD, chrome) :white_check_mark:
- [x] \( Preferred ) Mention: @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (Fixes `Uncaught TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')`)
