### PR TITLE
luci-mod-status: 29_ports.js: improve speed formatting

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/29_ports.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/29_ports.js
@@ -214,16 +214,20 @@ function formatSpeed(carrier, speed, duplex) {
 		var d = (duplex == 'half') ? '\u202f(H)' : '',
 		    e = E('span', { 'title': _('Speed: %d Mibit/s, Duplex: %s').format(speed, duplex) });
 
-		switch (speed) {
-		case 10:    e.innerText = '10\u202fM' + d;  break;
-		case 100:   e.innerText = '100\u202fM' + d; break;
-		case 1000:  e.innerText = '1\u202fGbE' + d; break;
-		case 2500:  e.innerText = '2.5\u202fGbE';   break;
-		case 5000:  e.innerText = '5\u202fGbE';     break;
-		case 10000: e.innerText = '10\u202fGbE';    break;
-		case 25000: e.innerText = '25\u202fGbE';    break;
-		case 40000: e.innerText = '40\u202fGbE';    break;
-		default:    e.innerText = '%d\u202fMbE%s'.format(speed, d);
+		switch (true) {
+		case (speed < 1000):
+			e.innerText = '%d\u202fM%s'.format(speed, d);
+			break;
+		case (speed == 1000):
+			e.innerText = '1\u202fGbE' + d;
+			break;
+		case (speed >= 1e6 && speed < 1e9):
+			e.innerText = '%f\u202fTbE'.format(speed / 1e6);
+			break;
+		case (speed >= 1e9):
+			e.innerText = '%f\u202fPbE'.format(speed / 1e9);
+			break;
+		default: e.innerText = '%f\u202fGbE'.format(speed / 1000);
 		}
 
 		return e;


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: x86 (Mellanox Spectrum SN3700), OpenWrt snapshot, Safari 18.1.1 :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: 

This adds more cases for a few link speeds beyond 40 GbE, i.e. for 50 GbE, 100 GbE and 200 GbE in speed formatting for luci-mod-status. While there are currently only a few devices where this may be useful, we actually operate some 200G switches and x86 devices with 200G/100G NICs.

**required to bump PKG_VERSION ?**