### PR TITLE
luci-theme-bootstrap: unbound darkmode file editor

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2621,3 +2621,7 @@ div.cbi-value var.cbi-tooltip-container,
 [data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > div > div > svg > line[style] {
 	stroke: #fff!important;
 }
+
+[data-darkmode="true"] .cbi-input-textarea {
+  background-color: var(--background-color-high);
+}


### PR DESCRIPTION
Add css to make the Unbound file editor have a dark background when using Bootstrap dark mode theme.
Currently the unbound file editor has a yellowish background, even in dark mode. This makes the background dark.
I am not sure if this is the best way to do this but the change is fairly straightforward.

Let me know if this is something you are interested in or if there are any changes you would like made.

Current:
![Screenshot 2025-04-22 090611](https://github.com/user-attachments/assets/6dfc444c-b145-4ced-b492-3865144d5548)


After change:
![Screenshot 2025-04-22 090024](https://github.com/user-attachments/assets/addc3cfd-1f81-4b08-b06f-1fbcde9676d0)
