### PR TITLE
luci-base: `TextValue` enhancements

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -4391,9 +4391,11 @@ const CBITextValue = CBIValue.extend(/** @lends LuCI.form.TextValue.prototype */
 	/**
 	 * Enforces the use of a monospace font for the textarea contents when set
 	 * to `true`.
+	 * Or provide a list of fontFamily in string. e.g.
+	 * `"Cascadia Code",Menlo,Monaco,Consolas,"Liberation Mono","Courier New"`
 	 *
 	 * @name LuCI.form.TextValue.prototype#monospace
-	 * @type boolean
+	 * @type boolean|string
 	 * @default false
 	 */
 

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -468,9 +468,11 @@ const UITextarea = UIElement.extend(/** @lends LuCI.ui.Textarea.prototype */ {
 	 * Specifies the HTML `placeholder` attribute which is displayed when the
 	 * corresponding `<textarea>` element is empty.
 	 *
-	 * @property {boolean} [monospace=false]
+	 * @property {boolean|string} [monospace=false]
 	 * Specifies whether a monospace font should be forced for the textarea
 	 * contents.
+	 * Or provide a list of fontFamily in string. e.g.
+	 * `"Cascadia Code",Menlo,Monaco,Consolas,"Liberation Mono","Courier New"`
 	 *
 	 * @property {number} [cols]
 	 * Specifies the HTML `cols` attribute to set on the corresponding
@@ -513,7 +515,7 @@ const UITextarea = UIElement.extend(/** @lends LuCI.ui.Textarea.prototype */ {
 		}, [ value ]));
 
 		if (this.options.monospace)
-			frameEl.firstElementChild.style.fontFamily = 'monospace';
+			frameEl.firstElementChild.style.fontFamily = (typeof this.options.monospace === 'string') ? this.options.monospace : 'monospace';
 
 		return this.bind(frameEl);
 	},


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86_64, 24.10.0-rc4, Chrome) :white_check_mark:
- [x] \( Preferred ) Mention: @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

## Description:

Allow option `monospace` in `TextValue` to accept `string` type.

This provides the ability to customize the fontFamily of the `TextValue` for developers.

Valid Example:</br>
`"Cascadia Code",Menlo,Monaco,Consolas,"Liberation Mono","Courier New"`



