### PR TITLE
luci-app-wol: Show additional possibly powered off hosts in dropdown menu

### DIFF
--- a/applications/luci-app-wol/htdocs/luci-static/resources/view/wol.js
+++ b/applications/luci-app-wol/htdocs/luci-static/resources/view/wol.js
@@ -57,6 +57,15 @@ return view.extend({
 			o.noaliases = true;
 			o.noinactive = true;
 
+			uci.sections('etherwake', 'target', function(section) {
+				if (section.mac && section.name) {
+					// Create a host entry if it doesn't exist
+					if (!hosts[section.mac]) {
+						hosts[section.mac] = { name: section.name };
+					}
+				}
+			});
+
 			if (has_wol)
 				o.depends('executable', '/usr/bin/etherwake');
 		}


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
  - Architecture: mvebu/cortexa9 (Turris Omnia)
  - OpenWrt version: 24.10.0-rc5
  - Browser: Google Chrome 135.0.7049.114
- [x] Description: This enhancement adds the ability to show additional possibly powered-off hosts in the Wake-on-LAN dropdown menu. It scans the etherwake configuration for target entries and adds them to the host selection dropdown, making it easier for users to wake up devices that are currently powered off and not visible in the ARP table.

@Damrod 