### PR TITLE
luci-app-usteer: Extra error checking

### DIFF
--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -192,13 +192,14 @@ function collectRemoteHosts (remotehosttableentries,Remotehosts) {
 						dns_cache[address] = replies[address];
 						continue;
 					} else {
-						dns_cache[address]=Hosts[
-							Object.keys(Hosts).find(mac =>   
-								((typeof Hosts[mac]['name'] !== 'undefined') && 
-									((Object.keys(Hosts[mac]['ip6addrs']).find(IPaddr2 => (address === Hosts[mac]['ip6addrs'][IPaddr2]))) ||
-									(Object.keys(Hosts[mac]['ipaddrs']).find(IPaddr2 => (address === Hosts[mac]['ipaddrs'][IPaddr2])))))
-									)
-							]['name'];
+						if (Hosts.length >0)
+							dns_cache[address]=Hosts[
+								Object.keys(Hosts).find(mac =>   
+									((typeof Hosts[mac]['name'] !== 'undefined') && 
+										((Object.keys(Hosts[mac]['ip6addrs']).find(IPaddr2 => (address === Hosts[mac]['ip6addrs'][IPaddr2]))) ||
+										(Object.keys(Hosts[mac]['ipaddrs']).find(IPaddr2 => (address === Hosts[mac]['ipaddrs'][IPaddr2])))))
+										)
+								]['name'];
 					}
 				}
 	});
@@ -328,7 +329,7 @@ return view.extend({
 			this.callGetRemoteinfo().catch (function (){return null;}),
 			this.callGetLocalinfo().catch (function (){return null;}),
 			this.callGetClients().catch (function (){return null;}),
-			network.getWifiNetworks()
+			network.getWifiNetworks().catch (function (){return null;})
 		]);
 	},
 
@@ -624,10 +625,11 @@ return view.extend({
 
 		o = s.taboption('settings', form.DynamicList, 'ssid_list', _('SSID list'), _('List of SSIDs to enable steering on')+' ('+_('empty means all')+')');
 		WifiNetworks.forEach(function (wifiNetwork) {
-			if (wifiNetwork.getSSID() && (!o.keylist || o.keylist.indexOf(wifiNetwork.getSSID()) === -1)) {
-				o.value(wifiNetwork.getSSID())
-			}
-		});
+			if (wifiNetwork && typeof wifiNetwork === 'object') 
+				if (wifiNetwork.getSSID() && (!o.keylist || o.keylist.indexOf(wifiNetwork.getSSID()) === -1)) {
+					o.value(wifiNetwork.getSSID())
+				}
+		});	
 		o.optional = true;
 		o.datatype = 'list(string)';
 


### PR DESCRIPTION
When you directly load the usteer page "/cgi-bin/luci/admin/network/usteer"  then somehow the wifi networks do not get populated, this throws an error. 
<img width="902" alt="image" src="https://github.com/user-attachments/assets/02fc1bf7-afeb-4c07-b6e1-2b6935cbe59e" />
I added extra checking to prevent this. The result is that the  SSID list is empty: 
<img width="335" alt="image" src="https://github.com/user-attachments/assets/3dbd5139-1764-4369-a14f-e6a8d058a9a8" />
while normally you get the list of all wifi networks. 

It would be better to additionally fix `network.js`, but to be honest I am not sure why it will not  show, maybe its a timing issue?

Also fixed a console error related to the hostnames by additional error checking.
