### PR TITLE
luci-app-tailscale: add new package

### DIFF
--- a/applications/luci-app-tailscale/Makefile
+++ b/applications/luci-app-tailscale/Makefile
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2024 asvow
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI for Tailscale
+LUCI_DEPENDS:=+tailscale
+
+PKG_MAINTAINER:=Geoffrey Hall <asvows@gmail.com>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js
+++ b/applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Copyright (C) 2022 ImmortalWrt.org
+ * Copyright (C) 2024 asvow
+ */
+
+'use strict';
+'require dom';
+'require fs';
+'require poll';
+'require ui';
+'require view';
+
+return view.extend({
+	async load() {
+		const res = await fs.exec('/sbin/ip', ['-s', '-j', 'ad']);
+		if (res.code !== 0 || !res.stdout || res.stdout.trim() === '') {
+			ui.addNotification(null, E('p', {}, _('Unable to get interface info: %s.').format(res.message)));
+			return [];
+		}
+
+		try {
+			const interfaces = JSON.parse(res.stdout);
+			const tailscaleInterfaces = interfaces.filter(iface => iface.ifname.match(/tailscale[0-9]+/));
+
+			return tailscaleInterfaces.map(iface => {
+				const parsedInfo = {
+					name: iface.ifname
+				};
+
+				const addr_info = iface.addr_info || [];
+				addr_info.forEach(addr => {
+					if (addr.family === 'inet' && !parsedInfo.ipv4) {
+						parsedInfo.ipv4 = addr.local;
+					} else if (addr.family === 'inet6' && !parsedInfo.ipv6) {
+						parsedInfo.ipv6 = addr.local;
+					}
+				});
+
+				parsedInfo.mtu = iface.mtu;
+				parsedInfo.rxBytes = '%1024mB'.format(iface.stats64.rx.bytes);
+				parsedInfo.txBytes = '%1024mB'.format(iface.stats64.tx.bytes);
+
+				return parsedInfo;
+			});
+		} catch (e) {
+			ui.addNotification(null, E('p', {}, _('Error parsing interface info: %s.').format(e.message)));
+			return [];
+		}
+	},
+
+	pollData(container) {
+		poll.add(async () => {
+			const data = await this.load();
+			dom.content(container, this.renderContent(data));
+		});
+	},
+
+	renderContent(data) {
+		if (!Array.isArray(data) || data.length === 0) {
+			return E('div', {}, _('No interface online.'));
+		}
+		const rows = [
+			E('th', { class: 'th', colspan: '2' }, _('Network Interface Information'))
+		];
+		data.forEach(interfaceData => {
+			rows.push(
+				E('tr', { class: 'tr' }, [
+					E('td', { class: 'td left', width: '25%' }, _('Interface Name')),
+					E('td', { class: 'td left', width: '25%' }, interfaceData.name)
+				]),
+				E('tr', { class: 'tr' }, [
+					E('td', { class: 'td left', width: '25%' }, _('IPv4 Address')),
+					E('td', { class: 'td left', width: '25%' }, interfaceData.ipv4)
+				]),
+				E('tr', { class: 'tr' }, [
+					E('td', { class: 'td left', width: '25%' }, _('IPv6 Address')),
+					E('td', { class: 'td left', width: '25%' }, interfaceData.ipv6)
+				]),
+				E('tr', { class: 'tr' }, [
+					E('td', { class: 'td left', width: '25%' }, _('MTU')),
+					E('td', { class: 'td left', width: '25%' }, interfaceData.mtu)
+				]),
+				E('tr', { class: 'tr' }, [
+					E('td', { class: 'td left', width: '25%' }, _('Total Download')),
+					E('td', { class: 'td left', width: '25%' }, interfaceData.rxBytes)
+				]),
+				E('tr', { class: 'tr' }, [
+					E('td', { class: 'td left', width: '25%' }, _('Total Upload')),
+					E('td', { class: 'td left', width: '25%' }, interfaceData.txBytes)
+				])
+			);
+		});
+
+		return E('table', { 'class': 'table' }, rows);
+	},
+
+	render(data) {
+		const content = E([], [
+			E('h2', { class: 'content' }, _('Tailscale')),
+			E('div', { class: 'cbi-map-descr' }, _('Tailscale is a cross-platform and easy to use virtual LAN.')),
+			E('div')
+		]);
+		const container = content.lastElementChild;
+
+		dom.content(container, this.renderContent(data));
+		this.pollData(container);
+
+		return content;
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/log.js
+++ b/applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/log.js
@@ -1,0 +1,92 @@
+'use strict';
+'require fs';
+'require poll';
+'require ui';
+'require view';
+
+return view.extend({
+	async retrieveLog() {
+		const stat = await Promise.all([
+			L.resolveDefault(fs.stat('/sbin/logread'), null),
+			L.resolveDefault(fs.stat('/usr/sbin/logread'), null)
+		]);
+		const logger = stat[0] ? stat[0].path : stat[1] ? stat[1].path : null;
+
+		const logdata = await fs.exec_direct(logger, ['-e', 'tailscale']);
+		const statusMappings = {
+			'daemon.err': { status: 'StdErr', startIndex: 9 },
+			'daemon.notice': { status: 'Info', startIndex: 10 }
+		};
+		const loglines = logdata.trim().split(/\n/).map(function(log) {
+			const logParts = log.split(' ').filter(Boolean);
+			if (logParts.length >= 6) {
+				const formattedTime = `${logParts[1]} ${logParts[2]} - ${logParts[3]}`;
+				const status = logParts[5];
+				const mapping = statusMappings[status] || { status: status, startIndex: 9 };
+				const newStatus = mapping.status;
+				const startIndex = mapping.startIndex;
+				const message = logParts.slice(startIndex).join(' ');
+				return `${formattedTime} [ ${newStatus} ] - ${message}`;
+			} else {
+				return 'Log is empty.';
+			}
+		}).filter(Boolean);
+		return { value: loglines.join('\n'), rows: loglines.length + 1 };
+	},
+
+	async pollLog() {
+		const element = document.getElementById('syslog');
+		if (element) {
+			try {
+				const log = await this.retrieveLog();
+				element.value = log.value;
+				element.rows = log.rows;
+			} catch (err) {
+				ui.addNotification(null, E('p', {}, _('Unable to load log data: ' + err.message)));
+			}
+		}
+	},
+
+	load() {
+		poll.add(this.pollLog.bind(this));
+		return this.retrieveLog();
+	},
+
+	render(loglines) {
+		const scrollDownButton = E('button', { 
+				id: 'scrollDownButton',
+				class: 'cbi-button cbi-button-neutral'
+			}, _('Scroll to tail', 'scroll to bottom (the tail) of the log file')
+		);
+		scrollDownButton.addEventListener('click', function() {
+			scrollUpButton.scrollIntoView();
+		});
+
+		const scrollUpButton = E('button', { 
+				id : 'scrollUpButton',
+				class: 'cbi-button cbi-button-neutral'
+			}, _('Scroll to head', 'scroll to top (the head) of the log file')
+		);
+		scrollUpButton.addEventListener('click', function() {
+			scrollDownButton.scrollIntoView();
+		});
+
+		return E([], [
+			E('div', { id: 'content_syslog' }, [
+				E('div', { style: 'padding-bottom: 20px' }, [scrollDownButton]),
+				E('textarea', {
+					id: 'syslog',
+					style: 'font-size:12px',
+					readonly: 'readonly',
+					wrap: 'off',
+					rows: loglines.rows,
+				}, [ loglines.value ]),
+				E('div', { style: 'padding-bottom: 20px' }, [scrollUpButton])
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js
+++ b/applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js
@@ -1,0 +1,268 @@
+/* SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Copyright (C) 2024 asvow
+ */
+
+'use strict';
+'require form';
+'require fs';
+'require network';
+'require poll';
+'require rpc';
+'require uci';
+'require view';
+
+const callServiceList = rpc.declare({
+	object: 'service',
+	method: 'list',
+	params: ['name'],
+	expect: { '': {} }
+});
+
+async function getInterfaceSubnets(interfaces = ['lan', 'wan']) {
+	const networks = await network.getNetworks();
+	return [...new Set(
+		networks
+			.filter(ifc => interfaces.includes(ifc.getName()))
+			.flatMap(ifc => ifc.getIPAddrs())
+			.filter(addr => addr.includes('/'))
+			.map(addr => {
+				const [ip, cidr] = addr.split('/');
+				const ipParts = ip.split('.').map(Number);
+				const mask = ~((1 << (32 - parseInt(cidr))) - 1);
+				const subnetParts = ipParts.map((part, i) => (part & (mask >> (24 - i * 8))) & 255);
+				return `${subnetParts.join('.')}/${cidr}`;
+			})
+	)];
+}
+
+async function getStatus() {
+	const status = {
+		isRunning: false,
+		backendState: undefined,
+		authURL: undefined,
+		displayName: undefined,
+		onlineExitNodes: [],
+		subnetRoutes: []
+	};
+	const res = await callServiceList('tailscale');
+	try {
+		status.isRunning = res['tailscale']['instances']['instance1']['running'];
+	} catch (e) {
+		return status;
+	}
+	const tailscaleRes = await fs.exec("/usr/sbin/tailscale", ["status", "--json"]);
+	const tailscaleStatus = JSON.parse(tailscaleRes.stdout.replace(/("\w+"):\s*(\d+)/g, '$1:"$2"'));
+	if (!tailscaleStatus.AuthURL && tailscaleStatus.BackendState === "NeedsLogin") {
+		fs.exec("/usr/sbin/tailscale", ["login"]);
+	}
+	status.backendState = tailscaleStatus.BackendState;
+	status.authURL = tailscaleStatus.AuthURL;
+	status.displayName = (status.backendState === "Running") ? tailscaleStatus.User[tailscaleStatus.Self.UserID].DisplayName : undefined;
+	if (tailscaleStatus.Peer) {
+		status.onlineExitNodes = Object.values(tailscaleStatus.Peer)
+			.flatMap(peer => (peer.ExitNodeOption && peer.Online) ? [peer.HostName] : []);
+		status.subnetRoutes = Object.values(tailscaleStatus.Peer)
+			.flatMap(peer => peer.PrimaryRoutes || []);
+	}
+	return status;
+}
+
+function renderStatus(isRunning) {
+	const spanTemp = '<em><span style="color:%s"><strong>%s %s</strong></span></em>';
+	let renderHTML;
+	if (isRunning) {
+		renderHTML = String.format(spanTemp, 'green', _('Tailscale'), _('RUNNING'));
+	} else {
+		renderHTML = String.format(spanTemp, 'red', _('Tailscale'), _('NOT RUNNING'));
+	}
+
+	return renderHTML;
+}
+
+function renderLogin(loginStatus, authURL, displayName) {
+	const spanTemp = '<span style="color:%s">%s</span>';
+	let renderHTML;
+	if (loginStatus === "NeedsLogin") {
+		renderHTML = String.format('<a href="%s" target="_blank">%s</a>', authURL, _('Need to log in'));
+	} else if (loginStatus === "Running") {
+		renderHTML = String.format('<a href="%s" target="_blank">%s</a>', 'https://login.tailscale.com/admin/machines', displayName);
+		renderHTML += String.format('<br><a style="color:green" id="logout_button">%s</a>', _('Log out and Unbind'));
+	} else {
+		renderHTML = String.format(spanTemp, 'orange', _('NOT RUNNING'));
+	}
+
+	return renderHTML;
+}
+
+return view.extend({
+	load() {
+		return Promise.all([
+			uci.load('tailscale'),
+			getStatus(),
+			getInterfaceSubnets()
+		]);
+	},
+
+	render(data) {
+		let m, s, o;
+		const statusData = data[1];
+		const interfaceSubnets = data[2];
+		const onlineExitNodes = statusData.onlineExitNodes;
+		const subnetRoutes = statusData.subnetRoutes;
+
+		m = new form.Map('tailscale', _('Tailscale'), _('Tailscale is a cross-platform and easy to use virtual LAN.'));
+
+		s = m.section(form.TypedSection);
+		s.anonymous = true;
+		s.render = function () {
+			poll.add(async function() {
+				const res = await getStatus();
+				const service_view = document.getElementById("service_status");
+				const login_view = document.getElementById("login_status_div");
+				service_view.innerHTML = renderStatus(res.isRunning);
+				login_view.innerHTML = renderLogin(res.backendState, res.authURL, res.displayName);
+				const logoutButton = document.getElementById('logout_button');
+				if (logoutButton) {
+					logoutButton.onclick = function() {
+						if (confirm(_('Are you sure you want to log out and unbind the current device?'))) {
+							fs.exec("/usr/sbin/tailscale", ["logout"]);
+						}
+					}
+				}
+			});
+
+			return E('div', { class: 'cbi-section', id: 'status_bar' }, [
+				E('p', { id: 'service_status' }, _('Collecting data ...'))
+			]);
+		}
+
+		s = m.section(form.NamedSection, 'settings', 'config');
+		s.tab('basic', _('Basic Settings'));
+
+		o = s.taboption('basic', form.Flag, 'enabled', _('Enable'));
+		o.default = o.disabled;
+		o.rmempty = false;
+
+		o = s.taboption('basic', form.DummyValue, 'login_status', _('Login Status'));
+		o.depends('enabled', '1');
+		o.renderWidget = function(section_id, option_id) {
+			return E('div', { 'id': 'login_status_div' }, _('Collecting data ...'));
+		};
+
+		o = s.taboption('basic', form.Value, 'port', _('Port'), _('Set the Tailscale port number.'));
+		o.datatype = 'port';
+		o.default = '41641';
+		o.rmempty = false;
+
+		o = s.taboption('basic', form.Value, 'config_path', _('Workdir'), _('The working directory contains config files, audit logs, and runtime info.'));
+		o.default = '/etc/tailscale';
+		o.rmempty = false;
+
+		o = s.taboption('basic', form.ListValue, 'fw_mode', _('Firewall Mode'));
+		o.value('nftables', 'nftables');
+		o.value('iptables', 'iptables');
+		o.default = 'nftables';
+		o.rmempty = false;
+
+		o = s.taboption('basic', form.Flag, 'log_stdout', _('StdOut Log'), _('Logging program activities.'));
+		o.default = o.enabled;
+		o.rmempty = false;
+
+		o = s.taboption('basic', form.Flag, 'log_stderr', _('StdErr Log'), _('Logging program errors and exceptions.'));
+		o.default = o.enabled;
+		o.rmempty = false;
+
+		s.tab('advance', _('Advanced Settings'));
+
+		o = s.taboption('advance', form.Flag, 'accept_routes', _('Accept Routes'), _('Accept subnet routes that other nodes advertise.'));
+		o.default = o.disabled;
+		o.rmempty = false;
+
+		o = s.taboption('advance', form.Value, 'hostname', _('Device Name'), _("Leave blank to use the device's hostname."));
+		o.default = '';
+		o.rmempty = true;
+
+		o = s.taboption('advance', form.Flag, 'accept_dns', _('Accept DNS'), _('Accept DNS configuration from the Tailscale admin console.'));
+		o.default = o.enabled;
+		o.rmempty = false;
+
+		o = s.taboption('advance', form.Flag, 'advertise_exit_node', _('Exit Node'), _('Offer to be an exit node for outbound internet traffic from the Tailscale network.'));
+		o.default = o.disabled;
+		o.rmempty = false;
+
+		o = s.taboption('advance', form.ListValue, 'exit_node', _('Online Exit Nodes'), _('Select an online machine name to use as an exit node.'));
+		if (onlineExitNodes.length > 0) {
+			o.optional = true;
+			onlineExitNodes.forEach(function(node) {
+				o.value(node, node);
+			});
+		} else {
+			o.value('', _('No Available Exit Nodes'));
+			o.readonly = true;
+		}
+		o.default = '';
+		o.depends('advertise_exit_node', '0');
+		o.rmempty = true;
+
+		o = s.taboption('advance', form.DynamicList, 'advertise_routes', _('Expose Subnets'), _('Expose physical network routes into Tailscale, e.g. <code>10.0.0.0/24</code>.'));
+		if (interfaceSubnets.length > 0) {
+			interfaceSubnets.forEach(function(subnet) {
+				o.value(subnet, subnet);
+			});
+		}
+		o.default = '';
+		o.rmempty = true;
+
+		o = s.taboption('advance', form.Flag, 'disable_snat_subnet_routes', _('Site To Site'), _('Use site-to-site layer 3 networking to connect subnets on the Tailscale network.'));
+		o.default = o.disabled;
+		o.depends('accept_routes', '1');
+		o.rmempty = false;
+
+		o = s.taboption('advance', form.DynamicList, 'subnet_routes', _('Subnet Routes'), _('Select subnet routes advertised by other nodes in Tailscale network.'));
+		if (subnetRoutes.length > 0) {
+			subnetRoutes.forEach(function(route) {
+				o.value(route, route);
+			});
+		} else {
+			o.value('', _('No Available Subnet Routes'));
+			o.readonly = true;
+		}
+		o.default = '';
+		o.depends('disable_snat_subnet_routes', '1');
+		o.rmempty = true;
+
+		o = s.taboption('advance', form.MultiValue, 'access', _('Access Control'));
+		o.value('ts_ac_lan', _('Tailscale access LAN'));
+		o.value('ts_ac_wan', _('Tailscale access WAN'));
+		o.value('lan_ac_ts', _('LAN access Tailscale'));
+		o.value('wan_ac_ts', _('WAN access Tailscale'));
+		o.default = "ts_ac_lan ts_ac_wan lan_ac_ts";
+		o.rmempty = true;
+
+		s.tab('extra', _('Extra Settings'));
+
+		o = s.taboption('extra', form.DynamicList, 'flags', _('Additional Flags'),
+			String.format(
+				_('List of extra flags. Format: --flags=value, e.g. <code>--exit-node=10.0.0.1</code>. <br> %s for enabling settings upon the initiation of Tailscale.'),
+				'<a href="https://tailscale.com/kb/1241/tailscale-up" target="_blank">' + _('Available flags') + '</a>'
+			)
+		);
+		o.default = '';
+		o.rmempty = true;
+
+		s = m.section(form.NamedSection, 'settings', 'config');
+		s.title = _('Custom Server Settings');
+		s.description = String.format(_('Use %s to deploy a private server.'), '<a href="https://github.com/juanfont/headscale" target="_blank">headscale</a>');
+
+		o = s.option(form.Value, 'login_server', _('Server Address'));
+		o.default = '';
+		o.rmempty = true;
+
+		o = s.option(form.Value, 'authKey', _('Auth Key'));
+		o.default = '';
+		o.rmempty = true;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-tailscale/po/templates/tailscale.pot
+++ b/applications/luci-app-tailscale/po/templates/tailscale.pot
@@ -1,0 +1,295 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:186
+msgid "Accept DNS"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:186
+msgid "Accept DNS configuration from the Tailscale admin console."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:178
+msgid "Accept Routes"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:178
+msgid "Accept subnet routes that other nodes advertise."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:235
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:245
+msgid "Additional Flags"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:176
+msgid "Advanced Settings"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:128
+msgid "Are you sure you want to log out and unbind the current device?"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:262
+msgid "Auth Key"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:248
+msgid "Available flags"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:141
+msgid "Basic Settings"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:136
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:150
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:255
+msgid "Custom Server Settings"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:182
+msgid "Device Name"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:143
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:47
+msgid "Error parsing interface info: %s."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:190
+msgid "Exit Node"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:208
+msgid "Expose Subnets"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:208
+msgid ""
+"Expose physical network routes into Tailscale, e.g. <code>10.0.0.0/24</code>."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:243
+msgid "Extra Settings"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:162
+msgid "Firewall Mode"
+msgstr ""
+
+#: applications/luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json:14
+msgid "Global Settings"
+msgstr ""
+
+#: applications/luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json:3
+msgid "Grant access to Tailscale configuration"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:73
+msgid "IPv4 Address"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:77
+msgid "IPv6 Address"
+msgstr ""
+
+#: applications/luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json:22
+msgid "Interface Info"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:69
+msgid "Interface Name"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:238
+msgid "LAN access Tailscale"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:182
+msgid "Leave blank to use the device's hostname."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:247
+msgid ""
+"List of extra flags. Format: --flags=value, e.g. <code>--exit-node=10.0.0.1</"
+"code>. <br> %s for enabling settings upon the initiation of Tailscale."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:90
+msgid "Log out and Unbind"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:168
+msgid "Logging program activities."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:172
+msgid "Logging program errors and exceptions."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:147
+msgid "Login Status"
+msgstr ""
+
+#: applications/luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json:30
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:81
+msgid "MTU"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:77
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:92
+msgid "NOT RUNNING"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:87
+msgid "Need to log in"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:64
+msgid "Network Interface Information"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:201
+msgid "No Available Exit Nodes"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:228
+msgid "No Available Subnet Routes"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:61
+msgid "No interface online."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:190
+msgid ""
+"Offer to be an exit node for outbound internet traffic from the Tailscale "
+"network."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:194
+msgid "Online Exit Nodes"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:153
+msgid "Port"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:75
+msgid "RUNNING"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/log.js:68
+msgctxt "scroll to top (the head) of the log file"
+msgid "Scroll to head"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/log.js:59
+msgctxt "scroll to bottom (the tail) of the log file"
+msgid "Scroll to tail"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:194
+msgid "Select an online machine name to use as an exit node."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:222
+msgid "Select subnet routes advertised by other nodes in Tailscale network."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:258
+msgid "Server Address"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:153
+msgid "Set the Tailscale port number."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:217
+msgid "Site To Site"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:172
+msgid "StdErr Log"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:168
+msgid "StdOut Log"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:222
+msgid "Subnet Routes"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:100
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:75
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:77
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:114
+#: applications/luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json:3
+msgid "Tailscale"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:236
+msgid "Tailscale access LAN"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:237
+msgid "Tailscale access WAN"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:101
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:114
+msgid "Tailscale is a cross-platform and easy to use virtual LAN."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:158
+msgid ""
+"The working directory contains config files, audit logs, and runtime info."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:85
+msgid "Total Download"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:89
+msgid "Total Upload"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/interface.js:18
+msgid "Unable to get interface info: %s."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/log.js:45
+msgid "Unable to load log data:"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:256
+msgid "Use %s to deploy a private server."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:217
+msgid ""
+"Use site-to-site layer 3 networking to connect subnets on the Tailscale "
+"network."
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:239
+msgid "WAN access Tailscale"
+msgstr ""
+
+#: applications/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/setting.js:158
+msgid "Workdir"
+msgstr ""

--- a/applications/luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json
+++ b/applications/luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json
@@ -1,0 +1,37 @@
+{
+	"admin/vpn/tailscale": {
+		"title": "Tailscale",
+		"order": 90,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-tailscale" ],
+			"uci": { "tailscale": true }
+		}
+	},
+	"admin/vpn/tailscale/setting": {
+		"title": "Global Settings",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "tailscale/setting"
+		}
+	},
+	"admin/vpn/tailscale/interface": {
+		"title": "Interface Info",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "tailscale/interface"
+		}
+	},
+	"admin/vpn/tailscale/log": {
+		"title": "Logs",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "tailscale/log"
+		}
+	}
+}

--- a/applications/luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json
+++ b/applications/luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json
@@ -1,0 +1,21 @@
+{
+	"luci-app-tailscale": {
+		"description": "Grant access to Tailscale configuration",
+		"read": {
+			"file": {
+				"/sbin/ip -s -j ad": [ "exec" ],
+				"/sbin/logread -e tailscale": [ "exec" ],
+				"/usr/sbin/tailscale status --json": [ "exec" ],
+				"/usr/sbin/tailscale login": [ "exec" ],
+				"/usr/sbin/tailscale logout": [ "exec" ]
+			},
+			"ubus": {
+				"service": [ "list" ]
+			},
+			"uci": [ "tailscale" ]
+		},
+		"write": {
+			"uci": [ "tailscale" ]
+		}
+	}
+}


### PR DESCRIPTION
Despite the guidance in the official [OpenWrt documentation](https://openwrt.org/docs/guide-user/services/vpn/tailscale/start), configuring Tailscale on OpenWrt remains quite cumbersome. I developed the [luci-app-tailscale](https://github.com/asvow/luci-app-tailscale) to simplify the configuration process through LuCI. Over the past year, I've continuously refined it, and now it's stable for use.

Previously, there were conflicts between `/etc/init.d/tailscale` and `/etc/config/tailscale` in the [Tailscale package](https://github.com/openwrt/packages/tree/master/net/tailscale), which had long troubled me. Recently, I successfully resolved this issue (asvow/neo-addon@4e71c60), and I'll submit a PR with this solution to the master branch of [openwrt/packages](https://github.com/openwrt/packages) later.

I'd like to integrate this feature into the LuCI master. @jow- @hnyman, what's your take on this? 