### PR TITLE
luci-mod-system: add LED speed and duplex triggers

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/netdev.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/netdev.js
@@ -22,6 +22,14 @@ return baseclass.extend({
 		o.modalonly = true;
 		o.depends('trigger', 'netdev');
 		o.value('link', _('Link On'));
+		o.value('link_10', _('Link 10M On'));
+		o.value('link_100', _('Link 100M On'));
+		o.value('link_1000', _('Link 1G On'));
+		o.value('link_2500', _('Link 2.5G On'));
+		o.value('link_5000', _('Link 5G On'));
+		o.value('link_10000', _('Link 10G On'));
+		o.value('half_duplex', _('Half Duplex'));
+		o.value('full_duplex', _('Full Duplex'));
 		o.value('tx', _('Transmit'));
 		o.value('rx', _('Receive'));
 	}


### PR DESCRIPTION
Many devices have LEDs to signal a specific link speed. They are incorrectly displayed in LUCI when they are deﬁned. This commit adds the missing speed and duplex triggers.

Tested on: mediatek/filogic/ex5601, snapshot, Firefox

![obraz](https://github.com/user-attachments/assets/0af32fd9-a10f-45d2-8e11-c3c563f3a064)


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @feckert  the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
