### PR TITLE
luci-mod-status: Cleanup and fix syslog.js bug

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -9,12 +9,12 @@ return view.extend({
 	logFacilityFilter: 'any',
 	invertLogFacilitySearch: false,
 	logSeverityFilter: 'any',
-	invertLogseveritySearch: false,
+	invertLogSeveritySearch: false,
 	logTextFilter: '',
 	invertLogTextSearch: false,
 
 	facilities: [
-		['any', '', _('Any')],
+		['any', 'any', _('Any')],
 		['0',  'kern',   _('Kernel')],
 		['1',  'user',   _('User')],
 		['2',  'mail',   _('Mail')],
@@ -42,7 +42,7 @@ return view.extend({
 	],
 
 	severity: [
-		['any', '', _('Any')],
+		['any','any', _('Any')],
 		['0',  'emerg',   _('Emergency')],
 		['1',  'alert',   _('Alert')],
 		['2',  'crit',   _('Critical')],
@@ -55,7 +55,6 @@ return view.extend({
 
 
 	retrieveLog: async function() {
-		const facility = this.logFacilityFilter;
 
 		return Promise.all([
 			L.resolveDefault(fs.stat('/usr/libexec/syslog-wrapper'), null),
@@ -65,24 +64,13 @@ return view.extend({
 			return fs.exec_direct(logger).then(logdata => {
 				let loglines = logdata.trim().split(/\n/);
 
-				// Filter by facility, and additionally severity string if selected
-				if (this.logSeverityFilter !== 'any') {
-					const sev = this.logSeverityFilter?.toLowerCase?.();
-					const fac = this.logFacilityFilter === 'any'
-						? this.facilities.map(f => f[1]) // all facility short names
-						: [ this.facilities.find(f => f[0] === this.logFacilityFilter)?.[1] ];
+				loglines = loglines.filter(line => {
+					const sevMatch = this.logSeverityFilter === 'any' || line.includes(`.${this.logSeverityFilter}`);
+					const facMatch = this.logFacilityFilter === 'any' || line.includes(`${this.logFacilityFilter}.`);
 
-					loglines = loglines.filter(line => {
-						const sevMatch = this.logSeverityFilter === 'any' || fac.some(facility => line.includes(`.${sev}`));
-						const facMatch = this.logFacilityFilter === 'any' || fac.some(facility => line.includes(`${facility}.`));
-
-						const finalMatch = (this.invertLogseveritySearch ? !sevMatch : sevMatch)
-						               && (this.invertLogFacilitySearch ? !facMatch : facMatch);
-
-						return finalMatch;
-					});
-
-				}
+					return (this.invertLogSeveritySearch != sevMatch)
+								   && (this.invertLogFacilitySearch != facMatch);
+				});
 
 				loglines = loglines.filter(line => {
 					const match = line.includes(this.logTextFilter);
@@ -123,14 +111,20 @@ return view.extend({
 				'class': 'cbi-button cbi-button-neutral'
 			}, _('Scroll to tail', 'scroll to bottom (the tail) of the log file')
 		);
-		scrollDownButton.addEventListener('click', () => scrollUpButton.scrollIntoView());
+		scrollDownButton.addEventListener('click', () => {
+			scrollUpButton.scrollIntoView();
+			scrollDownButton.blur();
+		});
 
 		const scrollUpButton = E('button', {
 				'id' : 'scrollUpButton',
 				'class': 'cbi-button cbi-button-neutral'
 			}, _('Scroll to head', 'scroll to top (the head) of the log file')
 		);
-		scrollUpButton.addEventListener('click', () => scrollDownButton.scrollIntoView());
+		scrollUpButton.addEventListener('click', () => {
+			scrollDownButton.scrollIntoView();
+			scrollUpButton.blur();		
+		});
 
 		const self = this;
 		const log_file = uci.get_first('system', 'system', 'log_file');
@@ -148,13 +142,13 @@ return view.extend({
 			'class': 'cbi-input-select',
 			'style': 'margin-bottom:10px',
 		},
-		this.facilities.map(([val, _, label]) =>
+		this.facilities.map(([_, val, label]) =>
 			E('option', { value: val }, label)
 		));
 
 		// Create severity invert checkbox
 		const severityInvert = E('input', {
-			'id': 'invertLogseveritySearch',
+			'id': 'invertLogSeveritySearch',
 			'type': 'checkbox',
 			'class': 'cbi-input-checkbox',
 		});
@@ -185,16 +179,10 @@ return view.extend({
 			self.logFacilityFilter = facilitySelect.value;
 			self.invertLogFacilitySearch = facilityInvert.checked;
 			self.logSeverityFilter = severitySelect.value;
-			self.invertLogseveritySearch = severityInvert.checked;
+			self.invertLogSeveritySearch = severityInvert.checked;
 			self.logTextFilter = filterTextInput.value;
 			self.invertLogTextSearch = filterTextInvert.checked;
-			self.retrieveLog().then(log => {
-				const element = document.getElementById('syslog');
-				if (element) {
-					element.value = log.value;
-					element.rows = log.rows;
-				}
-			});
+			self.pollLog();
 		}
 
 		facilitySelect.addEventListener('change', handleLogFilterChange);
@@ -212,7 +200,7 @@ return view.extend({
 					facilityInvert,
 					E('label', { 'for': 'logFacilitySelect', 'style': 'margin: 0 5px' }, _('facility:')),
 					facilitySelect,
-					E('label', { 'for': 'invertLogseveritySearch', 'style': 'margin: 0 5px' }, _('Not')),
+					E('label', { 'for': 'invertLogSeveritySearch', 'style': 'margin: 0 5px' }, _('Not')),
 					severityInvert,
 					E('label', { 'for': 'logSeveritySelect', 'style': 'margin: 0 5px' }, _('severity:')),
 					severitySelect,


### PR DESCRIPTION
Fixed bug in syslog.js where lines could be hidden even when "any" was selected, and simplified code a bit.
When clicking on "Not" they appear:
<img width="937" alt="image" src="https://github.com/user-attachments/assets/dc667112-3ede-47e9-be11-7f37de56611a" />


@systemcrash: Can you have a look? 

Also is there a way to check which logger is used (im using syslog-ng). That does not use a "." between, so the functionallity actually does not fully work? If so I can easily add this to the code. Alternative would be to remove the "."
