### PR TITLE
luci-base: add member `allowduplicates` to `DynamicList`

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -3863,6 +3863,17 @@ const CBIValue = CBIAbstractValue.extend(/** @lends LuCI.form.Value.prototype */
 const CBIDynamicList = CBIValue.extend(/** @lends LuCI.form.DynamicList.prototype */ {
 	__name__: 'CBI.DynamicList',
 
+	/**
+	 * Allows the underlying form controls to have multiple identical values.
+	 *
+	 * Default is `null`. If `true`, the underlying form value will
+	 * not be checked for duplication.
+	 *
+	 * @name LuCI.form.DynamicList.prototype#allowduplicates
+	 * @type boolean
+	 * @default null
+	 */
+
 	/** @private */
 	renderWidget(section_id, option_index, cfgvalue) {
 		const value = (cfgvalue != null) ? cfgvalue : this.default;
@@ -3872,6 +3883,7 @@ const CBIDynamicList = CBIValue.extend(/** @lends LuCI.form.DynamicList.prototyp
 		const widget = new ui.DynamicList(items, choices, {
 			id: this.cbid(section_id),
 			sort: this.keylist,
+			allowduplicates: this.allowduplicates,
 			optional: this.optional || this.rmempty,
 			datatype: this.datatype,
 			placeholder: this.placeholder,

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -2424,7 +2424,7 @@ const UIDynamicList = UIElement.extend(/** @lends LuCI.ui.DynamicList.prototype 
 				exists = true;
 		});
 
-		if (!exists) {
+		if (this.options.allowduplicates || !exists) {
 			const ai = dl.querySelector('.add-item');
 			ai.parentNode.insertBefore(new_item, ai);
 		}
@@ -2505,7 +2505,8 @@ const UIDynamicList = UIElement.extend(/** @lends LuCI.ui.DynamicList.prototype 
 			return;
 
 		sbIn.setValues(sbEl, null);
-		sbVal.element.setAttribute('unselectable', '');
+		if (!this.options.allowduplicates)
+			sbVal.element.setAttribute('unselectable', '');
 
 		if (sbVal.element.hasAttribute('created')) {
 			sbVal.element.removeAttribute('created');


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86_64, 24.10.0-rc4, Chrome) :white_check_mark:
- [x] \( Preferred ) Mention: @systemcrash 
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

## Description:

Add member `allowduplicates` to `DynamicList` to allow duplicate underlying form values.

`allowduplicates` defaults is `null`, `DynamicList` will keep the same behavior as before.
If `o.allowduplicates = true`, the underlying form value will not be checked for duplication.

## Screenshot:

![image](https://github.com/user-attachments/assets/958252af-a4fb-48f5-8263-2e545b5845dc)
