### PR TITLE
luci-app-keepalived: include FAULT state to state

### DIFF
--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
@@ -39,7 +39,21 @@ return view.extend({
 
 				cbi_update_table(table,
 					targets.map(function(target) {
-						var state = (target.stats.become_master - target.stats.release_master) ? 'MASTER' : 'BACKUP';
+						var state;
+						var instance_state = target.data.state;
+
+						if (instance_state === 2) {
+							state = 'MASTER';
+						} else if (instance_state === 1) {
+							state = 'BACKUP';
+						} else if (instance_state === 0) {
+							state = 'INIT';
+						} else if (instance_state === 3) {
+							state = 'FAULT';
+						} else {
+							state = 'UNKNOWN';
+						}
+
 						if (instances != '') {
 							for (var i = 0; i < instances.length; i++) {
 								if (instances[i]['name'] == target.data.iname) {

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/overview.js
@@ -24,7 +24,8 @@ return view.extend({
 				E('tr', { 'class': 'tr table-titles' }, [
 					E('th', { 'class': 'th' }, _('Name')),
 					E('th', { 'class': 'th' }, _('Interface')),
-					E('th', { 'class': 'th' }, _('Active State/State')),
+					E('th', { 'class': 'th' }, _('Active State')),
+					E('th', { 'class': 'th' }, _('Initial State')),
 					E('th', { 'class': 'th' }, _('Probes Sent')),
 					E('th', { 'class': 'th' }, _('Probes Received')),
 					E('th', { 'class': 'th' }, _('Last Transition')),
@@ -40,6 +41,7 @@ return view.extend({
 				cbi_update_table(table,
 					targets.map(function(target) {
 						var state;
+						var state_initial;
 						var instance_state = target.data.state;
 
 						if (instance_state === 2) {
@@ -57,7 +59,8 @@ return view.extend({
 						if (instances != '') {
 							for (var i = 0; i < instances.length; i++) {
 								if (instances[i]['name'] == target.data.iname) {
-									state = state + '/' + instances[i]['state'];
+									state = state;
+									state_initial = instances[i]['state'];
 									break;
 								}
 							}
@@ -66,6 +69,7 @@ return view.extend({
 							target.data.iname,
 							target.data.ifp_ifname,
 							state,
+							state_initial,
 							target.stats.advert_sent,
 							target.stats.advert_rcvd,
 							new Date(target.data.last_transition * 1000)

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/status/include/35_keepalived.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/status/include/35_keepalived.js
@@ -28,7 +28,8 @@ return baseclass.extend({
 				E('tr', { 'class': 'tr table-titles' }, [
 					E('th', { 'class': 'th' }, _('Name')),
 					E('th', { 'class': 'th' }, _('Interface')),
-					E('th', { 'class': 'th' }, _('Active State/State')),
+					E('th', { 'class': 'th' }, _('Active State')),
+					E('th', { 'class': 'th' }, _('Initial State')),
 					E('th', { 'class': 'th' }, _('Probes Sent')),
 					E('th', { 'class': 'th' }, _('Probes Received')),
 					E('th', { 'class': 'th' }, _('Last Transition')),
@@ -39,6 +40,7 @@ return baseclass.extend({
 		cbi_update_table(table,
 			targets.map(function(target) {
 				var state;
+				var state_initial;
 				var instance_state = target.data.state;
 
 				if (instance_state === 2) {
@@ -56,7 +58,8 @@ return baseclass.extend({
 				if (instances != '') {
 					for (var i = 0; i < instances.length; i++) {
 						if (instances[i]['name'] == target.data.iname) {
-							state = state + '/' + instances[i]['state'];
+							state = state;
+							state_initial = instances[i]['state'];
 							break;
 						}
 					}
@@ -65,6 +68,7 @@ return baseclass.extend({
 					target.data.iname,
 					target.data.ifp_ifname,
 					state,
+					state_initial,
 					target.stats.advert_sent,
 					target.stats.advert_rcvd,
 					new Date(target.data.last_transition * 1000)

--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/status/include/35_keepalived.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/status/include/35_keepalived.js
@@ -38,7 +38,21 @@ return baseclass.extend({
 
 		cbi_update_table(table,
 			targets.map(function(target) {
-				var state = (target.stats.become_master - target.stats.release_master) ? 'MASTER' : 'BACKUP';
+				var state;
+				var instance_state = target.data.state;
+
+				if (instance_state === 2) {
+					state = 'MASTER';
+				} else if (instance_state === 1) {
+					state = 'BACKUP';
+				} else if (instance_state === 0) {
+					state = 'INIT';
+				} else if (instance_state === 3) {
+					state = 'FAULT';
+				} else {
+					state = 'UNKNOWN';
+				}
+
 				if (instances != '') {
 					for (var i = 0; i < instances.length; i++) {
 						if (instances[i]['name'] == target.data.iname) {


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] \( Preferred ) Screenshot or mp4 of changes:
![image](https://github.com/user-attachments/assets/f74b4307-e0da-4970-b15d-a33bac543606)
![image](https://github.com/user-attachments/assets/e1c73dba-9330-4c47-bd50-02e9bac03033)
- [x] Tested on: (x86, owrt-24.10, firefox) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] Description: (describe the changes proposed in this PR)

Upstream only handles state according to whether the machine was in BACKUP or MASTER. FAULT state is not handled but upstream keepalived does support that by exporting json  with `state` which reflects the state (FAULT included).

This is included to luci-app-keepalived via `ubus call keepalived dump`.

The second commit separates the two states that are defined into separate columns.
