### PR TITLE
luci-proto-3g/ppp/pppossh: fix setting of keepalive

### DIFF
--- a/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
+++ b/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
@@ -23,14 +23,14 @@ network.registerPatternVirtual(/^3g-.+$/);
 function write_keepalive(section_id, value) {
 	var f_opt = this.map.lookupOption('_keepalive_failure', section_id),
 	    i_opt = this.map.lookupOption('_keepalive_interval', section_id),
-	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
-	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
+	    f = parseInt(f_opt?.[0]?.formvalue(section_id), 10),
+	    i = parseInt(i_opt?.[0]?.formvalue(section_id), 10);
 
-	if (f === '' || isNaN(f))
-		f = null;
-
-	if (i == null || i == '' || isNaN(i) || i < 1)
+	if (isNaN(i))
 		i = 1;
+
+	if (isNaN(f))
+		f = (i == 1) ? null : 5;
 
 	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
@@ -142,7 +142,7 @@ return network.registerProtocol('3g', {
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
 		o.placeholder = '1';
-		o.datatype    = 'min(1)';
+		o.datatype    = 'and(uinteger,min(1))';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
 		o.cfgvalue = function(section_id) {

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js
@@ -23,14 +23,14 @@ network.registerPatternVirtual(/^ppp-.+$/);
 function write_keepalive(section_id, value) {
 	var f_opt = this.map.lookupOption('_keepalive_failure', section_id),
 	    i_opt = this.map.lookupOption('_keepalive_interval', section_id),
-	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
-	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
+	    f = parseInt(f_opt?.[0]?.formvalue(section_id), 10),
+	    i = parseInt(i_opt?.[0]?.formvalue(section_id), 10);
 
-	if (f === '' || isNaN(f))
-		f = null;
-
-	if (i == null || i == '' || isNaN(i) || i < 1)
+	if (isNaN(i))
 		i = 1;
+
+	if (isNaN(f))
+		f = (i == 1) ? null : 5;
 
 	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
@@ -114,7 +114,7 @@ return network.registerProtocol('ppp', {
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
 		o.placeholder = '1';
-		o.datatype    = 'min(1)';
+		o.datatype    = 'and(uinteger,min(1))';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
 		o.cfgvalue = function(section_id) {

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoa.js
@@ -8,14 +8,14 @@ network.registerPatternVirtual(/^pppoa-.+$/);
 function write_keepalive(section_id, value) {
 	var f_opt = this.map.lookupOption('_keepalive_failure', section_id),
 	    i_opt = this.map.lookupOption('_keepalive_interval', section_id),
-	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
-	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
+	    f = parseInt(f_opt?.[0]?.formvalue(section_id), 10),
+	    i = parseInt(i_opt?.[0]?.formvalue(section_id), 10);
 
-	if (f === '' || isNaN(f))
-		f = null;
-
-	if (i == null || i == '' || isNaN(i) || i < 1)
+	if (isNaN(i))
 		i = 1;
+
+	if (isNaN(f))
+		f = (i == 1) ? null : 5;
 
 	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
@@ -100,7 +100,7 @@ return network.registerProtocol('pppoa', {
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
 		o.placeholder = '1';
-		o.datatype    = 'min(1)';
+		o.datatype    = 'and(uinteger,min(1))';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
 		o.cfgvalue = function(section_id) {

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js
@@ -8,14 +8,14 @@ network.registerPatternVirtual(/^pppoe-.+$/);
 function write_keepalive(section_id, value) {
 	var f_opt = this.map.lookupOption('_keepalive_failure', section_id),
 	    i_opt = this.map.lookupOption('_keepalive_interval', section_id),
-	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
-	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
+	    f = parseInt(f_opt?.[0]?.formvalue(section_id), 10),
+	    i = parseInt(i_opt?.[0]?.formvalue(section_id), 10);
 
-	if (f === '' || isNaN(f))
-		f = null;
-
-	if (i == null || i == '' || isNaN(i) || i < 1)
+	if (isNaN(i))
 		i = 1;
+
+	if (isNaN(f))
+		f = (i == 1) ? null : 5;
 
 	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
@@ -74,7 +74,7 @@ return network.registerProtocol('pppoe', {
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
 		o.placeholder = '1';
-		o.datatype    = 'min(1)';
+		o.datatype    = 'and(uinteger,min(1))';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
 		o.cfgvalue = function(section_id) {

--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js
@@ -8,14 +8,14 @@ network.registerPatternVirtual(/^pptp-.+$/);
 function write_keepalive(section_id, value) {
 	var f_opt = this.map.lookupOption('_keepalive_failure', section_id),
 	    i_opt = this.map.lookupOption('_keepalive_interval', section_id),
-	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
-	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
+	    f = parseInt(f_opt?.[0]?.formvalue(section_id), 10),
+	    i = parseInt(i_opt?.[0]?.formvalue(section_id), 10);
 
-	if (f === '' || isNaN(f))
-		f = null;
-
-	if (i == null || i == '' || isNaN(i) || i < 1)
+	if (isNaN(i))
 		i = 1;
+
+	if (isNaN(f))
+		f = (i == 1) ? null : 5;
 
 	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
@@ -87,7 +87,7 @@ return network.registerProtocol('pptp', {
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
 		o.placeholder = '1';
-		o.datatype    = 'min(1)';
+		o.datatype    = 'and(uinteger,min(1))';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
 		o.cfgvalue = function(section_id) {

--- a/protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js
+++ b/protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js
@@ -8,14 +8,14 @@ network.registerPatternVirtual(/^pppossh-.+$/);
 function write_keepalive(section_id, value) {
 	var f_opt = this.map.lookupOption('_keepalive_failure', section_id),
 	    i_opt = this.map.lookupOption('_keepalive_interval', section_id),
-	    f = (f_opt != null) ? +f_opt[0].formvalue(section_id) : null,
-	    i = (i_opt != null) ? +i_opt[0].formvalue(section_id) : null;
+	    f = parseInt(f_opt?.[0]?.formvalue(section_id), 10),
+	    i = parseInt(i_opt?.[0]?.formvalue(section_id), 10);
 
-	if (f === '' || isNaN(f))
-		f = null;
-
-	if (i == null || i == '' || isNaN(i) || i < 1)
+	if (isNaN(i))
 		i = 1;
+
+	if (isNaN(f))
+		f = (i == 1) ? null : 5;
 
 	if (f !== null)
 		uci.set('network', section_id, 'keepalive', '%d %d'.format(f, i));
@@ -110,7 +110,7 @@ return network.registerProtocol('pppossh', {
 
 		o = s.taboption('advanced', form.Value, '_keepalive_interval', _('LCP echo interval'), _('Send LCP echo requests at the given interval in seconds, only effective in conjunction with failure threshold'));
 		o.placeholder = '1';
-		o.datatype    = 'min(1)';
+		o.datatype    = 'and(uinteger,min(1))';
 		o.write       = write_keepalive;
 		o.remove      = write_keepalive;
 		o.cfgvalue = function(section_id) {


### PR DESCRIPTION
Fix regressions from previous fix:

1) It is no longer possible to leave the keepalive option empty. Then
   it becomes keepalive='0 1'

2) In case the interval is different from 1 it is necessary to
   explicitly set the option even if failures is left empty.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
