### PR TITLE
luci-mod-battstatus: preparing for other devices

### DIFF
--- a/modules/luci-mod-battstatus/Makefile
+++ b/modules/luci-mod-battstatus/Makefile
@@ -7,9 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Battery Status
-LUCI_DESCRIPTION:=Provides a battery charge indicator in LuCI. Currently only supports the HooToo HT-TM05 travel router.
+LUCI_DESCRIPTION:=Provides a battery charge indicator in LuCI.
 
-LUCI_DEPENDS:=+luci-base +libiwinfo-lua +rpcd-mod-iwinfo +libi2c +i2c-tools
+LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-battstatus/root/usr/libexec/rpcd/luci.battstatus
+++ b/modules/luci-mod-battstatus/root/usr/libexec/rpcd/luci.battstatus
@@ -2,6 +2,9 @@
 
 . /usr/share/libubox/jshn.sh
 
+board=$(cat /tmp/sysinfo/board_name)
+model=$(cat /tmp/sysinfo/model)
+
 case "$1" in
 	list)
 		printf '{ "getBatteryStatus": {} }'
@@ -10,26 +13,32 @@ case "$1" in
 		case "$2" in
 			getBatteryStatus)
 				json_init
+				json_add_object "$model"
 
-				eval $(/bin/ubus call system board 2>/dev/null | /usr/bin/jsonfilter -e 'MODEL=@.model')
-				json_add_object "$MODEL"
-
-				if [ -f /usr/sbin/i2cset ] && [ -f /usr/sbin/i2cget ]; then
-					json_add_boolean valid 1
-					if [ $(i2cset -y 0 0x0a 0x0a 0x01 && i2cget -y 0 0x0a 0x0a) = 0x40 ]; then
-						json_add_boolean charging 1
-					else
-						json_add_boolean charging 0
-					fi
-					json_add_int percentage $(i2cset -y 0 0x0a 0x0a 0x10 && i2cget -y 0 0x0a 0x0a | xargs printf %d)
-				else
+				case "$board" in
+					hootoo,ht-tm05)
+						if [ -f /usr/sbin/i2cset ] && [ -f /usr/sbin/i2cget ]; then
+							json_add_boolean valid 1
+							if [ $(i2cset -y 0 0x0a 0x0a 0x01 && i2cget -y 0 0x0a 0x0a) = 0x40 ]; then
+								json_add_boolean charging 1
+							else
+								json_add_boolean charging 0
+							fi
+							json_add_int percentage $(i2cset -y 0 0x0a 0x0a 0x10 && i2cget -y 0 0x0a 0x0a | xargs printf %d)
+						else
+							json_add_boolean valid 0
+							if [ ! -f /usr/sbin/i2cset ]; then
+								json_add_string message "Need i2cset"
+							else
+								json_add_string message "Need i2cget"
+							fi
+						fi
+					;;
+				*)
 					json_add_boolean valid 0
-					if [ ! -f /usr/sbin/i2cset ]; then
-						json_add_string message "Need i2cset"
-					else
-						json_add_string message "Need i2cget"
-					fi
-				fi
+					json_add_string message "Unsupported"
+					;;
+				esac
 
 				json_close_object
 				json_dump


### PR DESCRIPTION
For standard devices, we can read from `/sys/class/power_supply`

Add board checks to implement different solutions for different boards

