### PR TITLE
luci-base: allow sort value to be reassigned

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -3075,7 +3075,7 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 		ev.currentTarget.parentNode.querySelectorAll('tr.cbi-section-table-row').forEach(L.bind((tr, i) => {
 			const sid = tr.getAttribute('data-sid');
 			const opt = tr.childNodes[index].getAttribute('data-name');
-			const val = this.cfgvalue(sid, opt);
+			let val = this.cfgvalue(sid, opt);
 
 			tr.querySelectorAll('.flash').forEach((n) => {
 				n.classList.remove('flash')


### PR DESCRIPTION
Commit 234e1315073595771a7397d74a039d0eb4c1a89d changed the "val" variable to be a constant, but it's value is reassigned later. Change the variable to be declared with let instead so it can be reassigned.

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile N/A
- [X] Tested on: (x86/64, 24.10.0-rc4, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @systemcrash 
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: e.g. openwrt/luci#7519
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)

Before: sorting on zone forwardings fails (applies to all GridSections)
![Screenshot_18](https://github.com/user-attachments/assets/87c0d29a-8a0c-44c6-a0ab-495e03f1e86f)

After: sorting on zone forwardings works correctly (applies to all GridSections)
![Screenshot_19](https://github.com/user-attachments/assets/476d8df4-d839-44ee-b488-2f7561c158cd)
![Screenshot_20](https://github.com/user-attachments/assets/60cec402-3409-41b8-9e8d-f92057509cdf)
