### PR TITLE
luci-app-https-dns-proxy: DNS4EU support

### DIFF
--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json
@@ -1,0 +1,36 @@
+{
+	"title": "DNS4EU",
+	"template": "https://{option}.joindns4.eu/dns-query",
+	"bootstrap_dns": "86.54.11.1,86.54.11.201,2a13:1001::86:54:11:1,2a13:1001::86:54:11:201",
+	"help_link": "https://www.joindns4.eu/for-public",
+	"params": {
+		"option": {
+			"description": "Variant",
+			"type": "select",
+			"regex": "(protective|child|noads|child-noads|unfiltered)",
+			"options": [
+				{
+					"value": "protective",
+					"description": "Protective"
+				},
+				{
+					"value": "child",
+					"description": "Child Protection"
+				},
+				{
+					"value": "noads",
+					"description": "Ad blocking"
+				},
+				{
+					"value": "child-noads",
+					"description": "Child & Ad blocking"
+				},
+				{
+					"value": "unfiltered",
+					"description": "Unfiltered"
+				}
+			],
+			"default": "protective"
+		}
+	}
+}


### PR DESCRIPTION
Support DNS4EU DNS resolvers: https://www.joindns4.eu/for-public#resolver-options