### PR TITLE
luci-mod-network: add gui options for netifd source and destination port

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
@@ -195,6 +195,16 @@ return view.extend({
 			o.datatype = 'string';
 			o.placeholder = '0x1/0xf';
 
+			o = s.taboption('advanced', form.Value, 'sport', _('Source port'), _('Match traffic from this source port'));
+			o.modalonly = true;
+			o.datatype = 'string';
+			o.placeholder = '0-65535';
+
+			o = s.taboption('advanced', form.Value, 'dport', _('Destination port'), _('Match traffic from this destination port'));
+			o.modalonly = true;
+			o.datatype = 'string';
+			o.placeholder = '0-65535';
+
 			o = s.taboption('advanced', form.Value, 'tos', _('Type of service'), _('Specifies the TOS value to match in IP headers'));
 			o.modalonly = true;
 			o.datatype = 'uinteger';


### PR DESCRIPTION
Maintainer: @systemcrash
Compile tested: aarch64, cortex-a53, OpenWRT Main
Run tested: Dynalink DL-WRX36

Recently for netifd source and destination port have been added see https://github.com/openwrt/netifd/commit/7901e66c5f273bceee8981bc8a0c8b0e60945f60

This PR adds the GUI options for netifd source and destination port.

Signed-off-by: Erik Conijn egc112@msn.com

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
