### PR TITLE
luci-base: Allow "*" (== Any zone) in the firewall zone selection.

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
@@ -149,8 +149,8 @@ var CBIZoneSelect = form.ListValue.extend({
 			dropdown_items: this.dropdown_size || this.size || 5,
 			validate: L.bind(this.validate, this, section_id),
 			datatype: L.hasSystemFeature('firewall4')
-				? ( this.multiple ? 'list(uciname)' : 'uciname' )
-				: this.multiple ? 'list(and(uciname,maxlength(11)))' : 'and(uciname,maxlength(11))',
+				? ( this.multiple ? 'list(or(uciname,"*"))' : 'or(uciname,"*")' )
+				: this.multiple ? 'list(or(and(uciname,maxlength(11)),"*"))' : 'or(and(uciname,maxlength(11)),"*")',
 			create: !this.nocreate,
 			create_markup: '' +
 				'<li data-value="{{value}}">' +


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: x86_64 VM with OpenWrt 24.10.0-rc7 (r28417-daef29c75d)
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes #7591
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: followup to #7564, allowing a verbatim `*` for Any zone.
