### PR TITLE
[24.10] luci-app-attendedsysupgrade: maintain value of owut.rootfs_size in LuCI app

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -646,7 +646,12 @@ return view.extend({
 			target: promises[1].release.target,
 			version: promises[1].release.version,
 			diff_packages: true,
-			filesystem: promises[1].rootfs_type
+			filesystem: promises[1].rootfs_type,
+
+			// If the user has changed the rootfs partition size via owut,
+			// then make sure to keep new image the same size.  A null value
+			// is interpreted by the ASU server as "default".
+			rootfs_size_mb: uci.get('attendedsysupgrade', 'owut', 'rootfs_size'),
 		};
 		return [data, firmware];
 	},


### PR DESCRIPTION
Backport to 24.10

(cherry picked from commit 42d32dff7f718d27ae7ccc65ebc83d001ebf14e3)