### PR TITLE
luci-theme-material: change dropdown button for better visibility

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1586,6 +1586,10 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 	color: var(--main-menu-color);
 }
 
+.cbi-dropdown.btn.cbi-button.cbi-button-positive.important > ul > li[display] {
+	color: var(--white-color);
+}
+
 .cbi-dropdown > ul > li[display],
 .cbi-dropdown[open] > ul.preview,
 .cbi-dropdown[open] > ul.dropdown > li,

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1590,6 +1590,10 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 	color: var(--white-color);
 }
 
+.cbi-dropdown[open] > ul.dropdown > li[tabindex] {
+	color: var(--black-color) !important;
+}
+
 .cbi-dropdown > ul > li[display],
 .cbi-dropdown[open] > ul.preview,
 .cbi-dropdown[open] > ul.dropdown > li,
@@ -1622,6 +1626,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 
 .cbi-dropdown[open] > ul.dropdown > li[selected] {
 	background: #b0d0f0;
+	color: var(--black-color);
 }
 
 .cbi-dropdown[open] > ul.dropdown > li.focus,
@@ -1632,6 +1637,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 .cbi-dropdown[open] > ul.dropdown > li:last-child {
 	margin-bottom: 0;
 	border-bottom: 0;
+	color: var(--black-color);
 }
 
 .cbi-dropdown[open] > ul.dropdown > li[unselectable] {


### PR DESCRIPTION
My PR is a slight improvement, where the upstream version works fine, but my downstream version benefits heavily from it, so made the request:

On theme material it is barely possible to see the possible options in
the dropdown from my version of luci-theme-material. 
If the dropdown is switched to `--black-color` (EDIT: not `--gray-color-high`) it improves distinguishing the colors in my GUI.

*Before downstream version*
![image](https://github.com/user-attachments/assets/16a1ff2d-64a4-4bc4-8dab-08d8f78a8802)

*After downstream version*
![image](https://github.com/user-attachments/assets/cd718071-c578-48af-8b39-7c2c8adae1b8)


In the upstream version the dropdown is fine and also distinguishable with my modified version:

*Before upstream version*
![image](https://github.com/user-attachments/assets/d121adff-453a-4fab-9ec0-f1d95d10bbb7)
*After upstream version*
![image](https://github.com/user-attachments/assets/e00bcccf-eed3-4ade-9757-1966b14d0b9d)

On both versions (upstream/downstream) the button is no ideal as a display so I changed that also:
*Before*
![image](https://github.com/user-attachments/assets/4ebc18ae-f23d-4b26-877a-a4e6685e1fee)
*After*
![image](https://github.com/user-attachments/assets/f3fae64c-21d2-4648-ba55-ca386855003e)



- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86, openwrt 24.10, firefox) :white_check_mark:
- [x] Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
