### PR TITLE
luci-app-keepalived: do not restart keepalived on user notification change

### DIFF
--- a/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/notification.js
+++ b/applications/luci-app-keepalived/htdocs/luci-static/resources/view/keepalived/notification.js
@@ -16,8 +16,6 @@ return view.extend({
 		return fs.write('/etc/keepalived.user', value).then(function(rc) {
 			document.querySelector('textarea').value = value;
 			ui.addNotification(null, E('p', _('Contents have been saved.')), 'info');
-
-			return fs.exec('/etc/init.d/keepalived', [ 'reload' ]);
 		}).catch(function(e) {
 			ui.addNotification(null, E('p', _('Unable to save contents: %s').format(e.message)));
 		});


### PR DESCRIPTION
The content of the file is executed at the next event, so it is not necessary to reload `/etc/init.d/keepalived` if the user notification has changed.

Fixes: #7685 

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
