### PR TITLE
[23.05] luci-app-attendedsysupgrade: show upcoming versions when available

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -501,11 +501,6 @@ return view.extend({
 						break;
 					}
 
-					// skip branch upgrades outside the advanced mode
-					if (branch != remote_branch && advanced_mode == 0) {
-						continue;
-					}
-
 					candidates.unshift([remote_version, null]);
 
 					// don't offer branches older than the current


### PR DESCRIPTION
Do not hide upcoming versions behind the 'advanced_mode' setting, always show them.

Fixes: https://github.com/openwrt/asu/issues/1202
Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>
(cherry picked from commit 8b00d023b0335783dc459a738a1b1e9c2be9cacc)
