### PR TITLE
luci-mod-status: channel_analysis: fix 6 GHz support

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -311,7 +311,7 @@ return view.extend({
 				/* if channel_width <= 40, refer to HT (above) for actual channel width,
 				 * as vht_operation.channel_width == 40 really only means that the used
 				 * bandwidth is <= 40 and could be 20 Mhz as well */
-				if (res.vht_operation != null && res.vht_operation.channel_width > 40) {
+				if (res.vht_operation?.channel_width > 40) {
 					center_channels[0] = res.vht_operation.center_freq_1;
 					if (res.vht_operation.channel_width == 80) {
 						chan_width = 8;
@@ -340,6 +340,29 @@ return view.extend({
 						res.channel_width = "160 MHz";
 						chan_width = 16;
 					}
+				}
+
+				if (res.he_operation?.channel_width > 20) {
+					center_channels[0] = res.he_operation.center_freq_1;
+					chan_width = res.he_operation.channel_width / 10;
+					switch (res.he_operation.channel_width) {
+						case 40:
+							res.channel_width = "40 MHz";
+							break;
+						case 80:
+							res.channel_width = "80 MHz";
+							break;
+						case 160:
+							res.channel_width = "160 MHz";
+							center_channels.push(res.he_operation.center_freq_2);
+							break;
+					}
+				}
+
+				if (res.eht_operation?.channel_width == 320) {
+					chan_width = 32;
+					res.channel_width = "320 MHz";
+					center_channels.push(res.eht_operation.center_freq_2);
 				}
 
 				this.add_wifi_to_graph(chan_analysis, res, scanCache, center_channels, chan_width);


### PR DESCRIPTION
This commit fixes  wrong channel width in the 6 GHz band. Now all APs don't show a 20 MHz channel width.

Tested on ZyXEL EX5601 with MT7921 USB adapter.

Depends on: https://github.com/openwrt/rpcd/pull/11.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>

![obraz](https://github.com/user-attachments/assets/e2eee27c-a5c8-4ff1-9546-ca0b116f3b44)

~~~
Cell 15 - Address: 00:58:28:29:C1:D2
          ESSID: "OpenWrt"
          Mode: Master  Frequency: 5.955 GHz  Band: 6 GHz  Channel: 1
          Signal: -22 dBm  Quality: 70/70
          Encryption: WPA3 SAE (CCMP)
          HE Operation:
                    Center Frequency 1: 7
                    Center Frequency 2: 15
                    Channel Width: 160 MHz
          EHT Operation:
                    Center Frequency 1: 15
                    Center Frequency 2: 31
                    Channel Width: 320 MHz
~~~

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: mediatek/filogic/ex5601+mt7921 usb adapter, OpenWRT 24.10, Firefox 136.0.1 :white_check_mark:
- [x] \( Preferred ) Mention: @Ansuel @knarrff  the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)