### PR TITLE
luci-app-ddns: avoid Absent Interface: "wan" when the physical device does not exist

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -7,6 +7,7 @@
 'require rpc';
 'require fs';
 'require form';
+'require network';
 'require tools.widgets as widgets';
 
 return view.extend({
@@ -98,6 +99,16 @@ return view.extend({
 					_this.services[service] = false;
 			});
 		}, this))
+	},
+
+	/*
+	* Figure out what the wan interface on the device is.
+	* Determine if the physical device exist, or if we should use an alias.
+	*/
+	callGetWanInterface: function(m, ev) {
+		return network.getDevice('wan').then(dev => dev.getName())
+			.catch(err => network.getNetwork('wan').then(net => '@' + net.getName()))
+			.catch(err => null);
 	},
 
 	/*
@@ -243,7 +254,8 @@ return view.extend({
 			this.callDDnsGetStatus(),
 			this.callDDnsGetEnv(),
 			this.callGenServiceList(),
-			uci.load('ddns')
+			uci.load('ddns'),
+			this.callGetWanInterface()
 		]);
 	},
 
@@ -252,6 +264,7 @@ return view.extend({
 		var status = data[1] || [];
 		var env = data[2] || [];
 		var logdir = uci.get('ddns', 'global', 'ddns_logdir') || "/var/log/ddns";
+		var wan_interface = data[5];
 
 		var _this = this;
 
@@ -851,7 +864,7 @@ return view.extend({
 					o.modalonly = true;
 					o.depends("ip_source", "interface")
 					o.multiple = false;
-					o.default = 'wan';
+					o.default = wan_interface;
 
 					o = s.taboption('advanced', form.Value, 'ip_script',
 						_("Script"),


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: a x86_64 VM with OpenWrt 24.10.0-rc5 (r28304-6dacba30a7)
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes: 
![Screenshot_2025-01-10_21-07-55](https://github.com/user-attachments/assets/27e3ab9f-922a-42f4-9a69-a6d9547da342)
- [x] \( Optional ) Closes https://github.com/openwrt/luci/issues/7554
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: avoid Absent Interface: "wan" -- when the physical device does not exist, the Alias Interface is likely what we want for the default.
