### PR TITLE
use toolchain HOSTCC rather than cc

### DIFF
--- a/modules/luci-base/src/Makefile
+++ b/modules/luci-base/src/Makefile
@@ -2,7 +2,7 @@
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(FPIC) -DNDEBUG -c -o $@ $<
 
 contrib/lemon: contrib/lemon.c contrib/lempar.c
-	cc -o contrib/lemon $<
+	$(HOSTCC) -o contrib/lemon $<
 
 lib/plural_formula.c: lib/plural_formula.y contrib/lemon
 	./contrib/lemon -q $<


### PR DESCRIPTION
build was failing b/c gcc15 doesn't like lemon, which is odd b/c i overrode my compiler to gcc-14. turns out this is hardcoded to the cc on the path, which is undesirable.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile - shouldn't be necessary
- [x] Tested on: (Snapshot, Fedora 42) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback @jow- 
- [x] Description: (describe the changes proposed in this PR)
