### PR TITLE
luci-base: implement support for reversing buttons order on login

### DIFF
--- a/modules/luci-base/ucode/template/sysauth.ut
+++ b/modules/luci-base/ucode/template/sysauth.ut
@@ -35,8 +35,14 @@
 	</div>
 
 	<div class="cbi-page-actions">
-		<input type="submit" value="{{ _('Log in') }}" class="btn cbi-button cbi-button-apply" />
-		<input type="reset" value="{{ _('Reset') }}" class="btn cbi-button cbi-button-reset" />
+		{% let login_button_order = uci.get('luci', 'main', 'login_button_order') ?? "";
+		if (login_button_order == 'reverse'): %}
+			<input type="reset" value="{{ _('Reset') }}" class="btn cbi-button cbi-button-reset" />
+			<input type="submit" value="{{ _('Log in') }}" class="btn cbi-button cbi-button-apply" />
+		{% else %}
+			<input type="submit" value="{{ _('Log in') }}" class="btn cbi-button cbi-button-apply" />
+			<input type="reset" value="{{ _('Reset') }}" class="btn cbi-button cbi-button-reset" />
+		{% endif %}
 	</div>
 </form>
 


### PR DESCRIPTION
This adds support for swapping Login/Reset button order by setting luci.main.login_button_order=reverse.

Default order is [Login] [Reset], this has been bothering me as I perfer the order of [Reset] [Login]. The default action of Enter still causes the from to be submitted, even with the order of buttons reversed.

If this is actively unwanted, I can always patch the ut-file in my builds.
