### PR TITLE
luci-app-uhttpd: bugfix

### DIFF
--- a/applications/luci-app-uhttpd/htdocs/luci-static/resources/view/uhttpd/uhttpd.js
+++ b/applications/luci-app-uhttpd/htdocs/luci-static/resources/view/uhttpd/uhttpd.js
@@ -57,9 +57,6 @@ return view.extend({
 		lhttps = s.taboption('general', form.DynamicList, 'listen_https', _('HTTPS listener (address:port)'), _('Bind to specific interface:port (by specifying interface address)'));
 		lhttps.datatype = 'list(ipaddrport(1))';
 
-		var cert = uci.get('uhttpd', 'main', 'cert');
-		var key = uci.get('uhttpd', 'main', 'key');
-
 		lhttps.validate = function (section_id, value) {
 			let have_https_listener = false;
 			let have_http_listener = false;
@@ -94,8 +91,6 @@ return view.extend({
 
 			return true;
 		};
-
-		lhttps.depends({ cert, key });
 
 		o = s.taboption('general', form.Flag, 'redirect_https', _('Redirect all HTTP to HTTPS'));
 		o.default = o.enabled;


### PR DESCRIPTION
Fix a bug in luci-app-uhttpd: Updating the crt and/or key from the default config causes the https listener section to be deleted: 
<img width="841" alt="image" src="https://github.com/user-attachments/assets/c5bc6932-ed11-4668-8545-37ae2ecd5652" />

