### PR TITLE
luci-app-statistics: add UseLabels option for sensor

### DIFF
--- a/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/sensors.json
+++ b/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/sensors.json
@@ -3,7 +3,7 @@
 	"category": "general",
 	"legend": [
 		[],
-		["IgnoreSelected"],
+		["IgnoreSelected", "UseLabels"],
 		["Sensor"]
 	]
 }


### PR DESCRIPTION
- [x] Tested on: on 24.10 . by editing /usr/share/luci/statistics/plugins/sensors.json directly
- [x] \( Preferred ) Mention: @jow- 
- [ ] \( Preferred ) Screenshot or mp4 of changes: no visual changes
- [x] Description: add a new option from upstream. this may useful when sensor have multiple input on a same type (eg. sfp have both tx/rx power)

also https://github.com/openwrt/packages/pull/26308
