### PR TITLE
luci-compat: remove extra line breaks from description

### DIFF
--- a/modules/luci-compat/luasrc/view/cbi/full_valuefooter.htm
+++ b/modules/luci-compat/luasrc/view/cbi/full_valuefooter.htm
@@ -1,7 +1,4 @@
 		<% if self.description and #self.description > 0 then -%>
-			<% if not luci.util.instanceof(self, luci.cbi.DynamicList) and (not luci.util.instanceof(self, luci.cbi.Flag) or self.orientation == "horizontal") then -%>
-				<br />
-			<%- end %>
 			<div class="cbi-value-description">
 				<%=self.description%>
 			</div>


### PR DESCRIPTION
There’s no need to add extra line breaks here, as it will make the page look unbalanced and affect the overall aesthetics.
