### PR TITLE
luci-mod-network: fix default policy for bonding device

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
@@ -619,7 +619,7 @@ return baseclass.extend({
 		o.depends('type', 'bonding');
 
 		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'policy', _('Bonding Policy'));
-		o.default = 'active-backup';
+		o.default = 'balance-rr';
 		o.value('active-backup', _('Active backup'));
 		o.value('balance-rr', _('Round robin'));
 		o.value('balance-xor', _('Transmit hash - balance-xor'));
@@ -660,7 +660,7 @@ return baseclass.extend({
 				return 'balance-alb';
 
 			default:
-				return 'active-backup';
+				return 'balance-rr';
 			}
 		};
 		o.depends('type', 'bonding');


### PR DESCRIPTION
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [?] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: Firefox, Openwrt 24.10 on top of Luci 25.103.51521~2ac26e5  :white_check_mark:
- [X]  Closes: openwrt/luci#7683

This fixes the missing `policy` option in UCI when selecting 'active-backup'
 as the required policy in a bonding device.
