### PR TITLE
luci-app-filemanager: update chinese translations

### DIFF
--- a/applications/luci-app-filemanager/po/zh_Hans/filemanager.po
+++ b/applications/luci-app-filemanager/po/zh_Hans/filemanager.po
@@ -1,0 +1,442 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2024-12-29 00:30+0000\n"
+"Last-Translator: Anya Lin <hukk1996@gmail.com>\n"
+"Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationsfilemanager/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.3-dev\n"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:848
+msgid "Actions"
+msgstr "操作"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1607
+msgid "Are you sure you want to delete the selected files and directories?"
+msgstr "您确定要删除选定的文件和目录吗？"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2043
+msgid "Are you sure you want to delete this %s: \"%s\"?"
+msgstr "您确定要删除此%s: \"%s\" 吗？"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2458
+msgid "Changes to %s \"%s\" uploaded successfully."
+msgstr "对%s \"%s\" 的更改已成功。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1023
+msgid "Column Max Widths (format: name:maxWidth,type:maxWidth,...):"
+msgstr "最大列宽 (格式: name:maxWidth,type:maxWidth,...):"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1012
+msgid "Column Min Widths (format: name:minWidth,type:minWidth,...):"
+msgstr "最小列宽 (格式: name:minWidth,type:minWidth,...):"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1001
+msgid "Column Widths (format: name:width,type:width,...):"
+msgstr "列宽 (格式: name:width,type:width,...):"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1494
+msgid "Create"
+msgstr "创建"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1445
+msgid "Create Directory:"
+msgstr "创建目录:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:898
+msgid "Create File"
+msgstr "创建文件"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1502
+msgid "Create File:"
+msgstr "创建文件:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:894
+msgid "Create Folder"
+msgstr "创建文件夹"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1061
+msgid "Current Directory:"
+msgstr "当前目录:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:1238
+msgid "Decoded Text"
+msgstr "解码文字"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:904
+msgid "Delete Selected"
+msgstr "删除选定"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2051
+msgid "Deleted %s: \"%s\"."
+msgstr "已删除 %s: \"%s\"。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1707
+msgid "Directory"
+msgstr "目录"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1461
+msgid "Directory \"%s\" created successfully."
+msgstr "目录 \"%s\" 创建成功。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1428
+msgid "Directory Name"
+msgstr "目录名"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2015
+msgid "Downloaded file: \"%s\"."
+msgstr "下载文件: \"%s\"."
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:859
+msgid "Drop files here to upload"
+msgstr "将文件拖放到此处进行上传"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2406
+msgid "Editing %s: \"%s\""
+msgstr "编辑中%s: \"%s\""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2784
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2788
+msgid "Editing:"
+msgstr "编辑中:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:740
+msgid "Editor"
+msgstr "编辑"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2182
+msgid "Editor textarea not found."
+msgstr "未找到编辑器 textarea。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2300
+msgid "Failed to access symlink target: %s"
+msgstr "无法访问符号链接目标: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1276
+msgid "Failed to access the specified path: %s"
+msgstr "无法访问指定路径: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2261
+msgid "Failed to apply permissions to file \"%s\": %s"
+msgstr "无法对文件 \"%s\" 应用权限: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1470
+msgid "Failed to create directory \"%s\": %s"
+msgstr "无法创建目录 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1527
+msgid "Failed to create file \"%s\": %s"
+msgstr "无法创建文件 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2054
+msgid "Failed to delete %s \"%s\": %s"
+msgstr "无法删除%s \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1613
+msgid "Failed to delete %s: %s"
+msgstr "无法删除 %s: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1624
+msgid "Failed to delete selected files and directories: %s"
+msgstr "无法删除选定的文件和目录: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1636
+msgid "Failed to display the file list."
+msgstr "无法显示文件列表。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2018
+msgid "Failed to download file \"%s\": %s"
+msgstr "无法下载文件 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2167
+msgid "Failed to duplicate %s \"%s\": %s"
+msgstr "无法复制%s \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2170
+msgid "Failed to get file list: %s"
+msgstr "无法获取文件列表: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1813
+msgid "Failed to load file list: %s"
+msgstr "无法加载文件列表: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1977
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1979
+msgid "Failed to open file: %s"
+msgstr "无法打开文件: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1225
+msgid "Failed to render Help content: Container not found."
+msgstr "无法呈现帮助内容: 找不到容器。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2467
+msgid "Failed to save changes to %s \"%s\": %s"
+msgstr "无法保存对%s \"%s\" 的更改: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2277
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2279
+msgid "Failed to save file \"%s\": %s"
+msgstr "无法保存文件 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2584
+msgid "Failed to save settings: %s"
+msgstr "无法保存设置: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1190
+msgid "Failed to update file list: %s"
+msgstr "无法更新文件列表: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1734
+msgid "File"
+msgstr "文件"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1518
+msgid "File \"%s\" created successfully."
+msgstr "文件 \"%s\" 创建成功。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1398
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1400
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2254
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2256
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2265
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2267
+msgid "File \"%s\" uploaded successfully."
+msgstr "文件 \"%s\" 上传成功。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:731
+#: applications/luci-app-filemanager/root/usr/share/luci/menu.d/luci-app-filemanager.json:3
+msgid "File Manager"
+msgstr "文件管理器"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:697
+msgid "File Manager:"
+msgstr "文件管理器:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1485
+msgid "File Name"
+msgstr "文件名"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:713
+msgid "Go"
+msgstr "前往"
+
+#: applications/luci-app-filemanager/root/usr/share/rpcd/acl.d/luci-app-filemanager.json:3
+msgid "Grant access to File Manager"
+msgstr "授予访问 File Manager 的权限"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:759
+msgid "Help"
+msgstr "帮助"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:992
+msgid "Hex Editor Height:"
+msgstr "十六进制编辑器高度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:983
+msgid "Hex Editor Width:"
+msgstr "十六进制编辑器宽度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:939
+msgid "Interface Settings"
+msgstr "界面设置"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:830
+msgid "Last Modified"
+msgstr "最后修尬"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1928
+msgid "Loading file..."
+msgstr ""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:791
+msgid "Name"
+msgstr "名称"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1467
+msgid "No directory selected."
+msgstr "未选择目录。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:877
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1345
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1524
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1804
+msgid "No file selected."
+msgstr "未选择文件。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2464
+msgid "No item selected."
+msgstr "未选择物件。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:1226
+msgid "Offset (h)"
+msgstr "Offset (hex)"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1052
+msgid "Padding Max:"
+msgstr "最大 Padding:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1043
+msgid "Padding Min:"
+msgstr "最小 Padding:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1034
+msgid "Padding:"
+msgstr "Padding:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1075
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1437
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2396
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2713
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2755
+msgid "Save"
+msgstr "保存"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2224
+msgid "Saving file: \"%s\"..."
+msgstr ""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:428
+msgid "Search ASCII"
+msgstr "搜索 ASCII"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:431
+msgid "Search HEX (e.g., 4F6B)"
+msgstr "搜索 HEX (e.g., 4F6B)"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:434
+msgid "Search RegExp (e.g., \\d{3})"
+msgstr "搜索 RegExp (e.g., \\d{3})"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:916
+msgid "Select a file from the list to edit it here."
+msgstr "从列表中选择一个文件并在此进行编辑。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1617
+msgid "Selected files and directories deleted successfully."
+msgstr "选定的文件和目录已成功删除。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:749
+msgid "Settings"
+msgstr "设置"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2554
+msgid "Settings uploaded successfully."
+msgstr "设置已成功保存。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:817
+msgid "Size"
+msgstr "文件大小"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:834
+msgid "Sort by Last Modified"
+msgstr "按最后修改时间排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:795
+msgid "Sort by Name"
+msgstr "按名称排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:821
+msgid "Sort by Size"
+msgstr "文件大小"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:808
+msgid "Sort by Type"
+msgstr "按类型排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2045
+msgid "Successfully deleted %s: \"%s\"."
+msgstr "成功删除%s: \"%s\"。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2162
+msgid "Successfully duplicated %s \"%s\" as \"%s\"."
+msgstr "成功将%s \"%s\" 复制为 \"%s\"。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1779
+msgid "Symlink"
+msgstr "符号链接"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2304
+msgid "Symlink:"
+msgstr "符号链接:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:974
+msgid "Text Editor Height:"
+msgstr "文本编辑器高度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:965
+msgid "Text Editor Width:"
+msgstr "文本编辑器宽度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1273
+msgid "The specified path does not appear to be a directory."
+msgstr "指定的路径似乎不是目录。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2297
+msgid "The symlink points to an unsupported type."
+msgstr "符号链接指向不受支持的类型。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2729
+msgid "Toggle Line Numbers"
+msgstr "切换行号显示"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2763
+msgid "Toggle to ASCII Mode"
+msgstr "切换到 ASCII 模式"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2721
+msgid "Toggle to Hex Mode"
+msgstr "切换到十六进制模式"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:804
+msgid "Type"
+msgstr "類型"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1786
+msgid "Unknown"
+msgstr ""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:890
+msgid "Upload File"
+msgstr "上传文件"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1408
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1410
+msgid "Upload failed for file \"%s\": %s"
+msgstr "文件 \"%s\" 上传失败: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1372
+msgid "Uploading: \"%s\"..."
+msgstr "正在上传: \"%s\"..."
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:956
+msgid "Window Height:"
+msgstr "窗口高度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:947
+msgid "Window Width:"
+msgstr "窗口宽度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2031
+msgid "directory"
+msgstr "目录"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2033
+msgid "file"
+msgstr "文件"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2037
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2040
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2162
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2167
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2406
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2458
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2467
+msgid "item"
+msgstr "物件"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2035
+msgid "symbolic link"
+msgstr "符号链接"

--- a/applications/luci-app-filemanager/po/zh_Hant/filemanager.po
+++ b/applications/luci-app-filemanager/po/zh_Hant/filemanager.po
@@ -1,0 +1,442 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2024-12-29 00:30+0000\n"
+"Last-Translator: Anya Lin <hukk1996@gmail.com>\n"
+"Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationsfilemanager/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.3-dev\n"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:848
+msgid "Actions"
+msgstr "動作"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1607
+msgid "Are you sure you want to delete the selected files and directories?"
+msgstr "您確定要刪除選定的檔案和目錄嗎？"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2043
+msgid "Are you sure you want to delete this %s: \"%s\"?"
+msgstr "您確定要刪除此%s: \"%s\" 嗎？"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2458
+msgid "Changes to %s \"%s\" uploaded successfully."
+msgstr "對%s \"%s\" 的變更已成功。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1023
+msgid "Column Max Widths (format: name:maxWidth,type:maxWidth,...):"
+msgstr "最大列寬 (格式: name:maxWidth,type:maxWidth,...):"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1012
+msgid "Column Min Widths (format: name:minWidth,type:minWidth,...):"
+msgstr "最小列寬 (格式: name:minWidth,type:minWidth,...):"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1001
+msgid "Column Widths (format: name:width,type:width,...):"
+msgstr "列寬 (格式: name:width,type:width,...):"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1494
+msgid "Create"
+msgstr "創建"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1445
+msgid "Create Directory:"
+msgstr "創建目錄:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:898
+msgid "Create File"
+msgstr "創建檔案"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1502
+msgid "Create File:"
+msgstr "創建檔案:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:894
+msgid "Create Folder"
+msgstr "建立資料夾"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1061
+msgid "Current Directory:"
+msgstr "當前目錄:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:1238
+msgid "Decoded Text"
+msgstr "解碼文字"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:904
+msgid "Delete Selected"
+msgstr "刪除選定"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2051
+msgid "Deleted %s: \"%s\"."
+msgstr "已刪除 %s: \"%s\"。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1707
+msgid "Directory"
+msgstr "目錄"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1461
+msgid "Directory \"%s\" created successfully."
+msgstr "目錄 \"%s\" 已成功創建。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1428
+msgid "Directory Name"
+msgstr "目錄名"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2015
+msgid "Downloaded file: \"%s\"."
+msgstr "下載檔案: \"%s\"."
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:859
+msgid "Drop files here to upload"
+msgstr "將檔案拖曳到此處進行上傳"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2406
+msgid "Editing %s: \"%s\""
+msgstr "編輯中%s: \"%s\""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2784
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2788
+msgid "Editing:"
+msgstr "編輯中:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:740
+msgid "Editor"
+msgstr "編輯"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2182
+msgid "Editor textarea not found."
+msgstr "未找到編輯器 textarea。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2300
+msgid "Failed to access symlink target: %s"
+msgstr "無法存取符號連結目標: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1276
+msgid "Failed to access the specified path: %s"
+msgstr "無法存取指定路徑: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2261
+msgid "Failed to apply permissions to file \"%s\": %s"
+msgstr "無法對檔案 \"%s\" 應用權限: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1470
+msgid "Failed to create directory \"%s\": %s"
+msgstr "無法創建目錄 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1527
+msgid "Failed to create file \"%s\": %s"
+msgstr "無法創建檔案 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2054
+msgid "Failed to delete %s \"%s\": %s"
+msgstr "無法刪除%s \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1613
+msgid "Failed to delete %s: %s"
+msgstr "無法刪除 %s: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1624
+msgid "Failed to delete selected files and directories: %s"
+msgstr "無法刪除選定的檔案和目錄: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1636
+msgid "Failed to display the file list."
+msgstr "無法顯示文件清單。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2018
+msgid "Failed to download file \"%s\": %s"
+msgstr "無法下載檔案 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2167
+msgid "Failed to duplicate %s \"%s\": %s"
+msgstr "無法複製%s \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2170
+msgid "Failed to get file list: %s"
+msgstr "無法取得文件清單: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1813
+msgid "Failed to load file list: %s"
+msgstr "無法載入檔案清單: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1977
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1979
+msgid "Failed to open file: %s"
+msgstr "無法開啟檔案: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1225
+msgid "Failed to render Help content: Container not found."
+msgstr "無法呈現幫助內容: 找不到容器。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2467
+msgid "Failed to save changes to %s \"%s\": %s"
+msgstr "無法保存對%s \"%s\" 的變更: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2277
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2279
+msgid "Failed to save file \"%s\": %s"
+msgstr "無法保存檔案 \"%s\": %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2584
+msgid "Failed to save settings: %s"
+msgstr "無法保存設定: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1190
+msgid "Failed to update file list: %s"
+msgstr "無法更新文件列表: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1734
+msgid "File"
+msgstr "檔案"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1518
+msgid "File \"%s\" created successfully."
+msgstr "文档 \"%s\" 已成功創建。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1398
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1400
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2254
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2256
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2265
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2267
+msgid "File \"%s\" uploaded successfully."
+msgstr "文档 \"%s\" 已成功上傳。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:731
+#: applications/luci-app-filemanager/root/usr/share/luci/menu.d/luci-app-filemanager.json:3
+msgid "File Manager"
+msgstr "檔案管理器"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:697
+msgid "File Manager:"
+msgstr "檔案管理器:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1485
+msgid "File Name"
+msgstr "檔案名"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:713
+msgid "Go"
+msgstr "前往"
+
+#: applications/luci-app-filemanager/root/usr/share/rpcd/acl.d/luci-app-filemanager.json:3
+msgid "Grant access to File Manager"
+msgstr "授予訪問 File Manager 的權限"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:759
+msgid "Help"
+msgstr "幫助"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:992
+msgid "Hex Editor Height:"
+msgstr "十六進位編輯器高度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:983
+msgid "Hex Editor Width:"
+msgstr "十六進位編輯器寬度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:939
+msgid "Interface Settings"
+msgstr "介面設定"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:830
+msgid "Last Modified"
+msgstr "最後修改"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1928
+msgid "Loading file..."
+msgstr ""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:791
+msgid "Name"
+msgstr "名稱"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1467
+msgid "No directory selected."
+msgstr "未選擇目錄。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:877
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1345
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1524
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1804
+msgid "No file selected."
+msgstr "未選擇檔案。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2464
+msgid "No item selected."
+msgstr "未選擇物件。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:1226
+msgid "Offset (h)"
+msgstr "Offset (hex)"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1052
+msgid "Padding Max:"
+msgstr "最大 Padding:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1043
+msgid "Padding Min:"
+msgstr "最小 Padding:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1034
+msgid "Padding:"
+msgstr "Padding:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1075
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1437
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2396
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2713
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2755
+msgid "Save"
+msgstr "保存"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2224
+msgid "Saving file: \"%s\"..."
+msgstr ""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:428
+msgid "Search ASCII"
+msgstr "搜尋 ASCII"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:431
+msgid "Search HEX (e.g., 4F6B)"
+msgstr "搜尋 HEX (e.g., 4F6B)"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager/HexEditor.js:434
+msgid "Search RegExp (e.g., \\d{3})"
+msgstr "搜尋 RegExp (e.g., \\d{3})"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:916
+msgid "Select a file from the list to edit it here."
+msgstr "從清單中選擇一個档案以在此處進行編輯。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1617
+msgid "Selected files and directories deleted successfully."
+msgstr "選定的檔案和目錄已成功刪除。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:749
+msgid "Settings"
+msgstr "設定"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2554
+msgid "Settings uploaded successfully."
+msgstr "設定已成功保存。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:817
+msgid "Size"
+msgstr "档案大小"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:834
+msgid "Sort by Last Modified"
+msgstr "按最后修改時間排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:795
+msgid "Sort by Name"
+msgstr "按名稱排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:821
+msgid "Sort by Size"
+msgstr "按档案大小排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:808
+msgid "Sort by Type"
+msgstr "按類型排序"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2045
+msgid "Successfully deleted %s: \"%s\"."
+msgstr "成功刪除%s: \"%s\"。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2162
+msgid "Successfully duplicated %s \"%s\" as \"%s\"."
+msgstr "成功將%s \"%s\" 複製為 \"%s\"。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1779
+msgid "Symlink"
+msgstr "符號連結"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2304
+msgid "Symlink:"
+msgstr "符號連結:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:974
+msgid "Text Editor Height:"
+msgstr "文本編輯器高度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:965
+msgid "Text Editor Width:"
+msgstr "文本編輯器寬度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1273
+msgid "The specified path does not appear to be a directory."
+msgstr "指定的路徑似乎不是目錄。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2297
+msgid "The symlink points to an unsupported type."
+msgstr "符號連結指向不支援的類型。"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2729
+msgid "Toggle Line Numbers"
+msgstr "切換行號顯示"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2763
+msgid "Toggle to ASCII Mode"
+msgstr "切換到 ASCII 模式"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2721
+msgid "Toggle to Hex Mode"
+msgstr "切換到十六進位模式"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:804
+msgid "Type"
+msgstr "類型"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1786
+msgid "Unknown"
+msgstr ""
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:890
+msgid "Upload File"
+msgstr "上傳檔案"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1408
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1410
+msgid "Upload failed for file \"%s\": %s"
+msgstr "檔案 \"%s\" 上傳失敗: %s"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:1372
+msgid "Uploading: \"%s\"..."
+msgstr "正在上傳: \"%s\"..."
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:956
+msgid "Window Height:"
+msgstr "窗口高度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:947
+msgid "Window Width:"
+msgstr "窗口寬度:"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2031
+msgid "directory"
+msgstr "目錄"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2033
+msgid "file"
+msgstr "檔案"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2037
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2040
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2162
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2167
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2406
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2458
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2467
+msgid "item"
+msgstr "物件"
+
+#: applications/luci-app-filemanager/htdocs/luci-static/resources/view/system/filemanager.js:2035
+msgid "symbolic link"
+msgstr "符號連結"


### PR DESCRIPTION

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86_64, openwrt 24.10.0-rc2, Chrome) :white_check_mark:
- [x] \( Preferred ) Mention: @rdmitry0911 Dmitry R <rdmitry0911@gmail.com>
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: openwrt/luci#7509
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: The [weblate](https://hosted.weblate.org/projects/openwrt/luciapplicationsfilemanager/) page doesn't exist, so I can only commit directly to the repository.
