### PR TITLE
luci-app-nut: fix wrong nut_server option

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -160,7 +160,7 @@ return view.extend({
 		o = s.option(form.ListValue, 'driver', _('Driver'),
 			_('If this list is empty you need to %s'.format('<a href="/cgi-bin/luci/admin/system/package-manager?query=nut-driver-">%s</a>'.format(_('install drivers')))));
 		driver_list.forEach(driver => {
-			o.value(driver_path + driver);
+			o.value(driver);
 		});
 		o.optional = false;
 


### PR DESCRIPTION
There is no driver_path prefix in the original lua code.
https://github.com/openwrt/luci/blob/f6e6b055d514595941db4a4cc11c3d9902eabefb/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua#L132-L135
and currently the uci configuration file does not require this path prefix by default.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86/64, 24.10.0-rc4, Edge) :white_check_mark:
- [x] \( Preferred ) Mention: @systemcrash the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: [openwrt/packages#25552](https://github.com/openwrt/packages/issues/25552)
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
