### PR TITLE
treewide: fix notification call function arguments

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -174,9 +174,11 @@ return view.extend({
 	},
 
 	render: function(data) {
-		ui.addNotification(null, E('p', [
-			_('The LuCI ACL management is in an experimental stage! It does not yet work reliably with all applications')
-		]), 'warning');
+		ui.addNotification(null,
+			E('p', [_('The LuCI ACL management is in an experimental stage! It does not yet work reliably with all applications')]),
+			0,
+			'warning'
+		);
 
 		var has_uhttpd = data[0],
 		    known_unix_users = {};

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
@@ -12,7 +12,11 @@ return view.extend({
 		return fs.write('/etc/adblock/adblock.blacklist', value)
 			.then(function(rc) {
 				document.querySelector('textarea').value = value;
-				ui.addNotification(null, E('p', _('The changes to the blacklist have been saved. Reload your adblock lists for the changes to take effect.')), 'info');
+				ui.addNotification(null,
+					E('p', _('The changes to the blacklist have been saved. Reload your adblock lists for the changes to take effect.')),
+					0,
+					'info'
+				);
 			}).catch(function(e) {
 				ui.addNotification(null, E('p', _('Unable to save changes: %s').format(e.message)));
 			});

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
@@ -31,7 +31,11 @@ function handleAction(ev) {
 							if (res.search(pattern) === -1) {
 								var blacklist = res + domain + '\n';
 								fs.write('/etc/adblock/adblock.blacklist', blacklist);
-								ui.addNotification(null, E('p', _('Blacklist changes have been saved. Refresh your adblock lists that changes take effect.')), 'info');
+								ui.addNotification(null,
+									E('p', _('Blacklist changes have been saved. Refresh your adblock lists that changes take effect.')),
+									0,
+									'info'
+								);
 							}
 							L.hideModal();
 						});

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -83,18 +83,34 @@ function handleAction(ev) {
 							L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['timer', 'add', action, hours, minutes, days]))
 							.then(function(res) {
 								if (res) {
-									ui.addNotification(null, E('p', _('The Refresh Timer could not been updated.')), 'error');
+									ui.addNotification(null,
+										E('p', _('The Refresh Timer could not been updated.')),
+										0,
+										'error'
+									);
 								} else {
-									ui.addNotification(null, E('p', _('The Refresh Timer has been updated.')), 'info');
+									ui.addNotification(null,
+										E('p', _('The Refresh Timer has been updated.')),
+										0,
+										'info'
+									);
 								}
 							});
 						} else if (lineno) {
 							L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['timer', 'remove', lineno]))
 							.then(function(res) {
 								if (res) {
-									ui.addNotification(null, E('p', _('The Refresh Timer could not been updated.')), 'error');
+									ui.addNotification(null,
+										E('p', _('The Refresh Timer could not been updated.')),
+										0,
+										'error'
+									);
 								} else {
-									ui.addNotification(null, E('p', _('The Refresh Timer has been updated.')), 'info');
+									ui.addNotification(null,
+										E('p', _('The Refresh Timer has been updated.')),
+										0,
+										'info'
+									);
 								}
 							});
 						} else {

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
@@ -12,7 +12,11 @@ return view.extend({
 		return fs.write('/etc/adblock/adblock.whitelist', value)
 			.then(function(rc) {
 				document.querySelector('textarea').value = value;
-				ui.addNotification(null, E('p', _('The changes to the whitelist have been saved. Reload your adblock lists for the changes to take effect.')), 'info');
+				ui.addNotification(null,
+					E('p', _('The changes to the whitelist have been saved. Reload your adblock lists for the changes to take effect.')),
+					0,
+					'info'
+				);
 			}).catch(function(e) {
 				ui.addNotification(null, E('p', _('Unable to save changes: %s').format(e.message)));
 			});

--- a/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js
+++ b/applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js
@@ -31,7 +31,11 @@ return view.extend({
 		var script = res[1]['rrdcgi'];
 
 		if (!running) {
-			return ui.addNotification(null, E('h3', _('Service is not running'), 'danger'));
+			return ui.addNotification(null,
+					E('h3', _('Service is not running')),
+					0,
+					'danger'
+				);
 		}
 
 		return fs.stat(script).then(function(res) {
@@ -48,10 +52,18 @@ return view.extend({
 					])
 				]);
 			} else {
-				return ui.addNotification(null, E('h3', _('No data available'), 'danger'));
+				return ui.addNotification(null,
+						E('h3', _('No data available')),
+						0,
+						'danger'
+					);
 			}
 		}).catch(function(err) {
-			return ui.addNotification(null, E('h3', _('No access to server file'), 'danger'));
+			return ui.addNotification(null,
+					E('h3', _('No access to server file')),
+					0,
+					'danger'
+				);
 		});
 	},
 

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/allowlist.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/allowlist.js
@@ -19,13 +19,21 @@ return view.extend({
 				document.querySelector('textarea').value = value;
 				document.body.scrollTop = document.documentElement.scrollTop = 0;
 				if (!notMsg) {
-					ui.addNotification(null, E('p', _('Allowlist modifications have been saved, reload banIP that changes take effect.')), 'info');
+					ui.addNotification(null,
+						E('p', _('Allowlist modifications have been saved, reload banIP that changes take effect.')),
+						0,
+						'info'
+					);
 					notMsg = true;
 				}
 			}).catch(function (e) {
 				document.body.scrollTop = document.documentElement.scrollTop = 0;
 				if (!errMsg) {
-					ui.addNotification(null, E('p', _('Unable to save modifications: %s').format(e.message)), 'error');
+					ui.addNotification(null,
+						E('p', _('Unable to save modifications: %s').format(e.message)),
+						0,
+						'error'
+					);
 					errMsg = true;
 				}
 			});
@@ -33,7 +41,11 @@ return view.extend({
 	render: function (allowlist) {
 		if (allowlist[0].size >= 100000) {
 			document.body.scrollTop = document.documentElement.scrollTop = 0;
-			ui.addNotification(null, E('p', _('The allowlist is too big, unable to save modifications.')), 'error');
+			ui.addNotification(null,
+				E('p', _('The allowlist is too big, unable to save modifications.')),
+				0,
+				'error'
+			);
 		}
 		return E('div', { 'class': 'cbi-section cbi-section-descr' }, [
 			E('p', _('This is the local banIP allowlist that will permit certain MAC-, IP-addresses or domain names.<br /> \

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blocklist.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/blocklist.js
@@ -19,13 +19,21 @@ return view.extend({
 				document.querySelector('textarea').value = value;
 				document.body.scrollTop = document.documentElement.scrollTop = 0;
 				if (!notMsg) {
-					ui.addNotification(null, E('p', _('Blocklist modifications have been saved, reload banIP that changes take effect.')), 'info');
+					ui.addNotification(null,
+						E('p', _('Blocklist modifications have been saved, reload banIP that changes take effect.')),
+						0,
+						'info'
+					);
 					notMsg = true;
 				}
 			}).catch(function (e) {
 				document.body.scrollTop = document.documentElement.scrollTop = 0;
 				if (!errMsg) {
-					ui.addNotification(null, E('p', _('Unable to save modifications: %s').format(e.message)), 'error');
+					ui.addNotification(null,
+						E('p', _('Unable to save modifications: %s').format(e.message)),
+						0,
+						'error'
+					);
 					errMsg = true;
 				}
 			});
@@ -33,7 +41,11 @@ return view.extend({
 	render: function (blocklist) {
 		if (blocklist[0].size >= 100000) {
 			document.body.scrollTop = document.documentElement.scrollTop = 0;
-			ui.addNotification(null, E('p', _('The blocklist is too big, unable to save modifications.')), 'error');
+			ui.addNotification(null,
+				E('p', _('The blocklist is too big, unable to save modifications.')),
+				0,
+				'error'
+			);
 		}
 		return E('div', { 'class': 'cbi-section cbi-section-descr' }, [
 			E('p', _('This is the local banIP blocklist that will prevent certain MAC-, IP-addresses or domain names.<br /> \

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/feeds.js
@@ -69,20 +69,32 @@ function handleEdit(ev) {
 								continue;
 							}
 							fs.write('/etc/banip/banip.custom.feeds', null).then(function () {
-								ui.addNotification(null, E('p', _('Upload of the custom feed file failed.')), 'error');
+								ui.addNotification(null,
+									E('p', _('Upload of the custom feed file failed.')),
+									0,
+									'error'
+								);
 							});
 							return;
 						}
 					} else {
 						fs.write('/etc/banip/banip.custom.feeds', null).then(function () {
-							ui.addNotification(null, E('p', _('Upload of the custom feed file failed.')), 'error');
+							ui.addNotification(null,
+								E('p', _('Upload of the custom feed file failed.')),
+								0,
+								'error'
+							);
 						});
 						return;
 					}
 					location.reload();
 				} else {
 					fs.write('/etc/banip/banip.custom.feeds', null).then(function () {
-						ui.addNotification(null, E('p', _('Upload of the custom feed file failed.')), 'error');
+						ui.addNotification(null,
+							E('p', _('Upload of the custom feed file failed.')),
+							0,
+							'error'
+						);
 					});
 				}
 			});
@@ -116,7 +128,11 @@ function handleEdit(ev) {
 		const invalid = document.querySelectorAll('.cbi-input-invalid');
 		if (invalid.length > 0) {
 			document.body.scrollTop = document.documentElement.scrollTop = 0;
-			return ui.addNotification(null, E('p', _('Invalid input values, unable to save modifications.')), 'error');
+			return ui.addNotification(null,
+					E('p', _('Invalid input values, unable to save modifications.')),
+					0,
+					'error'
+				);
 		}
 	}
 	let sumSubElements = [], exportJson;

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -494,14 +494,22 @@ return view.extend({
 				try {
 					feeds = JSON.parse(result[0]);
 				} catch (e) {
-					ui.addNotification(null, E('p', _('Unable to parse the custom feed file!')), 'error');
+					ui.addNotification(null,
+						E('p', _('Unable to parse the custom feed file!')),
+						0,
+						'error'
+					);
 				}
 			}
 			if (result[1] && (!feeds || (feeds && !Object.keys(feeds).length))) {
 				try {
 					feeds = JSON.parse(result[1]);
 				} catch (e) {
-					ui.addNotification(null, E('p', _('Unable to parse the default feed file!')), 'error');
+					ui.addNotification(null,
+						E('p', _('Unable to parse the default feed file!')),
+						0,
+						'error'
+					);
 				}
 			}
 		}
@@ -710,7 +718,11 @@ return view.extend({
 					} catch (e) {
 						countries[i] = "";
 						if (!err) {
-							ui.addNotification(null, E('p', _('Unable to parse the countries file!')), 'error');
+							ui.addNotification(null,
+								E('p', _('Unable to parse the countries file!')),
+								0,
+								'error'
+							);
 						}
 						err = e;
 					}

--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/setreport.js
@@ -70,7 +70,11 @@ function handleAction(report, ev) {
 				content = JSON.parse(report[1]);
 			} catch (e) {
 				content = "";
-				ui.addNotification(null, E('p', _('Unable to parse the ruleset file!')), 'error');
+				ui.addNotification(null,
+					E('p', _('Unable to parse the ruleset file!')),
+					0,
+					'error'
+				);
 			}
 		} else {
 			content = "";
@@ -149,7 +153,11 @@ return view.extend({
 				content = JSON.parse(report[0]);
 			} catch (e) {
 				content = "";
-				ui.addNotification(null, E('p', _('Unable to parse the report file!')), 'error');
+				ui.addNotification(null,
+					E('p', _('Unable to parse the report file!')),
+					0,
+					'error'
+				);
 			}
 		} else {
 			content = "";

--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/custom.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/custom.js
@@ -13,7 +13,11 @@ return view.extend({
 
 		return fs.write('/etc/firewall.user', value).then(function(rc) {
 			document.querySelector('textarea').value = value;
-			ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
+			ui.addNotification(null,
+				E('p', _('Contents have been saved.')),
+				0,
+				'info'
+			);
 			fs.exec('/etc/init.d/firewall', ['restart']);
 		}).catch(function(e) {
 			ui.addNotification(null, E('p', _('Unable to save contents: %s').format(e.message)));

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/notify.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/notify.js
@@ -15,7 +15,11 @@ return view.extend({
 
 		return fs.write('/etc/mwan3.user', value).then(function(rc) {
 			document.querySelector('textarea').value = value;
-				ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
+				ui.addNotification(null,
+					E('p', _('Contents have been saved.')),
+					0,
+					'info'
+				);
 			}).catch(function(e) {
 				ui.addNotification(null, E('p', _('Unable to save contents: %s').format(e.message)));
 			});

--- a/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -518,7 +518,13 @@ return view.extend({
 				'id': 'btn_update',
 				'click': ui.createHandlerFn(this, function () {
 					return fs.exec('/etc/init.d/smartdns', ['updatefiles'])
-						.catch(function (e) { ui.addNotification(null, E('p', e.message), 'error') });
+						.catch(function (e) {
+							ui.addNotification(null,
+								E('p', e.message),
+								0,
+								'error'
+							)
+						});
 				})
 			}, [_("Update")]);
 		}
@@ -1169,7 +1175,13 @@ return view.extend({
 				'id': 'btn_restart',
 				'click': ui.createHandlerFn(this, function () {
 					return fs.exec('/etc/init.d/smartdns', ['restart'])
-						.catch(function (e) { ui.addNotification(null, E('p', e.message), 'error') });
+						.catch(function (e) {
+							ui.addNotification(null,
+								E('p', e.message),
+								0,
+								'error'
+							)
+						});
 				})
 			}, [_("Restart")]);
 		}

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
@@ -135,7 +135,11 @@ function _handleKeyGenSubmit(event) {
 	keyName = keyName.startsWith('id_') ? keyName : 'id_' + keyName;
 	if (allSshKeys[keyName]) {
 		document.body.scrollTop = document.documentElement.scrollTop = 0;
-		ui.addNotification(null, E('p', _('A key with that name already exists.'), 'error'));
+		ui.addNotification(null,
+			E('p', _('A key with that name already exists.')),
+			0,
+			'error'
+		);
 		return false;
 	}
 
@@ -154,7 +158,11 @@ function _handleKeyGenSubmit(event) {
 		}
 	}).catch(function (e) {
 		document.body.scrollTop = document.documentElement.scrollTop = 0;
-		ui.addNotification(null, E('p', _('Unable to generate a key: %s').format(e.message)), 'error');
+		ui.addNotification(null,
+			E('p', _('Unable to generate a key: %s').format(e.message)),
+			0,
+			'error'
+		);
 	});
 	return false;
 }

--- a/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
+++ b/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
@@ -54,9 +54,17 @@ function handleAction(ev) {
 						L.resolveDefault(fs.exec('/etc/init.d/travelmate', ['setup', iface, zone, metric]))
 							.then(function (res) {
 								if (res) {
-									ui.addNotification(null, E('p', res.trim() + '.'), 'error');
+									ui.addNotification(null,
+										E('p', res.trim() + '.'),
+										0,
+										'error'
+									);
 								} else {
-									ui.addNotification(null, E('p', _('The uplink interface has been updated.')), 'info');
+									ui.addNotification(null,
+										E('p', _('The uplink interface has been updated.')),
+										0,
+										'info'
+									);
 								}
 							});
 						L.hideModal();

--- a/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js
+++ b/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js
@@ -1081,17 +1081,29 @@ return view.extend({
 			}
 			if (!ssid || ((encryption.includes('psk') || encryption.includes('wpa') || encryption.includes('sae')) && !password)) {
 				if (!ssid) {
-					ui.addNotification(null, E('p', 'Empty SSID, the uplink station could not be saved.'), 'error');
+					ui.addNotification(null,
+						E('p', 'Empty SSID, the uplink station could not be saved.'),
+						0,
+						'error'
+					);
 				}
 				else {
-					ui.addNotification(null, E('p', 'Empty Password, the uplink station could not be saved.'), 'error');
+					ui.addNotification(null,
+						E('p', 'Empty Password, the uplink station could not be saved.'),
+						0,
+						'error'
+					);
 				}
 				return ui.hideModal();
 			}
 			for (var i = 0; i < w_sections.length; i++) {
 				if (w_sections[i].device === device && w_sections[i].ssid === ssid) {
 					if (ignore_bssid === '1' || (ignore_bssid === '0' && w_sections[i].bssid === bssid)) {
-						ui.addNotification(null, E('p', 'Duplicate wireless entry, the uplink station could not be saved.'), 'error');
+						ui.addNotification(null,
+							E('p', 'Duplicate wireless entry, the uplink station could not be saved.'),
+							0,
+							'error'
+						);
 						return ui.hideModal();
 					}
 				}

--- a/applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js
+++ b/applications/luci-app-xinetd/htdocs/luci-static/resources/view/xinetd/xinetd.js
@@ -175,7 +175,11 @@ return view.extend({
 					uci.set('xinetd', section, 'server', value);
 					return;
 				} else {
-					ui.addNotification(null, E('p', _('Service "%s": Invalid server file "%s"').format(section, value)), 'danger');
+					ui.addNotification(null,
+						E('p', _('Service "%s": Invalid server file "%s"').format(section, value)),
+						0,
+						'danger'
+					);
 				}
 			}).catch(function(err) {
 				ui.addNotification(null, E('p', _('Service "%s": No access to server file "%s" (%s)').format(section, value, err.message)), 'danger');

--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -2308,7 +2308,10 @@
 				if (!e.reported) {
 					if (classes.ui)
 						classes.ui.addNotification(e.name || _('Runtime error'),
-							E('pre', {}, e.message), 'danger');
+							E('pre', {}, e.message),
+							0,
+							'danger'
+						);
 					else
 						DOM.content(document.querySelector('#maincontent'),
 							E('pre', { 'class': 'alert-message error' }, e.message));

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
@@ -306,15 +306,27 @@ return view.extend({
 	handleCounterReset: function(has_ip6tables, ev) {
 		return Promise.all([
 			fs.exec('/usr/sbin/iptables', [ '-Z' ])
-				.catch(function(err) { ui.addNotification(null, E('p', {}, _('Unable to reset iptables counters: %s').format(err.message))) }),
+				.catch(function(err) {
+					ui.addNotification(null,
+						E('p', {}, _('Unable to reset iptables counters: %s').format(err.message))
+					)
+				}),
 			has_ip6tables ? fs.exec('/usr/sbin/ip6tables', [ '-Z' ])
-				.catch(function(err) { ui.addNotification(null, E('p', {}, _('Unable to reset ip6tables counters: %s').format(err.message))) }) : null
+				.catch(function(err) {
+					ui.addNotification(null,
+						E('p', {}, _('Unable to reset ip6tables counters: %s').format(err.message))
+					)
+				}) : null
 		]);
 	},
 
 	handleRestart: function(ev) {
 		return fs.exec_direct('/etc/init.d/firewall', [ 'restart' ])
-				.catch(function(err) { ui.addNotification(null, E('p', {}, _('Unable to restart firewall: %s').format(err.message))) });
+				.catch(function(err) {
+					ui.addNotification(null,
+						E('p', {}, _('Unable to restart firewall: %s').format(err.message))
+					)
+				});
 	},
 
 	render: function(has_ip6tables) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
@@ -683,7 +683,7 @@ return view.extend({
 					'class': 'btn cbi-button',
 					'click': function() { location.href = 'nftables/iptables' }
 				}, _('Open iptables rules overview…'))
-			], 'warning');
+			], 0, 'warning');
 		}
 	},
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js
@@ -15,7 +15,11 @@ return view.extend({
 
 		return fs.write('/etc/crontabs/root', value).then(function(rc) {
 			document.querySelector('textarea').value = value;
-			ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
+			ui.addNotification(null,
+				E('p', _('Contents have been saved.')),
+				0,
+				'info'
+			);
 
 			return fs.exec('/etc/init.d/cron', [ 'reload' ]);
 		}).catch(function(e) {

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -367,7 +367,11 @@ return view.extend({
 		return m.save(function() {
 			return fs.write('/etc/sysupgrade.conf', mapdata.config.editlist.trim().replace(/\r\n/g, '\n') + '\n');
 		}).then(function() {
-			ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
+			ui.addNotification(null,
+				E('p', _('Contents have been saved.')),
+				0,
+				'info'
+			);
 		}).catch(function(e) {
 			ui.addNotification(null, E('p', _('Unable to save contents: %s').format(e)));
 		});

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
@@ -76,15 +76,27 @@ return view.extend({
 				return;
 
 			if (formData.password.pw1 != formData.password.pw2) {
-				ui.addNotification(null, E('p', _('Given password confirmation did not match, password not changed!')), 'danger');
+				ui.addNotification(null,
+					E('p', _('Given password confirmation did not match, password not changed!')),
+					0,
+					'danger'
+				);
 				return;
 			}
 
 			return callSetPassword('root', formData.password.pw1).then(function(success) {
 				if (success)
-					ui.addNotification(null, E('p', _('The system password has been successfully changed.')), 'info');
+					ui.addNotification(null,
+						E('p', _('The system password has been successfully changed.')),
+						0,
+						'info'
+					);
 				else
-					ui.addNotification(null, E('p', _('Failed to change the system password.')), 'danger');
+					ui.addNotification(null,
+						E('p', _('Failed to change the system password.')),
+						0,
+						'danger'
+					);
 
 				formData.password.pw1 = null;
 				formData.password.pw2 = null;

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js
@@ -51,7 +51,11 @@ return view.extend({
 
 		return fs.write('/etc/rc.local', value).then(function() {
 			document.querySelector('textarea').value = value;
-			ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
+			ui.addNotification(null,
+				E('p', _('Contents have been saved.')),
+				0,
+				'info'
+			);
 		}).catch(function(e) {
 			ui.addNotification(null, E('p', _('Unable to save contents: %s').format(e.message)));
 		});


### PR DESCRIPTION
I was wondering why no CSS class was set for a notification. The problem was that the call arguments of the addNotification function have changed. This [commit](https://github.com/openwrt/luci/commit/53e36e3293bee2ea2ce0fbc1250074c44cfe8335) changed the API of the function.
I have now adjusted this. I have not tested everything as I do not use all applications. 
@systemcrash can you have a look at this and cross check my changes.


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
