### PR TITLE
luci-app-pbr: version bump to sync with principal package

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.1.8
-PKG_RELEASE:=2
+PKG_RELEASE:=6
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-pbr/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0-rc6
Run tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0-rc6

Description:
* depends on https://github.com/openwrt/packages/pull/25842