### PR TITLE
luci-app-attendedsysupgrade: sort latest version array

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -450,6 +450,9 @@ return view.extend({
 			} else {
 				const latest = response.json().latest;
 
+				// ensure order: newest to oldest release
+				latest.sort().reverse();
+
 				for (let remote_version of latest) {
 					let remote_branch = get_branch(remote_version);
 


### PR DESCRIPTION
The Attended Sysupgrade app requires that the array of latest versions be in order from newest release to oldest.  Ensure that this is true even when upstream presents them in arbitrary order.