### PR TITLE
luci-proto-wireguard: fixed incorrect peer name detection when peer IP has been changed

### DIFF
--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -89,11 +89,16 @@ const methods = {
 					}
 					else {
 						let peer_name;
+						let peer_name_legacy;
 
 						uci.foreach('network', `wireguard_${last_device}`, (s) => {
 							if (!s.disabled && s.public_key == record[1] && (!s.endpoint_host || checkPeerHost(s.endpoint_host, s.endpoint_port, record[3])))
 								peer_name = s.description;
+							if (s.public_key == record[1])
+								peer_name_legacy = s.description;
 						});
+
+						if (!peer_name) peer_name = peer_name_legacy;
 
 						const peer = {
 							name: peer_name,


### PR DESCRIPTION
Added the legacy peer name detection algorithm.
If the new algorithm fails to find a peer's name (e.g. when the IP address has been changed) then the legacy value will be used.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile **Not applicable to luci-proto-wireguard**
- [X] Tested on: aarch64_cortex-a53 OpenWrt SNAPSHOT r29139-65b8a978de :white_check_mark:
- [X] \( Preferred ) Mention: @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: e.g. openwrt/luci#7720
- [ ] \( Optional ) Depends on: nothing
- [X] Description: see above