### PR TITLE
luci-app-adblock-fast: version bump

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 MOSSDeF, Stan Grishin (stangri@melmac.ca).
+# Copyright 2023-2025 MOSSDeF, Stan Grishin (stangri@melmac.ca).
 # This is free software, licensed under AGPL-3.0-or-later.
 
 include $(TOPDIR)/rules.mk
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.1.2
-PKG_RELEASE:=18
+PKG_VERSION:=1.1.3
+PKG_RELEASE:=1
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-adblock-fast/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0-rc6
Run tested: x86_64, Dell EMC Edge620, OpenWrt 24.10.0-rc6

Description:
* version bump to sync with principal package