### PR TITLE
luci-proto-yggdrasil: fix interface selection

### DIFF
--- a/protocols/luci-proto-yggdrasil/htdocs/luci-static/resources/protocol/yggdrasil.js
+++ b/protocols/luci-proto-yggdrasil/htdocs/luci-static/resources/protocol/yggdrasil.js
@@ -276,7 +276,9 @@ return network.registerProtocol('yggdrasil',
 			o=ss.option(form.Value,"address",_("Peer URI"));
 			o.placeholder="tls://0.0.0.0:0"
 			o.validate=validateYggdrasilPeerUri;
-			ss.option(widgets.NetworkSelect,"interface",_("Peer interface"));
+
+			o=ss.option(widgets.DeviceSelect,"interface",_("Peer interface"));
+			o.noaliases=true;
 
 			o=s.taboption('peers', form.SectionValue, '_interfaces', form.TableSection, 'yggdrasil_%s_interface'.format(this.sid), _("Multicast rules"))
 			ss=o.subsection;
@@ -286,6 +288,7 @@ return network.registerProtocol('yggdrasil',
 
 			o=ss.option(widgets.DeviceSelect,"interface",_("Devices"));
 			o.multiple=true;
+			o.noaliases=true;
 
 			ss.option(form.Flag,"beacon",_("Send multicast beacon"));
 


### PR DESCRIPTION
Package `yggdrasil` doesn't support network names and aliases.

To avoid back-porting and upgrading main package across releases, it's simpler to reflect this behavior in interface instead.

I'm leaving out incrementing package version for @wfleurant as there may be other issues to fix (see #7526).

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (OpenWrt 24.10.2, ramips/mt7621, Firefox 140) :white_check_mark:
- [X] ( Preferred ) Mention: @ the original code author for feedback
- [X] Description: (describe the changes proposed in this PR)
