### PR TITLE
Luci-Theme-Bootstrap DarkMode Unbound File Edit

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2622,3 +2622,7 @@ div.cbi-value var.cbi-tooltip-container,
 [data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > div > div > svg > line[style] {
 	stroke: #fff!important;
 }
+
+[data-darkmode="true"] .cbi-input-textarea {
+  background-color: var(--background-color-high);
+}


### PR DESCRIPTION
Add css to make the Unbound file editor have a dark background when using Bootstrap dark mode theme. 
Currently the unbound file editor has a yellowish background, even in dark mode. This makes the background dark. 
I am not sure if this is the best way to do this but the change is fairly straightforward. 

Let me know if this is something you are interested in or if there are any changes you would like made. 

Current: 
<img width="728" alt="Screenshot 2025-04-22 090615" src="https://github.com/user-attachments/assets/5b610b30-99c7-4a0d-b71b-26c31a3e49c2" />

After change:
![Screenshot 2025-04-22 090024](https://github.com/user-attachments/assets/27a34a63-ca50-476e-bd91-798ef052b7ab)
