### PR TITLE
luci-app-example: add missing dependencies

### DIFF
--- a/applications/luci-app-example/Makefile
+++ b/applications/luci-app-example/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI example app for js based luci
-LUCI_DEPENDS:=+luci-base
+LUCI_DEPENDS:=+lua +luci-base +luci-lib-jsonc +luci-lib-nixio +luci-lua-runtime
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: ath79/generic, OpenWrt 24.10.0-rc7 r28417-daef29c75d on TP-Link Archer C7 v2 :white_check_mark:
- [x] \( Preferred ) Mention: @andibraeu @cricalix 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description:
    `luci-app-example` that's installed from 24.10.0-rc7 repos has non-working RPC examples due to missing dependencies used in `applications/luci-app-example/root/usr/libexec/rpcd/luci.example`. This PR adds the required dependencies to the app's `Makefile`.
