### PR TITLE
modules: dhcp: improve wording for DHCP reservations

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -122,8 +122,9 @@ return baseclass.extend({
 				rows.push(E('button', {
 					'class': 'cbi-button cbi-button-apply',
 					'click': L.bind(this.handleCreateStaticLease, this, lease),
+					'data-tooltip': _('Reserve a specific IP address for this device'),
 					'disabled': this.isMACStatic[mac]
-				}, [ _('Set Static') ]));
+				}, [ _('Reserve IP') ]));
 			}
 
 			return rows;
@@ -171,8 +172,9 @@ return baseclass.extend({
 				rows.push(E('button', {
 					'class': 'cbi-button cbi-button-apply',
 					'click': L.bind(this.handleCreateStaticLease6, this, lease),
+					'data-tooltip': _('Reserve a specific IP address for this device'),
 					'disabled': this.isDUIDStatic[duid]
-				}, [ _('Set Static') ]));
+				}, [ _('Reserve IP') ]));
 			}
 
 			return rows;


### PR DESCRIPTION
The use of "static" regarding DHCP reservations can be misleading, as static usually implies a setting on the host device, where what we're actually doing is reserving the address on the server.

Change the button label from "Set Static" to "Reserve IP" to more clearly indicate the action to be taken.  Add some tip text to make it even more clear.

Fixes: https://github.com/openwrt/luci/issues/7801