### PR TITLE
luci-base: ui: filebrowser parent dir fix

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3084,7 +3084,7 @@ const UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */
 				i ? ' » ' : '',
 				E('a', {
 					'href': '#',
-					'click': UI.prototype.createHandlerFn(this, 'handleSelect', cur ?? '/', null)
+					'click': UI.prototype.createHandlerFn(this, 'handleSelect', '/' + cur, null)
 				}, dirs[i] != '' ? '%h'.format(dirs[i]) : E('em', '(root)')),
 			]);
 		}


### PR DESCRIPTION
Fix for a bug in file browser parent directory button.

When clicking on a parent directory link in a file browser control (ex. selecting a certificate in OpenVPN app) it will send an incorrect directory request that will end in an empty list.

Main problem is with how current directory is split by splitPath function: 
`/etc/config -> ['', 'etc', 'config']`

and reassembled:
```
for(let i = 0; i < dirs.length; i++) {
cur = cur ? ``${cur}/${dirs[i]}`` : dirs[i];

```
this will result with path strings missing the root directory slash: `etc/config`
sending this into the request will produce an invalid directory -> empty list.

A bonus bug is with how ?? operator treats empty strings: 
```
let foo = '';
return foo ? 'full' : 'empty'; //  -> returns 'empty' 
return foo ?? 'empty';         //  -> returns '' not 'empty'
```

The easiest fix (without completely rewriting the whole algorithm) is to just always add the missing slash before sending the request.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [ :white_check_mark: ] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch 
- [ :white_check_mark: ] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [ :white_check_mark: ] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [N/A] Incremented :up: any `PKG_VERSION` in the Makefile
- [ :white_check_mark: ] Tested on: ARMv8 Processor rev 1, 25.073.41994~96c3654, LibreWolf(Firefox)/Chromium
- [ :white_check_mark: ] Description: (describe the changes proposed in this PR)
