### PR TITLE
luci-app-firewall: fix zone log option

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -293,11 +293,23 @@ return view.extend({
 		for (var i = 0; i < ctHelpers.length; i++)
 			o.value(ctHelpers[i].name, E('<span><span class="hide-close">%s (%s)</span><span class="hide-open">%s</span></span>'.format(ctHelpers[i].description, ctHelpers[i].name.toUpperCase(), ctHelpers[i].name.toUpperCase())));
 
-		o = s.taboption('advanced', form.Flag, 'log', _('Enable logging on this zone'));
+		o = s.taboption('advanced', form.MultiValue, 'log', _('Enable logging'), _('Log matched packets on the selected tables to syslog.'));
 		o.modalonly = true;
+		o.value('filter');
+		o.value('mangle');
+		o.placeholder = 'No table selected';
+		const TABLES = { filter: 1, mangle: 2 };
+		o.cfgvalue = function (section_id) {
+			let bitfield = this.super('load', [section_id]) || this.default;
+			return Object.keys(TABLES).filter(table => bitfield & TABLES[table]);
+		};
+		o.write = function (section_id, value) {
+			let bitfield = L.toArray(value).reduce((acc, table) => acc | (TABLES[table] || 0), 0);
+			return this.super('write', [section_id, bitfield]);
+		};
 
 		o = s.taboption('advanced', form.Value, 'log_limit', _('Limit log messages'));
-		o.depends('log', '1');
+		o.depends({log: [], "!reverse": true});
 		o.placeholder = '10/minute';
 		o.modalonly = true;
 


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: BPI R4 running 24.10.0 :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:

![image](https://github.com/user-attachments/assets/e2cc4b41-de43-49a4-9edd-e6ee27e53f5c)

![image](https://github.com/user-attachments/assets/f7f1cbc8-e0b5-4227-bee2-ef8faf158af9)

- [x] Description: The luci option to enable zone logging was a simple checkbox while the uci option is a bitfield which led to enabling logging just on the "filter" table when toggled, with no option to enable it for the "mangle" table.
This PR changes the zone log checkbox to a multivalue selection.
From the [documentation](https://openwrt.org/docs/guide-user/firewall/firewall_configuration#zones):

![image](https://github.com/user-attachments/assets/7b2b047a-970f-4bbe-bff4-11958d6628f2)

