### PR TITLE
luci-mod-network: validate DHCP lease time format

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -10348,6 +10348,10 @@ msgstr "عنوان IP %h مستخدم بالفعل من قبل عقد إيجار
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "عنوان IP خارج نطاق أي عنوان تجمع DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "عنوان IP لخادم التمهيد"

--- a/modules/luci-base/po/ast/base.po
+++ b/modules/luci-base/po/ast/base.po
@@ -9960,6 +9960,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -10021,6 +10021,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/bn/base.po
+++ b/modules/luci-base/po/bn/base.po
@@ -9947,6 +9947,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -9957,6 +9957,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -10087,6 +10087,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -10545,6 +10545,10 @@ msgstr "IP adresa %h už je používána jinou statickou zápůjčkou"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP adresa se nachází mimo jakýkoli z rozsahů DHCP fondů"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "IP adresa serveru, ze kterého zavádět"

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -10390,6 +10390,10 @@ msgstr "IP-adressen %h er allerede brugt af en anden statisk lease"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP-adressen er uden for et DHCP-adresseområde i en DHCP-pool"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "IP-adressen på opstartsserveren"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -10605,6 +10605,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Die IP-Adresse liegt außerhalb jedes DHCP-Adressbereiches"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Die IP-Adresse des Boot-Servers"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -10062,6 +10062,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -10636,6 +10636,10 @@ msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 "La dirección IP está fuera de cualquier rango de direcciones del grupo DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "La dirección IP del servidor de arranque"

--- a/modules/luci-base/po/fa/base.po
+++ b/modules/luci-base/po/fa/base.po
@@ -9957,6 +9957,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -10162,6 +10162,10 @@ msgstr "IP-osoite %h on jo toisen pysyvän lainan käytössä"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP-osoite ei ole minkään DHCP-varannon osoitealueen sisällä"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/fil/base.po
+++ b/modules/luci-base/po/fil/base.po
@@ -10021,6 +10021,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -10448,6 +10448,10 @@ msgstr "L'adresse IP %h est déjà utilisée par un autre bail statique"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "L’adresse IP est en dehors de toute plage d’adresses du pool DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Adresse IP du serveur de démarrage"

--- a/modules/luci-base/po/ga/base.po
+++ b/modules/luci-base/po/ga/base.po
@@ -10576,6 +10576,10 @@ msgstr "Úsáidtear an seoladh IP %h cheana féin ag léas statach eile"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Tá an seoladh IP lasmuigh d'aon raon seoltaí linn snámha DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Seoladh IP an fhreastalaí tosaithe"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -9983,6 +9983,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -9955,6 +9955,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -10719,6 +10719,10 @@ msgstr "%h IP-címet egy másik statikus bérlet már használja"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Az IP-cím kívül esik a DHCP-készletek címtartományain"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "A rendszerindító-kiszolgáló IP-címe."

--- a/modules/luci-base/po/id/base.po
+++ b/modules/luci-base/po/id/base.po
@@ -9953,6 +9953,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -10535,6 +10535,10 @@ msgstr ""
 "L'indirizzo IP è al di fuori di qualsiasi intervallo di indirizzi del pool "
 "DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "L'indirizzo IP del server di avvio"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -10220,6 +10220,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/ka/base.po
+++ b/modules/luci-base/po/ka/base.po
@@ -9953,6 +9953,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -10084,6 +10084,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/lt/base.po
+++ b/modules/luci-base/po/lt/base.po
@@ -10727,6 +10727,10 @@ msgstr "IP adresas – %h jau yra naudojamas kitai nekintamajai nuomai"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP adresas yra už bet kurio „DHCP“ telkinio adresų diapazono ribų"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Pajungimo serverio IP adresas"

--- a/modules/luci-base/po/lv/base.po
+++ b/modules/luci-base/po/lv/base.po
@@ -9957,6 +9957,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/ml/base.po
+++ b/modules/luci-base/po/ml/base.po
@@ -9947,6 +9947,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -9954,6 +9954,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -9978,6 +9978,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -10051,6 +10051,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -10423,6 +10423,10 @@ msgstr "Het IP-adres %h wordt al gebruikt door een andere statische lease"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Het IP-adres valt buiten het adresbereik van een DHCP-pool"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Het IP-adres van de opstartserver"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -10584,6 +10584,10 @@ msgstr "Adres IP %h jest już używany przez inną dzierżawę stałą"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Adres IP jest poza zakresem adresów puli DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Adres IP serwera startowego"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -10555,6 +10555,10 @@ msgstr "O endereço IP %h já é utilizado por outra concessão estática"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "O endereço IP está fora de qualquer faixa de endereços do DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "O endereço IP do servidor de inicialização"

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -10568,6 +10568,10 @@ msgstr "O endereço IP %h já é utilizado por outra concessão estática"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "O endereço IP está fora de qualquer faixa de endereços do DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "O endereço IP do servidor de inicialização"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -10431,6 +10431,10 @@ msgstr "Adresa IP %h este deja folosită de o altă închiriere statică"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Adresa IP se află în afara oricărui interval de adrese de grup DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Adresa IP a serverului de pornire"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -10620,6 +10620,10 @@ msgstr "IP-адрес %h уже используется в другой пос�
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP-адрес находится вне диапазона пула адресов DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "IP-адрес загрузочного сервера"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -10171,6 +10171,10 @@ msgstr "IP adresu %h už používa iný statický prenájom"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -9989,6 +9989,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/ta/base.po
+++ b/modules/luci-base/po/ta/base.po
@@ -10507,6 +10507,10 @@ msgstr "ஐபி முகவரி %எச் ஏற்கனவே மற்�
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "ஐபி முகவரி எந்த டி.எச்.சி.பி பூல் முகவரி வரம்பிற்கும் வெளியே உள்ளது"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "துவக்க சேவையகத்தின் ஐபி முகவரி"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -9944,6 +9944,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -10487,6 +10487,10 @@ msgstr "%h IP adresi zaten başka bir statik kiralama tarafından kullanılıyor
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP adresi, herhangi bir DHCP havuzu adres aralığının dışında"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Önyükleme sunucusunun IP adresi"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -10627,6 +10627,10 @@ msgstr "IP-адреса %h уже використовується іншою с
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP-адреса знаходиться поза межами пулу адрес DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "IP-адреса сервера завантаження"

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -9953,6 +9953,10 @@ msgstr ""
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr ""

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -10449,6 +10449,10 @@ msgstr "Địa chỉ IP %h đã được sử dụng bởi một giao kết tĩn
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "Địa chỉ IP nằm ngoài phạm vi địa chỉ trong bể DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "Địa chỉ IP của máy chủ khởi động"

--- a/modules/luci-base/po/yua/base.po
+++ b/modules/luci-base/po/yua/base.po
@@ -10561,6 +10561,10 @@ msgid "The IP address is outside of any DHCP pool address range"
 msgstr ""
 "La dirección IP está fuera de cualquier rango de direcciones del grupo DHCP"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "La dirección IP del servidor de arranque"

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -10228,6 +10228,10 @@ msgstr "IP 地址 %h 已被另一个静态租约使用"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP 地址不在任何 DHCP 池地址范围之内"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr "无效的格式,请留空或者输入类似 “5m”, “3h”, “7d”, “infinite”格式的值"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "引导服务器的 IP 地址"

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -10128,6 +10128,10 @@ msgstr "IP位址%h已被另一個靜態租約使用"
 msgid "The IP address is outside of any DHCP pool address range"
 msgstr "IP位址不在任何DHCP位址池範圍之內"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:1310
+msgid "Expecting format like \"5m\", \"3h\", \"7d\", \"infinite\" or blank"
+msgstr "無效的格式，請留空或者輸入類似「5m」，「3h」，「7d」，「infinite」這種格式的值。"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:895
 msgid "The IP address of the boot server"
 msgstr "引導伺服器IP位址"

--- a/modules/luci-mod-network/Makefile
+++ b/modules/luci-mod-network/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Network Administration
 LUCI_DEPENDS:=+luci-base +rpcd-mod-iwinfo
 
-PKG_LICENSE:=Apache-2.0
+PKG_LICENSE:=Apache-2.0-2025.07.07
 
 include ../../luci.mk
 

--- a/modules/luci-mod-network/Makefile
+++ b/modules/luci-mod-network/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Network Administration
 LUCI_DEPENDS:=+luci-base +rpcd-mod-iwinfo
 
-PKG_LICENSE:=Apache-2.0-2025.07.07
+PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1306,7 +1306,7 @@ return view.extend({
 		so.validate = function(section, value) {
 			if (!value || value === '') return true;
 			if (value === 'infinite') return true;
-			if (/^\d+[mhds]$/.test(value)) return true;
+			if (/^\d+[mhdsw]$/i.test(value)) return true;
 			return _('Expecting format like "5m", "3h", "7d", "infinite" or blank');
 		};
 		so = ss.option(form.Value, 'duid',

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1303,7 +1303,12 @@ return view.extend({
 		so.value('12h', _('12h (12 hours - default)'));
 		so.value('7d', _('7d (7 days)'));
 		so.value('infinite', _('infinite (lease does not expire)'));
-
+		so.validate = function(section, value) {
+			if (!value || value === '') return true;
+			if (value === 'infinite') return true;
+			if (/^\d+[mhds]$/.test(value)) return true;
+			return _('Expecting format like "5m", "3h", "7d", "infinite" or blank');
+		};
 		so = ss.option(form.Value, 'duid',
 			_('DUID'),
 			_('The DHCPv6-DUID (DHCP unique identifier) of this host.'));


### PR DESCRIPTION
Add custom validation for the "Lease time" field in DHCP static leases. Accepted formats include '5m', '3h', '7d', 'infinite', or blank. Invalid formats will now trigger a user-visible error message.

Also added translations for zh_Hans and zh_Hant locales.

![04cd27c9-913e-40f8-ae88-e19b47c95c43](https://github.com/user-attachments/assets/98fd32a1-3cb0-4288-b5cf-2286deb2fb0f)


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86/64, 24.10.1, chrome 138.0.7204.97) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
