### PR TITLE
luci-app-acl: also grand read access to luci-mod-status-index

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -98,7 +98,7 @@ var cbiACLSelect = form.Value.extend({
 		]);
 
 		Object.keys(aclList).sort().forEach(function(aclGroupName) {
-			var isRequired = (aclGroupName == 'unauthenticated' || aclGroupName == 'luci-base'),
+			var isRequired = (aclGroupName == 'unauthenticated' || aclGroupName == 'luci-base' || aclGroupName == 'luci-mod-status-index'),
 			    isReadable = (readMatches[0].test(aclGroupName) && !readMatches[1].test(aclGroupName)) || null,
 			    isWritable = (writeMatches[0].test(aclGroupName) && !writeMatches[1].test(aclGroupName)) || null;
 


### PR DESCRIPTION
If a new user is created, 'luci-mod-status-index' should also be selected, as this is the start page after login. If a user is created without this, only  a 404 is displayed. To fix this also grand read access to the 'luci-mod-status-index' page. Once you log in and see this page, you can't log out either

![Screenshot 2025-03-06 at 11-52-16 YODA-B-000037 - LuCI](https://github.com/user-attachments/assets/7606b126-6b78-48d2-b599-b669af370ff6)

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
