### PR TITLE
luci-app-ddns: Update global cacert path doc to reflect it is a file not a dir

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -440,8 +440,8 @@ return view.extend({
 
 		}
 
-		o = s.taboption('global', form.Value, 'cacert', _('CA Certs path'));
-		o.description = _('CA certificates path that will be used to download services data. Set IGNORE to skip certificate validation.');
+		o = s.taboption('global', form.Value, 'cacert', _('CA cert bundle file'));
+		o.description = _('CA certificate bundle file that will be used to download services data. Set IGNORE to skip certificate validation.');
 		o.placeholder = 'IGNORE';
 		o.write = function(section_id, value) {
 			if(value == 'ignore')

--- a/applications/luci-app-ddns/po/ar/ddns.po
+++ b/applications/luci-app-ddns/po/ar/ddns.po
@@ -61,12 +61,12 @@ msgstr ""
 "المحددة بشكل صحيح!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "مسار شهادات Ca"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "مسار شهادات Ca الذي سيتم استخدامه لتنزيل بيانات الخدمات. قم بتعيين IGNORE "

--- a/applications/luci-app-ddns/po/bg/ddns.po
+++ b/applications/luci-app-ddns/po/bg/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/bn_BD/ddns.po
+++ b/applications/luci-app-ddns/po/bn_BD/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/ca/ddns.po
+++ b/applications/luci-app-ddns/po/ca/ddns.po
@@ -61,12 +61,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/cs/ddns.po
+++ b/applications/luci-app-ddns/po/cs/ddns.po
@@ -66,12 +66,12 @@ msgstr ""
 "BusyBox, nemůže správně zpracovat uvedené servery DNS!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Adresář certifikátů CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Adresář který bude využit pro stažení dat služeb. Nastavte na IGNORE pro "

--- a/applications/luci-app-ddns/po/da/ddns.po
+++ b/applications/luci-app-ddns/po/da/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/de/ddns.po
+++ b/applications/luci-app-ddns/po/de/ddns.po
@@ -65,12 +65,12 @@ msgstr ""
 "Server nicht korrekt verarbeiten!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Pfad zu CA-Zertifikaten"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Ca Certs Pfad, der für das Herunterladen von Servicedaten verwendet werden "

--- a/applications/luci-app-ddns/po/el/ddns.po
+++ b/applications/luci-app-ddns/po/el/ddns.po
@@ -59,12 +59,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/es/ddns.po
+++ b/applications/luci-app-ddns/po/es/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "los servidores DNS determinados!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Ruta de certificados CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Ruta de los certificados CA que se utilizarán para descargar los datos de "

--- a/applications/luci-app-ddns/po/fa/ddns.po
+++ b/applications/luci-app-ddns/po/fa/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/fi/ddns.po
+++ b/applications/luci-app-ddns/po/fi/ddns.po
@@ -60,12 +60,12 @@ msgstr ""
 "DNS-palvelimia oikein!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "CaCerts-polku"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Ca Certs -polku, jota käytetään palvelutietojen lataamiseen. Aseta IGNORE "

--- a/applications/luci-app-ddns/po/fr/ddns.po
+++ b/applications/luci-app-ddns/po/fr/ddns.po
@@ -65,12 +65,12 @@ msgstr ""
 "correctement les serveurs DNS donnés !"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Chemin d'accès des certificats CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Chemin d'accès Ca Certs qui sera utilisé afin de télécharger les données de "

--- a/applications/luci-app-ddns/po/ga/ddns.po
+++ b/applications/luci-app-ddns/po/ga/ddns.po
@@ -61,12 +61,12 @@ msgstr ""
 "DNS a thugtar i gceart!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Cosán Teastais CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Conair deimhnithe CA a úsáidfear chun sonraí seirbhísí a íoslódáil. Socraigh "

--- a/applications/luci-app-ddns/po/he/ddns.po
+++ b/applications/luci-app-ddns/po/he/ddns.po
@@ -59,12 +59,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/hi/ddns.po
+++ b/applications/luci-app-ddns/po/hi/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/hu/ddns.po
+++ b/applications/luci-app-ddns/po/hu/ddns.po
@@ -59,12 +59,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/it/ddns.po
+++ b/applications/luci-app-ddns/po/it/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "Server DNS correttamente!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Percorso certificati CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Percorso dei certificati CA che verrà utilizzato per scaricare i dati dei "

--- a/applications/luci-app-ddns/po/ja/ddns.po
+++ b/applications/luci-app-ddns/po/ja/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "バーを正しく処理しません！"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "CA 証明書パス"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "サービスデータをダウンロードするために使用される CA 証明書のパスです。証明書"

--- a/applications/luci-app-ddns/po/ko/ddns.po
+++ b/applications/luci-app-ddns/po/ko/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "CA 인증서 경로"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "서비스 데이터를 다운로드할 때 사용될 CA 인증서의 경로입니다. IGNORE로 설정하"

--- a/applications/luci-app-ddns/po/lt/ddns.po
+++ b/applications/luci-app-ddns/po/lt/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "netvarko duotus „DNS“ serverius tinkamai!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "„CA“ sertifikatų kelias"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "„CA“ sertifikatų kelias bus naudojamas atsisiųsti tarnybos duomenis. "

--- a/applications/luci-app-ddns/po/mr/ddns.po
+++ b/applications/luci-app-ddns/po/mr/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/ms/ddns.po
+++ b/applications/luci-app-ddns/po/ms/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/nb_NO/ddns.po
+++ b/applications/luci-app-ddns/po/nb_NO/ddns.po
@@ -59,12 +59,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/nl/ddns.po
+++ b/applications/luci-app-ddns/po/nl/ddns.po
@@ -61,12 +61,12 @@ msgstr ""
 "servers niet correct verwerken!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Ca Certs pad"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Ca Certs-pad dat wordt gebruikt om servicegegevens te downloaden. Stel "

--- a/applications/luci-app-ddns/po/pl/ddns.po
+++ b/applications/luci-app-ddns/po/pl/ddns.po
@@ -64,12 +64,12 @@ msgstr ""
 "podanych serwerów DNS!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Ścieżka certyfikatów CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Ścieżka certyfikatów CA do pobierania danych usług. Ustaw IGNORE, aby "

--- a/applications/luci-app-ddns/po/pt/ddns.po
+++ b/applications/luci-app-ddns/po/pt/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "corretamente com os servidores de DNS dados!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Caminho de Certs de Ac"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Caminho de Certs Ac que será usado para descarregar os dados dos serviços. "

--- a/applications/luci-app-ddns/po/pt_BR/ddns.po
+++ b/applications/luci-app-ddns/po/pt_BR/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "com servidores DNS dados!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Caminho dos certificados Ca"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "O caminho dos certificados Ca que serão utilizados para fazer o download dos "

--- a/applications/luci-app-ddns/po/ro/ddns.po
+++ b/applications/luci-app-ddns/po/ro/ddns.po
@@ -64,12 +64,12 @@ msgstr ""
 "serverele DNS date!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Ca Certs cale de acces"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Ca Certs calea de acces care va fi utilizată pentru a descărca datele "

--- a/applications/luci-app-ddns/po/ru/ddns.po
+++ b/applications/luci-app-ddns/po/ru/ddns.po
@@ -67,12 +67,12 @@ msgstr ""
 "данными серверами DNS!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Путь к сертификатам CA"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Путь к сертификатам CA, которые будут использоваться для загрузки данных "

--- a/applications/luci-app-ddns/po/sk/ddns.po
+++ b/applications/luci-app-ddns/po/sk/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/sv/ddns.po
+++ b/applications/luci-app-ddns/po/sv/ddns.po
@@ -56,12 +56,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Sökväg till CA-certifikat"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Sökvägen till CA-certifikaten som används för att ladda ner tjänstdata. Välj "

--- a/applications/luci-app-ddns/po/templates/ddns.pot
+++ b/applications/luci-app-ddns/po/templates/ddns.pot
@@ -47,12 +47,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA bundle file path"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"File path of the CA bundle that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/tr/ddns.po
+++ b/applications/luci-app-ddns/po/tr/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "doğru şekilde işlemez!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Ca Sertifikaları yolu"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Servis verilerini indirmek için kullanılacak Ca Sertifikaları yolu. "

--- a/applications/luci-app-ddns/po/uk/ddns.po
+++ b/applications/luci-app-ddns/po/uk/ddns.po
@@ -62,12 +62,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Шлях до CA сертифікатів"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/vi/ddns.po
+++ b/applications/luci-app-ddns/po/vi/ddns.po
@@ -63,12 +63,12 @@ msgstr ""
 "xác!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Đường dẫn Ca Certs"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 "Đường dẫn Ca Certs sẽ được sử dụng để tải dữ liệu dịch vụ. Đặt IGNORE để bỏ "

--- a/applications/luci-app-ddns/po/yua/ddns.po
+++ b/applications/luci-app-ddns/po/yua/ddns.po
@@ -50,12 +50,12 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr ""
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr ""
 

--- a/applications/luci-app-ddns/po/zh_Hans/ddns.po
+++ b/applications/luci-app-ddns/po/zh_Hans/ddns.po
@@ -64,12 +64,12 @@ msgid ""
 msgstr "当前编译版本中的 BusyBox 的 nslookup 不能正确处理给定的 DNS 服务器！"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "Ca 证书路径"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr "用于下载服务数据的 Ca 证书路径。设置 IGNORE 将跳过证书验证。"
 

--- a/applications/luci-app-ddns/po/zh_Hant/ddns.po
+++ b/applications/luci-app-ddns/po/zh_Hant/ddns.po
@@ -62,12 +62,12 @@ msgid ""
 msgstr "現行編譯版本中BusyBox的nslookup無法正確處理給定的DNS伺服器！"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:443
-msgid "CA Certs path"
+msgid "CA cert bundle file"
 msgstr "CA憑證路徑"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:444
 msgid ""
-"CA certificates path that will be used to download services data. Set IGNORE "
+"CA certificate bundle file that will be used to download services data. Set IGNORE "
 "to skip certificate validation."
 msgstr "下載服務資料使用的CA憑證路徑；設定IGNORE來略過憑證驗證。"
 


### PR DESCRIPTION
Description:
1. The UI (`Dynamic DNS > Global Settings`) describes `cacert` as the path for certificates (plural)
2. However, code in `packages/net/ddns-scripts/files/usr/bin/ddns.sh` expects the parameter to be a file path, i.e., a certificate bundle, not a directory
3. Therefore (1) is misleading and if someone supplies a directory, e.g., `/etc/ssl/certs`, DDNS services list updates silently fail

I would expect the following to succeed given how this parameter is documented:
```
# uci get ddns.global.cacert
/etc/ssl/certs/
# ls /etc/ssl/certs/
ca-certificates.crt
# /usr/bin/ddns service update
Certification file not found (/etc/ssl/certs/)
```

When a file path is used instead, DDNS service update succeeds:
```
# uci get ddns.global.cacert
/etc/ssl/certs/ca-certificates.crt
# /usr/bin/ddns service update
Downloading 'https://raw.githubusercontent.com/openwrt/packages/master/net/ddns-scripts/files/usr/share/ddns/list'
[...]
Download completed (825 bytes)
```

This change updates the language in `Dynamic DNS > Global Settings` to indicate that `cacert` is a file and not a directory.