### PR TITLE
treewide: adjust packages against glibc 2.41

### DIFF
--- a/libs/luci-lib-nixio/Makefile
+++ b/libs/luci-lib-nixio/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=NIXIO POSIX library
-LUCI_DEPENDS:=+liblua
+LUCI_DEPENDS:= +USE_GLIBC:libcrypt-compat +liblua
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Depends on: https://github.com/openwrt/openwrt/pull/19293