### PR TITLE
luci-app-lxc: fix configure lxc container POST request

### DIFF
--- a/applications/luci-app-lxc/luasrc/controller/lxc.lua
+++ b/applications/luci-app-lxc/luasrc/controller/lxc.lua
@@ -140,6 +140,7 @@ function lxc_configuration_set(lxc_name)
 	luci.http.prepare_content("text/plain")
 
 	local lxc_configuration = luci.http.formvalue("lxc_conf")
+	lxc_configuration = luci.http.urldecode(lxc_configuration, true)
 	if lxc_configuration == nil then
 		util.perror("lxc error: config formvalue is empty")
 		return

--- a/applications/luci-app-lxc/luasrc/view/lxc.htm
+++ b/applications/luci-app-lxc/luasrc/view/lxc.htm
@@ -250,7 +250,7 @@ local target = nx.uname().machine
 		var lxc_name = textarea.dataset['id'];
 		var lxc_conf = textarea.value;
 
-	new XHR().post('<%=luci.dispatcher.build_url("admin", "services")%>/lxc_configuration_set/' + lxc_name, "lxc_conf=" + encodeURIComponent(lxc_conf),
+	new XHR().post('<%=luci.dispatcher.build_url("admin", "services")%>/lxc_configuration_set/' + lxc_name, {"lxc_conf": encodeURIComponent(lxc_conf)},
 		function(x)
 		{
 			if (!x || x.responseText != "0")


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86_64, 23.0.5, Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#6098
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: the code for sending POST request to Luci was in wrong format, It did not have key value for formvalue and the value has to decode from encodeURIComponent

The backend code is: 
```local lxc_configuration = luci.http.formvalue("lxc_conf")```
 but frontend do not send formvalue with key "lxc_conf": 
```new XHR().post('<%=luci.dispatcher.build_url("admin", "services")%>/lxc_configuration_set/' + lxc_name, "lxc_conf=" + encodeURIComponent(lxc_conf)```

The fix is: 
```
new XHR().post('<%=luci.dispatcher.build_url("admin", "services")%>/lxc_configuration_set/' + lxc_name, {"lxc_conf": encodeURIComponent(lxc_conf)}
```
and decoded string is required for LXC
```
lxc_configuration = luci.http.urldecode(lxc_configuration, true)
```