### PR TITLE
luci-app-nlbwmon: the default of database_compress is 1, match that behaviour in UI.

### DIFF
--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/config.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/config.js
@@ -150,6 +150,7 @@ return view.extend({
 
 		o = s.taboption('advanced', form.Flag, 'database_compress', _('Compress database'),
 			_('Whether to gzip compress archive databases. Compressing the database files makes accessing old data slightly slower but helps to reduce storage requirements.'));
+		o.default = o.enabled;
 
 		o = s.taboption('advanced', form.Value, 'database_generations', _('Stored periods'),
 			_('Maximum number of accounting periods to keep, use zero to keep databases forever.'));


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: x86_64 VM with OpenWrt 24.10.0-rc5 (r28304-6dacba30a7)
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes: 
![Screenshot_2025-01-11_16-29-38](https://github.com/user-attachments/assets/e7122071-f41f-4754-a300-ca28a524c077)
- [x] \( Optional ) Closes #5243
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: Right after fresh installation of `luci-app-nlbwmon`, the `/etc/config/nlbwmon` has
```
	# Whether to gzip compress archive databases. Compressing the database
	#option database_compress 1
```
With this change, the no option situation is matched in the UI.
