### PR TITLE
luci-proto-modemmanager: fix username and password show if allowedauth is configured

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -125,14 +125,18 @@ return network.registerProtocol('modemmanager', {
 		o.depends('allowedmode','5g|4g|3g|2g');
 
 		o = s.taboption('general', form.Value, 'username', _('PAP/CHAP username'));
-		o.depends('auth', 'pap');
-		o.depends('auth', 'chap');
-		o.depends('auth', 'both');
+		o.depends({'allowedauth': 'pap', '!contains': true });
+		o.depends({'allowedauth': 'chap', '!contains': true });
+		o.depends({'allowedauth': 'mschap', '!contains': true });
+		o.depends({'allowedauth': 'mschapv2', '!contains': true });
+		o.depends({'allowedauth': 'eap', '!contains': true });
 
 		o = s.taboption('general', form.Value, 'password', _('PAP/CHAP password'));
-		o.depends('auth', 'pap');
-		o.depends('auth', 'chap');
-		o.depends('auth', 'both');
+		o.depends({'allowedauth': 'pap', '!contains': true });
+		o.depends({'allowedauth': 'chap', '!contains': true });
+		o.depends({'allowedauth': 'mschap', '!contains': true });
+		o.depends({'allowedauth': 'mschapv2', '!contains': true });
+		o.depends({'allowedauth': 'eap', '!contains': true });
 		o.password = true;
 
 		o = s.taboption('general', form.ListValue, 'iptype', _('IP Type'));


### PR DESCRIPTION
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86_64, openwrt master, firefox) :white_check_mark:
- [x] \( Optional ) Closes: openwrt/luci#7784
