### PR TITLE
luci-app-squid: remove variable redeclaration

### DIFF
--- a/applications/luci-app-squid/htdocs/luci-static/resources/view/squid.js
+++ b/applications/luci-app-squid/htdocs/luci-static/resources/view/squid.js
@@ -49,7 +49,7 @@ return view.extend({
 		s.tab('general', _('General Settings'));
 		s.tab('advanced', _('Advanced Settings'));
 
-		var o = s.taboption('general', form.Value, 'config_file', _('Config file'));
+		o = s.taboption('general', form.Value, 'config_file', _('Config file'));
 		o.datatype = 'string';
 		o.default = '/etc/squid/squid.conf';
 		o.validate = function(section_id, value) {


### PR DESCRIPTION
Since 22d4830 the form variables m, s, and o was changed to be declared with let instead of var, but the o variable was redeclared in the app, resulting in a redeclaration error when it was changed to instead be declared with let.

See https://forum.openwrt.org/t/openwrt-24-10-0-rc4-fourth-release-candidate/219368/81?u=dannil

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile N/A
- [X] Tested on: (x86/64, 24.10-rc4, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @stokito and @dannil (myself)
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)

Before
![Screenshot_11](https://github.com/user-attachments/assets/853c2ce0-71ec-4ffb-aa38-b85e14d2bd1c)

After
![Screenshot_12](https://github.com/user-attachments/assets/12b3c82b-5bfa-43cb-8b19-32569d60aa06)

