### PR TITLE
luci-app-https-dns-proxy: bugfix and version bump

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=2023.12.26
-PKG_RELEASE:=2
+PKG_RELEASE:=4
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-https-dns-proxy/

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Restarting %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/lu.restena.kaitain.json:2
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/lu.restena.dnspub.json:2
 msgid "Restena DNS (LU)"
 msgstr ""
 

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/lu.restena.dnspub.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/lu.restena.dnspub.json
@@ -1,7 +1,7 @@
 {
 	"title": "Restena DNS (LU)",
-	"template": "https://kaitain.restena.lu/dns-query",
+	"template": "https://dnspub.restena.lu/dns-query",
 	"bootstrap_dns": "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
-	"help_link": "https://www.restena.lu/en/service/public-dns-resolver",
+	"help_link": "https://www.restena.lu/en/document/190-configuring-your-server-public-dns-resolver",
 	"http2_only": true
 }


### PR DESCRIPTION
* bugfix: restna.lu URL (thanks @giantplaceholder)
* version bump to sync with principal package
