### PR TITLE
[24.10] luci-app-adblock-fast: update to 1.1.4-6

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.1.4
-PKG_RELEASE:=4
+PKG_RELEASE:=6
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-adblock-fast/

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -25,6 +25,15 @@ var pkg = {
 			(pkg.ReadmeCompat ? pkg.ReadmeCompat + "/" : "")
 		);
 	},
+	get DonateURL() {
+		return (
+			"https://docs.openwrt.melmac.ca/" +
+			pkg.Name +
+			"/" +
+			(pkg.ReadmeCompat ? pkg.ReadmeCompat + "/" : "") +
+			"#Donate"
+		);
+	},
 	isVersionMismatch: function (luci, pkg, rpcd) {
 		return luci !== pkg || pkg !== rpcd || luci !== rpcd;
 	},
@@ -113,9 +122,9 @@ var status = baseclass.extend({
 		return Promise.all([
 			L.resolveDefault(getInitStatus(pkg.Name), {}),
 			L.resolveDefault(getUbusInfo(pkg.Name), {}),
-		]).then(function (data) {
+		]).then(function ([initStatus, ubusInfo]) {
 			var reply = {
-				status: data[0]?.[pkg.Name] || {
+				status: initStatus?.[pkg.Name] || {
 					enabled: false,
 					status: null,
 					packageCompat: 0,
@@ -136,7 +145,7 @@ var status = baseclass.extend({
 					outputGzipExists: null,
 					leds: [],
 				},
-				ubus: data[1]?.[pkg.Name]?.instances?.main?.data || {
+				ubus: ubusInfo?.[pkg.Name]?.instances?.main?.data || {
 					packageCompat: 0,
 					errors: [],
 					warnings: [],
@@ -205,6 +214,15 @@ var status = baseclass.extend({
 							});
 							text += ".";
 						}
+						text +=
+							"<br />" +
+							"<br />" +
+							_(
+								"Please %sdonate%s to support development of this project."
+							).format(
+								"<a href='" + pkg.DonateURL + "' target='_blank'>",
+								"</a>"
+							);
 						break;
 					case "statusStopped":
 						if (reply.status.enabled) {
@@ -232,7 +250,7 @@ var status = baseclass.extend({
 			} else {
 				text = _("Not installed or not found");
 			}
-			var statusText = E("div", {}, text);
+			var statusText = E("div", { class: "cbi-value-description" }, text);
 			var statusField = E("div", { class: "cbi-value-field" }, statusText);
 			var statusDiv = E("div", { class: "cbi-value" }, [
 				statusTitle,

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -1,11 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:300
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:318
 msgid "%s is currently disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:170
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:179
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:39
 msgid "%s is not installed or not found"
 msgstr ""
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:178
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:187
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:49
 msgid "Active"
 msgstr ""
@@ -57,7 +57,7 @@ msgstr ""
 msgid "AdBlock-Fast - Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:181
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:190
 msgid "AdBlock-Fast - Status"
 msgstr ""
 
@@ -105,7 +105,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:194
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:203
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgstr ""
 msgid "Cache file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:217
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:235
 msgid "Cache file found."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:263
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:281
 msgid "Can't detect free RAM"
 msgstr ""
 
@@ -129,15 +129,15 @@ msgstr ""
 msgid "Compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:199
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:208
 msgid "Compressed cache file created."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:219
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:237
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:298
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:316
 msgid "Config (%s) validation failure!"
 msgstr ""
 
@@ -171,7 +171,7 @@ msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:501
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:519
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:347
 msgid "Disable"
 msgstr ""
@@ -180,11 +180,11 @@ msgstr ""
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:214
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:232
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:495
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:513
 msgid "Disabling %s service"
 msgstr ""
 
@@ -208,12 +208,12 @@ msgstr ""
 msgid "Download time-out (in seconds)"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:176
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:185
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:45
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:482
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:500
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:348
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:502
 msgid "Enable"
@@ -228,7 +228,7 @@ msgstr ""
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:476
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:494
 msgid "Enabling %s service"
 msgstr ""
 
@@ -236,7 +236,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:375
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:393
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
@@ -244,95 +244,95 @@ msgstr ""
 msgid "Fail"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:319
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:337
 msgid "Failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:317
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:335
 msgid "Failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:334
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:352
 msgid "Failed to create block-list or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:327
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:345
 msgid "Failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:316
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:334
 msgid "Failed to create directory for %s file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:345
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:363
 msgid "Failed to create output/cache/gzip file directory"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:347
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:365
 msgid "Failed to detect format %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:340
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:358
 msgid "Failed to download %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:338
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:356
 msgid "Failed to download Config Update file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:323
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:341
 msgid "Failed to format data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:330
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:348
 msgid "Failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:325
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:343
 msgid "Failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:321
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:339
 msgid "Failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:342
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:360
 msgid "Failed to parse %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:341
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:359
 msgid "Failed to parse Config Update file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:322
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:340
 msgid "Failed to process allow-list"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:336
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:354
 msgid "Failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:328
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:346
 msgid "Failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:318
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:336
 msgid "Failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:320
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:338
 msgid "Failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:177
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:186
 msgid "Failed to start"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:335
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:353
 msgid "Failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:329
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:347
 msgid "Failed to unpack compressed cache"
 msgstr ""
 
@@ -340,11 +340,11 @@ msgstr ""
 msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:202
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:211
 msgid "Force DNS ports:"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:175
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:184
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:44
 msgid "Force Reloading"
 msgstr ""
@@ -357,7 +357,7 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:423
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:441
 msgid "Force redownloading %s block lists"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:352
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:370
 msgid "Free ram (%s) is not enough to process all enabled block-lists"
 msgstr ""
 
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-adblock-fast"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:359
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:377
 msgid "Heartbeat domain is not accessible after resolver restart"
 msgstr ""
 
@@ -401,14 +401,14 @@ msgstr ""
 msgid "Individual domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:246
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:264
 msgid ""
 "Internal version mismatch (package: %s, luci app: %s, luci rpcd: %s), you "
 "may need to update packages or reboot the device, please check the "
 "%sREADME%s."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:261
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:279
 msgid "Invalid compressed cache directory '%s'"
 msgstr ""
 
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:252
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:270
 msgid "Missing recommended package: '%s'"
 msgstr ""
 
@@ -446,15 +446,15 @@ msgstr ""
 msgid "No Ad-blocking on dnsmasq"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:343
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:361
 msgid "No HTTPS/SSL support on device"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:349
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:367
 msgid "No blocked list URLs nor blocked-domains enabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:233
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:251
 msgid "Not installed or not found"
 msgstr ""
 
@@ -462,11 +462,11 @@ msgstr ""
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:444
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:462
 msgid "Pause"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:439
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:457
 msgid "Pausing %s"
 msgstr ""
 
@@ -486,6 +486,10 @@ msgstr ""
 msgid "Pick the dnsmasq instance(s) for ad-blocking"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:221
+msgid "Please %sdonate%s to support development of this project."
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:61
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:66
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:71
@@ -499,41 +503,41 @@ msgstr ""
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:173
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:182
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:42
 msgid "Processing lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:429
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:447
 msgid "Redownload"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:174
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:183
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:43
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:264
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:282
 msgid "Sanity check discovered TLDs in %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:266
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:284
 msgid "Sanity check discovered leading dots in %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:542
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:560
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:365
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:383
 msgid "Service Errors"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:185
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:194
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:272
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:290
 msgid "Service Warnings"
 msgstr ""
 
@@ -553,16 +557,16 @@ msgstr ""
 msgid "Some output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:410
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:428
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:172
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:181
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:41
 msgid "Starting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:404
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:422
 msgid "Starting %s service"
 msgstr ""
 
@@ -570,7 +574,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:463
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:481
 msgid "Stop"
 msgstr ""
 
@@ -578,12 +582,12 @@ msgstr ""
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:171
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:180
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:40
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:457
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:475
 msgid "Stopping %s service"
 msgstr ""
 
@@ -599,38 +603,38 @@ msgstr ""
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:313
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:331
 msgid "The %s failed to discover WAN gateway"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:255
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:273
 msgid ""
 "The WebUI application (luci-app-adblock-fast) is outdated, please update it"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:302
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:320
 msgid ""
 "The dnsmasq ipset support is enabled, but dnsmasq is either not installed or "
 "installed dnsmasq does not support ipset"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:305
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:323
 msgid ""
 "The dnsmasq ipset support is enabled, but ipset is either not installed or "
 "installed ipset does not support '%s' type"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:308
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:326
 msgid ""
 "The dnsmasq nft set support is enabled, but dnsmasq is either not installed "
 "or installed dnsmasq does not support nft set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:311
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:329
 msgid "The dnsmasq nft sets support is enabled, but nft is not installed"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:258
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:276
 msgid "The principal package (adblock-fast) is outdated, please update it"
 msgstr ""
 
@@ -653,15 +657,15 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:372
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:390
 msgid "Unknown error"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:32
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:41
 msgid "Unknown message"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:279
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:297
 msgid "Unknown warning"
 msgstr ""
 
@@ -673,7 +677,7 @@ msgstr ""
 msgid "Use ad-blocking on the dnsmasq instance(s)"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:249
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:267
 msgid ""
 "Use of external dnsmasq config file detected, please set '%s' option to '%s'"
 msgstr ""
@@ -690,7 +694,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:188
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:197
 msgid "Version %s"
 msgstr ""
 
@@ -730,19 +734,19 @@ msgstr ""
 msgid "dnsmasq servers file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:354
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:372
 msgid "failed to create backup file %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:357
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:375
 msgid "failed to create final block-list %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:355
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:373
 msgid "failed to delete data file %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:356
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:374
 msgid "failed to restore backup file %s"
 msgstr ""
 

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -101,10 +101,7 @@ get_init_status() {
 	local name
 	name="$(basename "$1")"
 	name="${name:-$packageName}"
-	local ports dns outputFile outputCache outputGzip outputConfig
-	local i j k
-# shellcheck disable=SC2034
-	local compressed_cache_dir
+	local ports dns outputFile outputCache outputGzip outputConfig compressed_cache_dir i
 	config_load "$name"
 	config_get compressed_cache_dir 'config' 'compressed_cache_dir' '/etc'
 	compressed_cache_dir="$(sanitize_dir "$compressed_cache_dir")"
@@ -221,7 +218,11 @@ get_platform_support() {
 		json_add_boolean 'unbound_installed' '0'
 	fi
 	json_add_array 'leds'
-		for i in /sys/class/leds/*; do json_add_string '' "$(basename "$i")"; done
+		if ls /sys/class/leds/* >/dev/null 2>&1; then
+			for i in /sys/class/leds/*; do
+				[ -d "$i" ] && json_add_string '' "$(basename "$i")"
+			done
+		fi
 	json_close_array
 	json_close_object
 	json_dump


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 640vn, OpenWrt 24.10.2
Run tested: x86_64, Dell EMC Edge 640vn, OpenWrt 24.10.2

Description:
* add Donate section/URL to status
* improve visibility with the RPCD return variable names (thanks @systemcrash)
* improve LEDs detection in RPCD script

(cherry picked from commit 68a315f5ad0bffce4ba708d942178281e7661441)
