### PR TITLE
luci-app-ddns: show the URL which will be used.

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -586,6 +586,7 @@ return view.extend({
 			return _this.handleGetServiceData(service).then(L.bind(function (service_data) {
 				s.service_available = true;
 				s.service_supported = true;
+				s.url = null;
 
 				if (service != '-') {
 					if (!service_data)
@@ -594,6 +595,11 @@ return view.extend({
 						service_data = JSON.parse(service_data);
 						if (ipv6 == "1" && !service_data.ipv6)
 							s.service_supported = false;
+						else if (ipv6 == "1") {
+							s.url = service_data.ipv6.url;
+						} else {
+							s.url = service_data.ipv4.url;
+						}
 					}
 				}
 
@@ -672,6 +678,14 @@ return view.extend({
 					o.cfgvalue = function () {
 						return _("Service doesn't support this IP type")
 					};
+				}
+
+				if (Boolean(s.url)) {
+					o = s.taboption('basic', form.DummyValue, '_url', _("Update URL"));
+					o.rawhtml = true;
+					o.default = '<div style="font-family: monospace;">'
+						+ s.url.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")
+						+ '</div>';
 				}
 
 				var service_switch = s.taboption('basic', form.Button, '_switch_proto');


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: x86_64 VM with OpenWrt 24.10.0-rc5 (r28304-6dacba30a7)
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes: 
![Screenshot_2025-01-11_14-33-50](https://github.com/user-attachments/assets/e9da02f7-2c9c-40a1-aa61-266633883b68)
- [x] \( Optional ) Closes https://github.com/openwrt/luci/issues/2436
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: When using the DDNS settings, I was always puzzled a bit by the `Replaces [DOMAIN] in Update-URL (URL-encoded)` comments. It's certainly nice to have that information but I always wondered "what is that Update-URL?" for this service? Then I came across https://github.com/openwrt/luci/issues/2436 which basically discusses that this DDNS provider does not use username and expects host (?) instead. We likely cannot finetune the description of the fields in the UI to this case but maybe if we actually showed the admin the Update-URL which will be used, it might be easier for them to figure out which field to use for what.
