### PR TITLE
[24.10] luci-app-mwan3: only request interfaces status

### DIFF
--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/status/overview.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/status/overview.js
@@ -6,6 +6,7 @@
 const callMwan3Status = rpc.declare({
 	object: 'mwan3',
 	method: 'status',
+	params: ['section'],
 	expect: {  },
 });
 
@@ -76,13 +77,13 @@ function renderMwan3Status(status) {
 return view.extend({
 	load: function() {
 		return Promise.all([
-			callMwan3Status(),
+			callMwan3Status("interfaces"),
 		]);
 	},
 
 	render: function (data) {
 		poll.add(function() {
-			return callMwan3Status().then(function(result) {
+			return callMwan3Status("interfaces").then(function(result) {
 				var view = document.getElementById('mwan3-service-status');
 				view.innerHTML = renderMwan3Status(result);
 			});

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/status/include/90_mwan3.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/status/include/90_mwan3.js
@@ -5,6 +5,7 @@
 const callMwan3Status = rpc.declare({
 	object: 'mwan3',
 	method: 'status',
+	params: ['section'],
 	expect: {  },
 });
 
@@ -19,7 +20,7 @@ return baseclass.extend({
 
 	load: function() {
 		return Promise.all([
-			callMwan3Status(),
+			callMwan3Status("interfaces"),
 		]);
 	},
 


### PR DESCRIPTION
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: openwrt-24.10 :white_check_mark:
- [X] \( Preferred ) Mention: @feckert
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: Before mwan3 rpcd plugin optimisations, same change in prometheus-node-exporter-lua changed request time from 1.9s to 1.3s.

(cherry picked from commit c358b34a53b53fa4d6310452848643daf4a192fb)
Backport #7844 to 24.10