### PR TITLE
luci-base: revert timeout function argument for addNotification

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3848,11 +3848,6 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * to the `dom.content()` function - refer to its documentation for
 	 * applicable values.
 	 *	 
-	 * @param {int} [timeout]
-	 * A millisecond value after which the notification will disappear
-	 * automatically. If omitted, the notification will remain until it receives
-	 * the click event.
-	 *
 	 * @param {...string} [classes]
 	 * A number of extra CSS class names which are set on the notification
 	 * banner element.
@@ -3860,7 +3855,7 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * @returns {Node}
 	 * Returns a DOM Node representing the notification banner element.
 	 */
-	addNotification(title, children, timeout, ...classes) {
+	addNotification(title, children, ...classes) {
 		const mc = document.querySelector('#maincontent') ?? document.body;
 		const msg = E('div', {
 			'class': 'alert-message fade-in',
@@ -3877,7 +3872,7 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					'class': 'btn',
 					'style': 'margin-left:auto; margin-top:auto',
 					'click': function(ev) {
-						fadeOutNotification(ev.target);
+						dom.parent(ev.target, '.alert-message').classList.add('fade-out');
 					},
 
 				}, [ _('Dismiss') ])
@@ -3892,27 +3887,6 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 		msg.classList.add(...classes);
 
 		mc.insertBefore(msg, mc.firstElementChild);
-
-		function fadeOutNotification(element) {
-			const notification = dom.parent(element, '.alert-message');
-			if (notification) {
-				notification.classList.add('fade-out');
-				notification.classList.remove('fade-in');
-				setTimeout(() => {
-					if (notification.parentNode) {
-						notification.parentNode.removeChild(notification);
-					}
-				});
-			}
-		}
-
-		if (typeof timeout === 'number' && timeout > 0) {
-			setTimeout(() => {
-				if (msg && msg.parentNode) {
-					fadeOutNotification(msg);
-				}
-			}, timeout);
-		}
 
 		return msg;
 	},


### PR DESCRIPTION
The function signature changed and all function call to addNotification that add a CSS class does not work anymore. A direct revert is not possible.

If this feature is needed than a new function musst be added, that does not break the function signature.

Fixes: 53e36e3293bee2ea2ce0fbc1250074c44cfe8335

See discussion for an other solution #7670 

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
