### PR TITLE
luci-mod-status: consider family when rendering nftables chains and rules

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
@@ -607,7 +607,7 @@ return view.extend({
 		]));
 
 		for (var i = 0; i < data.length; i++)
-			if (typeof(data[i].rule) == 'object' && data[i].rule.table == spec.table && data[i].rule.chain == spec.name)
+			if (typeof(data[i].rule) == 'object' && data[i].rule.table == spec.table && data[i].rule.chain == spec.name && data[i].rule.family == spec.family)
 				node.lastElementChild.appendChild(this.renderRule(data, data[i].rule));
 
 		if (node.lastElementChild.childNodes.length == 1)
@@ -669,7 +669,7 @@ return view.extend({
 		]);
 
 		for (var i = 0; i < data.length; i++)
-			if (typeof(data[i].chain) == 'object' && data[i].chain.table == spec.name)
+			if (typeof(data[i].chain) == 'object' && data[i].chain.table == spec.name && data[i].chain.family == spec.family)
 				node.lastElementChild.lastElementChild.appendChild(this.renderChain(data, data[i].chain));
 
 		return node;


### PR DESCRIPTION
In nftables, there can be multiple tables with the same name but different family attribute (inet, ip, ip6, ...). The same goes for chains. So the family attribute needs to be considered when rendering chains and rules.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [X] Description: (describe the changes proposed in this PR)

Not sure which/how to increment package version, and not sure how to test.

@jow- 