### PR TITLE
[24.10] luci-base: Hardcode 'openwrt-24.10' as the branch name

### DIFF
--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-base
 PKG_BUILD_FLAGS:=no-lto
 
+# Hardcode 'openwrt-24.10' release branch as the branch name
+PKG_GITBRANCH:=LuCI openwrt-24.10 branch
+
 LUCI_TYPE:=mod
 LUCI_BASENAME:=base
 


### PR DESCRIPTION
Hardcode 'openwrt-24.10' release branch as the branch name to avoid `LuCI (HEAD detached at 2ac26e56) branch` being shown as the branch.

Feeds are since March 2025 cloned shallow if cloned from a specific commit, like done with a release tag. Change in OpenWrt: https://github.com/openwrt/openwrt/commit/32d0a57dc10811a24816e51f10e55963f40fe462

As the only cloned commit of a release tag is without history, the branch can't be identified.

So, hardcode the branch name to get the proper branch name `LuCI openwrt-24.10 branch` into version.uc.

Fixes #7737

Similar change should likely be done also for 23.05 (into where the same feeds logic has been backported).

Note that the change will only have impact from 24.10.2 onward, as 24.10.1 tag is naturally unimpacted by this.

The change is unnecessary for builds from feeds with full history, but locking the release branch name is harmless, as the branch name does not change.

cc @robimarko @subnut @4nth5 @jow- 

----
Before:
```
perus@ub2504:/OpenWrt/r7800-2410$ make package/luci-base/clean ; make -j 5 package/luci-base/compile ; cat staging_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/root-ipq806x/usr/share/ucode/luci/version.uc  ; (cd feeds/luci ; git status | head -n 3 ; git diff )
 make[1] package/luci-base/compile
...
 make[2] -C feeds/luci/libs/rpcd-mod-luci compile
 make[2] -C feeds/luci/modules/luci-base compile
export const revision = '25.103.51521~2ac26e5', branch = 'LuCI (HEAD detached at 2ac26e56) branch';
HEAD detached at 2ac26e56
nothing to commit, working tree clean
```

With this PR:
```
perus@ub2504:/OpenWrt/r7800-2410$ make package/luci-base/clean ; make -j 5 package/luci-base/compile ; cat staging_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/root-ipq806x/usr/share/ucode/luci/version.uc  ; (cd feeds/luci ; git status | head -n 3 ; git diff )
...
 make[2] -C feeds/luci/modules/luci-base compile
export const revision = '25.103.51521~2ac26e5', branch = 'LuCI openwrt-24.10 branch';
HEAD detached at 2ac26e56
Changes not staged for commit:
```
