### PR TITLE
Add firmware upgrade notification to status page

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js
@@ -2,6 +2,8 @@
 'require baseclass';
 'require fs';
 'require rpc';
+'require uci'
+'require ui';
 
 var callLuciVersion = rpc.declare({
 	object: 'luci',
@@ -18,6 +20,43 @@ var callSystemInfo = rpc.declare({
 	method: 'info'
 });
 
+function showUpgradeModal(type, current_version, new_version) {
+	ui.showModal(_('New Firmware Available'), [
+		E('p', _('A new %s version of OpenWrt is available: %s').format(type, new_version)),
+		E('p', _('Your current version is: %s').format(current_version)),
+		E('p', _('Please check the https://firmware-selector.openwrt.org/ for the firmware upgrade image')),
+		E('div', { class: 'btn', click: ui.hideModal }, _('Close')),
+	]);
+};
+
+function checkDeviceAvailable(boardinfo, new_version) {
+	const profile_url = 'https://downloads.openwrt.org/releases/%s/targets/%s/profiles.json'.format(new_version, boardinfo.release.target);
+	return fetch(profile_url)
+		.then(response => response.json())
+		.then(data => {
+			// special case for x86 and armsr
+			if (Object.keys(data.profiles).length == 1 && Object.keys(data.profiles)[0] == "generic") {
+				return true;
+			}
+
+			for (var i = 0; i < data.profiles.length; i++) {
+				if (data.profiles[i].profile == boardinfo.board_name) {
+					return true;
+				}
+				for (var j = 0; j < data.profiles[i].supported_devices.length; j++) {
+					if (data.profiles[i].supported_devices[j] == boardinfo.board_name) {
+						return true;
+					}
+				}
+			}
+		})
+		.catch(error => {
+			console.error('Failed to fetch profile information:', error);
+			return false;
+		});
+};
+
+
 return baseclass.extend({
 	title: _('System'),
 
@@ -25,8 +64,39 @@ return baseclass.extend({
 		return Promise.all([
 			L.resolveDefault(callSystemBoard(), {}),
 			L.resolveDefault(callSystemInfo(), {}),
-			L.resolveDefault(callLuciVersion(), { revision: _('unknown version'), branch: 'LuCI' })
+			L.resolveDefault(callLuciVersion(), { revision: _('unknown version'), branch: 'LuCI' }),
+			uci.load('luci')
 		]);
+	},
+
+	oneshot: function(data) {
+		var boardinfo = data[0];
+		var check_upgrades = uci.get_first('luci', 'core', 'check_firmware_version') || false;
+		console.log(check_upgrades)
+
+		if (check_upgrades == '1' || check_upgrades == 'true') {
+				fetch('https://downloads.openwrt.org/.versions.json')
+				.then(response => response.json())
+				.then(data => {
+						if (data.oldstable_version
+								&& data.oldstable_version > boardinfo.release.version
+								&& checkDeviceAvailable(boardinfo, data.oldstable_version)) {
+							showUpgradeModal("oldstable", boardinfo.release.version, data.oldstable_version)
+						} else if (data.stable_version
+								&& data.stable_version > boardinfo.release.version
+								&& checkDeviceAvailable(boardinfo, data.stable_version)) {
+							showUpgradeModal("stable", boardinfo.release.version, data.stable_version)
+						} else if (data.upcoming_version
+								&& boardinfo.release.version > data.stable_version
+								&& data.upcoming_version > boardinfo.release.version
+								&& checkDeviceAvailable(boardinfo, data.upcoming_version)) {
+							showUpgradeModal("upcomming", boardinfo.release.version, data.upcoming_version)
+						}
+				})
+				.catch(error => {
+						console.error('Failed to fetch version information:', error);
+				});
+		}
 	},
 
 	render: function(data) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
@@ -40,6 +40,11 @@ function startPolling(includes, containers) {
 				else if (includes[i].content != null)
 					content = includes[i].content;
 
+				if (typeof (includes[i].oneshot) == 'function') {
+					includes[i].oneshot(results ? results[i] : null);
+					includes[i].oneshot = null;
+				}
+
 				if (content != null) {
 					containers[i].parentNode.style.display = '';
 					containers[i].parentNode.classList.add('fade-in');


### PR DESCRIPTION
This is likely not cleanly implemented, I'm unfamiliar with the LuCI tricks and JavaScript in general.

The core idea is to show a notification whenever a new firmware is available.

<img width="732" alt="image" src="https://github.com/user-attachments/assets/c1046911-880f-493a-a2a0-61bd62dd7e4d" />

Right now it's just a notification, this could be extended to include the luci-app-attendedsysupgrade functionality or a slimmed down version.

@jow- please have a look


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [x] Description: (describe the changes proposed in this PR)
