### PR TITLE
luci-mod-network: handle missing dnsrr hexdata as empty string

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1067,13 +1067,13 @@ return view.extend({
 		ss.nodescriptions = true;
 
 		function hexdecodeload(section_id) {
-			let arr = uci.get('dhcp', section_id, this.option) || [];
+			let value = uci.get('dhcp', section_id, this.option) || '';
 			// Remove any spaces or colons from the hex string - they're allowed
-			arr = arr.replace(/[\s:]/g, '');
+			value = value.replace(/[\s:]/g, '');
 			// Hex-decode the string before displaying
 			let decodedString = '';
-			for (let i = 0; i < arr.length; i += 2) {
-				decodedString += String.fromCharCode(parseInt(arr.substr(i, 2), 16));
+			for (let i = 0; i < value.length; i += 2) {
+				decodedString += String.fromCharCode(parseInt(value.substr(i, 2), 16));
 			}
 			return decodedString;
 		}
@@ -1109,7 +1109,7 @@ return view.extend({
 		so.width = '10%';
 		so.rawhtml = true;
 		so.load = function(section_id) {
-			let hexdata = uci.get('dhcp', section_id, 'hexdata') || [];
+			let hexdata = uci.get('dhcp', section_id, 'hexdata') || '';
 			hexdata = hexdata.replace(/[:]/g, '');
 			if (hexdata) {
 				return hexdata.replace(/(.{20})/g, '$1<br/>'); // Inserts <br> after every 2 characters (hex pair)


### PR DESCRIPTION
If the value returned from UCI was falsy, it became an empty array instead of an empty string, which crashed the UI when trying to invoke the non-existing replace instance function on the value.

First observed here https://forum.openwrt.org/t/openwrt-24-10-0-rc4-fourth-release-candidate/219368/145?u=dannil

Before:

https://github.com/user-attachments/assets/5549cf24-7aae-4a01-9e6c-00184a4054b2

```
root@labmouse:~# cat /etc/config/dhcp

config dnsmasq
        option domainneeded '1'
        option localise_queries '1'
        option rebind_protection '1'
        option rebind_localhost '1'
        option local '/lan/'
        option domain 'lan'
        option expandhosts '1'
        option cachesize '1000'
        option authoritative '1'
        option readethers '1'
        option leasefile '/tmp/dhcp.leases'
        option resolvfile '/tmp/resolv.conf.d/resolv.conf.auto'
        option localservice '1'
        option ednspacket_max '1232'
        option confdir '/tmp/dnsmasq.d'

config dhcp 'lan'
        option interface 'lan'
        option start '100'
        option limit '150'
        option leasetime '12h'
        option dhcpv4 'server'
        option dhcpv6 'server'
        option ra 'server'
        option ra_slaac '1'
        list ra_flags 'managed-config'
        list ra_flags 'other-config'

config odhcpd 'odhcpd'
        option maindhcp '0'
        option leasefile '/tmp/hosts/odhcpd'
        option leasetrigger '/usr/sbin/odhcpd-update'
        option loglevel '4'

config dnsrr

```

After:

https://github.com/user-attachments/assets/fd7442d0-e2ff-4e57-bd1d-070e763f8e85

```
root@labmouse:~# cat /etc/config/dhcp

config dnsmasq
        option domainneeded '1'
        option localise_queries '1'
        option rebind_protection '1'
        option rebind_localhost '1'
        option local '/lan/'
        option domain 'lan'
        option expandhosts '1'
        option cachesize '1000'
        option authoritative '1'
        option readethers '1'
        option leasefile '/tmp/dhcp.leases'
        option resolvfile '/tmp/resolv.conf.d/resolv.conf.auto'
        option localservice '1'
        option ednspacket_max '1232'
        option confdir '/tmp/dnsmasq.d'

config dhcp 'lan'
        option interface 'lan'
        option start '100'
        option limit '150'
        option leasetime '12h'
        option dhcpv4 'server'
        option dhcpv6 'server'
        option ra 'server'
        option ra_slaac '1'
        list ra_flags 'managed-config'
        list ra_flags 'other-config'

config odhcpd 'odhcpd'
        option maindhcp '0'
        option leasefile '/tmp/hosts/odhcpd'
        option leasetrigger '/usr/sbin/odhcpd-update'
        option loglevel '4'

config dnsrr
        option dnsrr 'r1.labmouse.lan.'
        option rrnumber '64'
        option hexdata '666f6f626172'

```

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile N/A
- [X] Tested on: (x86/64, 24.10.0-rc4, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @systemcrash 
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
