### PR TITLE
luci-mod-status: channel_analysis: fix 802.11be local interface channel width

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -228,7 +228,7 @@ return view.extend({
 
 				if (chan_analysis.offset_tbl[local_wifi.channel] != null && local_wifi.center_chan1) {
 					var center_channels = [local_wifi.center_chan1],
-					    chan_width_text = local_wifi.htmode.replace(/(V)*H[TE]/,''), /* Handle HT VHT HE */
+					    chan_width_text = local_wifi.htmode.replace(/[EV]*H[TE]/,''), /* Handle HT VHT HE EHT */
 					    chan_width = parseInt(chan_width_text)/10;
 
 					if (local_wifi.center_chan2) {


### PR DESCRIPTION
The channel width for WiFi 802.11be displays incorrectly on the graph and this commit fixes it.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>

![obraz](https://github.com/user-attachments/assets/336072f3-c27b-4171-b7ee-8fdaadc14e1f)

~~~
root@OpenWrt:/# iwinfo
phy0.2-ap0 ESSID: "OpenWrt"
          Access Point: 00:58:28:29:C1:D2
          Mode: Master  Channel: 33 (6.115 GHz)  HT Mode: EHT320
          Center Channel 1: 31 2: unknown
          Tx-Power: 23 dBm  Link Quality: unknown/70
          Signal: unknown  Noise: -85 dBm
          Bit Rate: unknown
          Encryption: WPA3 OWE (CCMP)
          Type: nl80211  HW Mode(s): 802.11ac/ax/b/be/g/n
          Hardware: 14C3:7990 14C3:6639 [MediaTek MT7996E]
          TX power offset: none
          Frequency offset: none
          Supports VAPs: yes  PHY name: phy0
~~~

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: mediate/airoha/w1700q, OpenWRT snapshot, Firefox 135.0.1 :white_check_mark:
- [x] \( Preferred ) Mention: @Ansuel @knarrff  the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
