### PR TITLE
luci-app-attendedsysupgrade: avoid redirects, handle redirect errors

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -338,19 +338,17 @@ return view.extend({
 							}
 						}
 						break;
-					case 400: // bad request
-					case 422: // bad package
-					case 500: // build failed
+					default:  // any error or unexpected responses
 						if (main == true) {
 							poll.remove(this.pollFn);
 							this.handleError(response, data, firmware);
-							break;
 						} else {
 							poll.remove(this.rebuilder_polls[server]);
 							document.getElementById(server).innerText = '🚫 %s'.format(
 								server
 							);
 						}
+						break;
 				}
 			});
 	},
@@ -632,7 +630,7 @@ return view.extend({
 			uci.load('attendedsysupgrade'),
 		]);
 		const data = {
-			url: uci.get_first('attendedsysupgrade', 'server', 'url'),
+			url: uci.get_first('attendedsysupgrade', 'server', 'url').replace(/\/+$/, ''),
 			branch: get_branch(promises[1].release.version),
 			revision: promises[1].release.revision,
 			efi: promises[2],


### PR DESCRIPTION
When users add an extraneous slash to the server url, then the ASU server redirects GET requests.  But, this causes an error on POST requests as the ASU server does not redirect those, so the LuCI client failed inappropriately with an unhandled error.

Fix both of these by first trimming trailing slashes from the server url as it is loaded to avoid the redirects.  Then, also handle all unexpected responses, instead of just a select few.

Links: efahl/owut@724c990d6cc0