### PR TITLE
luci-base: allow submitting new value in dropdown lists in android chromium

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -1090,7 +1090,8 @@ const UIDropdown = UIElement.extend(/** @lends LuCI.ui.Dropdown.prototype */ {
 				'class': 'create-item-input',
 				'readonly': this.options.readonly ? '' : null,
 				'maxlength': this.options.maxlength,
-				'placeholder': this.options.custom_placeholder ?? this.options.placeholder
+				'placeholder': this.options.custom_placeholder ?? this.options.placeholder,
+				'inputmode': 'text',
 			});
 
 			if (this.options.datatype || this.options.validate)


### PR DESCRIPTION
Update ui.js to allow submitting from dropdown on android chromium.

Fixes: [https://github.com/openwrt/luci/issues/7819](https://github.com/openwrt/luci/issues/7819)

P.S. maybe we should also fix the `ev.keyCode` as this may also be unreliable (and using e.g. ev.key is more readable)