### PR TITLE
luci-app-firewall: replace 'Masquerading' with 'IPv4 Masquerading'

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -164,7 +164,7 @@ return view.extend({
 		p[1].default = fwDefaults.getOutput();
 		p[2].default = fwDefaults.getForward();
 
-		o = s.taboption('general', form.Flag, 'masq', _('Masquerading'),
+		o = s.taboption('general', form.Flag, 'masq', _('IPv4 Masquerading'),
 			_('Enable network address and port translation IPv4 (NAT4 or NAPT4) for outbound traffic on this zone. This is typically enabled on the <em>wan</em> zone.'));
 		o.editable = true;
 		o.tooltip = function(section_id) {

--- a/applications/luci-app-firewall/po/ar/firewall.po
+++ b/applications/luci-app-firewall/po/ar/firewall.po
@@ -704,7 +704,7 @@ msgid "MSS clamping"
 msgstr "لقط MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "تنكر"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/bg/firewall.po
+++ b/applications/luci-app-firewall/po/bg/firewall.po
@@ -653,7 +653,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/bn_BD/firewall.po
+++ b/applications/luci-app-firewall/po/bn_BD/firewall.po
@@ -638,7 +638,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ca/firewall.po
+++ b/applications/luci-app-firewall/po/ca/firewall.po
@@ -644,7 +644,7 @@ msgid "MSS clamping"
 msgstr "Fixació MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Mascarada"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/cs/firewall.po
+++ b/applications/luci-app-firewall/po/cs/firewall.po
@@ -728,7 +728,7 @@ msgid "MSS clamping"
 msgstr "MSS clamping"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Maškárádování"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/da/firewall.po
+++ b/applications/luci-app-firewall/po/da/firewall.po
@@ -729,7 +729,7 @@ msgid "MSS clamping"
 msgstr "MSS fastspænding"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Maskering"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/de/firewall.po
+++ b/applications/luci-app-firewall/po/de/firewall.po
@@ -742,7 +742,7 @@ msgid "MSS clamping"
 msgstr "MSS Korrektur"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "NAT aktivieren"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/el/firewall.po
+++ b/applications/luci-app-firewall/po/el/firewall.po
@@ -643,7 +643,7 @@ msgid "MSS clamping"
 msgstr "Περιορισμός MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/es/firewall.po
+++ b/applications/luci-app-firewall/po/es/firewall.po
@@ -743,7 +743,7 @@ msgid "MSS clamping"
 msgstr "Sujeción MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Enmascaramiento"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/fa/firewall.po
+++ b/applications/luci-app-firewall/po/fa/firewall.po
@@ -726,7 +726,7 @@ msgid "MSS clamping"
 msgstr "بستن MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "ماسکه کردن"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/fi/firewall.po
+++ b/applications/luci-app-firewall/po/fi/firewall.po
@@ -710,7 +710,7 @@ msgid "MSS clamping"
 msgstr "MSS-kiinnitys"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Naamiointi"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/fr/firewall.po
+++ b/applications/luci-app-firewall/po/fr/firewall.po
@@ -738,7 +738,7 @@ msgid "MSS clamping"
 msgstr "Contrainte du MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Masquage"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ga/firewall.po
+++ b/applications/luci-app-firewall/po/ga/firewall.po
@@ -737,7 +737,7 @@ msgid "MSS clamping"
 msgstr "Clampáil MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Masquerating"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/he/firewall.po
+++ b/applications/luci-app-firewall/po/he/firewall.po
@@ -636,7 +636,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/hi/firewall.po
+++ b/applications/luci-app-firewall/po/hi/firewall.po
@@ -638,7 +638,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/hu/firewall.po
+++ b/applications/luci-app-firewall/po/hu/firewall.po
@@ -742,7 +742,7 @@ msgid "MSS clamping"
 msgstr "MSS összefogás"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Álcázás"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/id/firewall.po
+++ b/applications/luci-app-firewall/po/id/firewall.po
@@ -681,7 +681,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/it/firewall.po
+++ b/applications/luci-app-firewall/po/it/firewall.po
@@ -743,7 +743,7 @@ msgid "MSS clamping"
 msgstr "Ancoraggio MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Masquerading"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ja/firewall.po
+++ b/applications/luci-app-firewall/po/ja/firewall.po
@@ -705,7 +705,7 @@ msgid "MSS clamping"
 msgstr "MSSクランプ"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "マスカレード"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ka/firewall.po
+++ b/applications/luci-app-firewall/po/ka/firewall.po
@@ -652,7 +652,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ko/firewall.po
+++ b/applications/luci-app-firewall/po/ko/firewall.po
@@ -641,7 +641,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/lt/firewall.po
+++ b/applications/luci-app-firewall/po/lt/firewall.po
@@ -740,7 +740,7 @@ msgid "MSS clamping"
 msgstr "„MSS“ prispaudimas"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Privataus IP į viešojo IP konvertavimas"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/mr/firewall.po
+++ b/applications/luci-app-firewall/po/mr/firewall.po
@@ -638,7 +638,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ms/firewall.po
+++ b/applications/luci-app-firewall/po/ms/firewall.po
@@ -636,7 +636,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/nb_NO/firewall.po
+++ b/applications/luci-app-firewall/po/nb_NO/firewall.po
@@ -637,7 +637,7 @@ msgid "MSS clamping"
 msgstr "MSS Kontroll (Clamping)"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Masquerading"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/nl/firewall.po
+++ b/applications/luci-app-firewall/po/nl/firewall.po
@@ -738,7 +738,7 @@ msgid "MSS clamping"
 msgstr "MSS klemmen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Gemaskerd"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/pl/firewall.po
+++ b/applications/luci-app-firewall/po/pl/firewall.po
@@ -738,7 +738,7 @@ msgid "MSS clamping"
 msgstr "Dostosuj MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Maskarada"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/pt/firewall.po
+++ b/applications/luci-app-firewall/po/pt/firewall.po
@@ -739,7 +739,7 @@ msgid "MSS clamping"
 msgstr "Fixação de MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Mascaramento"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/pt_BR/firewall.po
+++ b/applications/luci-app-firewall/po/pt_BR/firewall.po
@@ -736,7 +736,7 @@ msgid "MSS clamping"
 msgstr "Ajuste do MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Mascaramento"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ro/firewall.po
+++ b/applications/luci-app-firewall/po/ro/firewall.po
@@ -734,7 +734,7 @@ msgid "MSS clamping"
 msgstr "Ajustare MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Translatare"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ru/firewall.po
+++ b/applications/luci-app-firewall/po/ru/firewall.po
@@ -748,7 +748,7 @@ msgid "MSS clamping"
 msgstr "Ограничение MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Маскарадинг"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/si/firewall.po
+++ b/applications/luci-app-firewall/po/si/firewall.po
@@ -638,7 +638,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/sk/firewall.po
+++ b/applications/luci-app-firewall/po/sk/firewall.po
@@ -667,7 +667,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Maškaráda"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/sr/firewall.po
+++ b/applications/luci-app-firewall/po/sr/firewall.po
@@ -638,7 +638,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/sv/firewall.po
+++ b/applications/luci-app-firewall/po/sv/firewall.po
@@ -676,7 +676,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Maskering"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ta/firewall.po
+++ b/applications/luci-app-firewall/po/ta/firewall.po
@@ -704,7 +704,7 @@ msgid "MSS clamping"
 msgstr "எம்.எச்.எச் கிளம்பிங்"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "முகமூடி"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/tr/firewall.po
+++ b/applications/luci-app-firewall/po/tr/firewall.po
@@ -735,7 +735,7 @@ msgid "MSS clamping"
 msgstr "MSS bağlama"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Maskeleme"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -746,7 +746,7 @@ msgid "MSS clamping"
 msgstr "Обмежування MSS"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Підміна"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/ur/firewall.po
+++ b/applications/luci-app-firewall/po/ur/firewall.po
@@ -637,7 +637,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/vi/firewall.po
+++ b/applications/luci-app-firewall/po/vi/firewall.po
@@ -727,7 +727,7 @@ msgid "MSS clamping"
 msgstr "MSS Clamping"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "Masquerading"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/yua/firewall.po
+++ b/applications/luci-app-firewall/po/yua/firewall.po
@@ -637,7 +637,7 @@ msgid "MSS clamping"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/zh_Hans/firewall.po
+++ b/applications/luci-app-firewall/po/zh_Hans/firewall.po
@@ -707,7 +707,7 @@ msgid "MSS clamping"
 msgstr "MSS 钳制"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "IP 动态伪装"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213

--- a/applications/luci-app-firewall/po/zh_Hant/firewall.po
+++ b/applications/luci-app-firewall/po/zh_Hant/firewall.po
@@ -705,7 +705,7 @@ msgid "MSS clamping"
 msgstr "MSS限制"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:167
-msgid "Masquerading"
+msgid "IPv4 Masquerading"
 msgstr "NAT"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js:213


### PR DESCRIPTION
Although the description in the UI explains that this setting affects IPv4 only, a more clear label can help some users (hint: me) know that there the existence of this option does not exclude the existence of the separate 'IPv6 Masquerading' option.

---

CC: @mastaal
First time contributor here - couldn't find a `PKG_VERSION` in the corresponding Makefile.


<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
