### PR TITLE
luci-app-attendedsysupgrade: change error reporting url

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -263,7 +263,7 @@ return view.extend({
 			E('p', {}, _('Server response: %s').format(response.detail)),
 			E(
 				'a',
-				{ href: 'https://github.com/openwrt/asu/issues' },
+				{ href: 'https://forum.openwrt.org/t/luci-attended-sysupgrade-support-thread/230552' },
 				_('Please report the error message and request')
 			),
 			E('p', {}, _('Request Data:')),


### PR DESCRIPTION
Direct error reports to a LuCI-ASU-app-specific thread on the forum, where they'll get more attention and reduce clutter on the ASU server's github issues.

(Needs backport to 24.10, maybe 23.05 if that's easy...)