### PR TITLE
luci-app-keepalived: set acl dependency

### DIFF
--- a/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
+++ b/applications/luci-app-keepalived/root/usr/share/luci/menu.d/luci-app-keepalived.json
@@ -5,6 +5,9 @@
 		"action": {
 			"type": "alias",
 			"path": "admin/services/keepalived/globals"
+		},
+		"depends": {
+			"acl": [ "luci-app-keepalived" ]
 		}
 	},
 
@@ -113,6 +116,9 @@
 		"action": {
 			"type": "view",
 			"path": "keepalived/overview"
+		},
+		"depends": {
+			"acl": [ "luci-app-keepalived" ]
 		}
 	}
 }


### PR DESCRIPTION
Because no ACL has been set for luci-app-keepalived in menu.d, the menu entry is always displayed, even if access is disabled in the '/etc/config/rpcd' file. Add the missing information to the menu.d file fixes this issue.

![Screenshot 2025-03-06 at 11-52-16 YODA-B-000037 - LuCI](https://github.com/user-attachments/assets/d9f2c6a5-be5c-4db7-83fe-460dd3672cde)


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
