### PR TITLE
luci-base: remove bad Unicode on clone button

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2728,11 +2728,11 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 
 			dom.append(tdEl.lastElementChild,
 				E('button', {
-					'title': btn_title || _('Clone') + '⿻',
+					'title': btn_title || _('Clone'),
 					'class': 'btn cbi-button cbi-button-neutral',
 					'click': ui.createHandlerFn(this, 'handleClone', section_id, true),
 					'disabled': this.map.readonly || null
-				}, [ btn_title || _('Clone') + '⿻' ])
+				}, [ btn_title || _('Clone') ])
 			);
 		}
 


### PR DESCRIPTION
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages

This Unicode character is intended to be followed by 2 more characters which are combined. It's entirely unnecessary, so just remove it.