### PR TITLE
[24.10] luci-app-https-dns-proxy: update to 2025.05.11-4

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -1,5 +1,5 @@
-# Copyright 2017-2024 MOSSDeF, Stan Grishin (stangri@melmac.ca).
-# This is free software, licensed under AGPL-3.0-or-later.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright 2017-2025 MOSSDeF, Stan Grishin (stangri@melmac.ca).
 
 include $(TOPDIR)/rules.mk
 
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=2025.05.11
-PKG_RELEASE:=1
+PKG_RELEASE:=4
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-https-dns-proxy/

--- a/applications/luci-app-https-dns-proxy/README.md
+++ b/applications/luci-app-https-dns-proxy/README.md
@@ -1,3 +1,22 @@
-# README
+# luci-app-https-dns-proxy
 
-Documentation for this project is available at [https://docs.openwrt.melmac.net/https-dns-proxy/](https://docs.openwrt.melmac.net/https-dns-proxy/).
+[![OpenWrt](https://img.shields.io/badge/OpenWrt-Compatible-blueviolet)](https://openwrt.org)
+[![Web UI](https://img.shields.io/badge/Web_UI-Available-blue)](https://docs.openwrt.melmac.ca/https-dns-proxy/)
+[![Resolvers](https://img.shields.io/badge/Resolvers-40%2B%20Built--in-brightgreen)](https://docs.openwrt.melmac.ca/https-dns-proxy/)
+[![Minimal Footprint](https://img.shields.io/badge/Size-~40KB-green)](https://github.com/stangri/https-dns-proxy)
+[![License](https://img.shields.io/badge/License-MIT-lightgrey)](https://github.com/stangri/https-dns-proxy/blob/master/LICENSE)
+
+A WebUI for lightweight, RFC8484-compliant DNS-over-HTTPS (DoH) proxy service for OpenWrt.  
+Includes optional integration with `dnsmasq`, automatic fallback, and canary domain support.
+
+## Features
+
+- Small footprint (~40KB installed)
+- Seamless dnsmasq integration and fallback
+- LuCI Web UI with 40+ built-in resolvers
+
+**Full documentation:**
+
+[https://docs.openwrt.melmac.ca/https-dns-proxy/](https://docs.openwrt.melmac.ca/https-dns-proxy/)
+
+Based on [@aarond10](https://github.com/aarond10)'s excellent [https_dns_proxy](https://github.com/aarond10/https_dns_proxy)

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
@@ -18,10 +18,19 @@ var pkg = {
 	},
 	get URL() {
 		return (
-			"https://docs.openwrt.melmac.net/" +
+			"https://docs.openwrt.melmac.ca/" +
 			pkg.Name +
 			"/" +
 			(pkg.ReadmeCompat ? pkg.ReadmeCompat + "/" : "")
+		);
+	},
+	get DonateURL() {
+		return (
+			"https://docs.openwrt.melmac.ca/" +
+			pkg.Name +
+			"/" +
+			(pkg.ReadmeCompat ? pkg.ReadmeCompat + "/" : "") +
+			"#Donate"
 		);
 	},
 	templateToRegexp: function (template) {
@@ -203,7 +212,7 @@ var status = baseclass.extend({
 			} else {
 				text = _("Not installed or not found");
 			}
-			var statusText = E("div", {}, text);
+			var statusText = E("div", { class: "cbi-value-description" }, text);
 			var statusField = E("div", { class: "cbi-value-field" }, statusText);
 			var statusDiv = E("div", { class: "cbi-value" }, [
 				statusTitle,
@@ -281,7 +290,13 @@ var status = baseclass.extend({
 							"<br />"
 						);
 				});
-				var instancesText = E("div", {}, text);
+				text +=
+					"<br />" +
+					_("Please %sdonate%s to support development of this project.").format(
+						"<a href='" + pkg.DonateURL + "' target='_blank'>",
+						"</a>"
+					);
+				var instancesText = E("div", { class: "cbi-value-description" }, text);
 				var instancesField = E("div", { class: "cbi-value-field" }, [
 					instancesText,
 					instancesDescr,

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -329,12 +329,50 @@ return view.extend({
 				};
 				_paramText.remove = _paramText.write;
 			}
+			const _boot_dns = s.option(
+				form.Value,
+				"_bootstrap_dns_" + i,
+				_("Bootstrap DNS")
+			);
+			_boot_dns.template = prov.template;
+			_boot_dns.modalonly = true;
+			_boot_dns.depends("_provider", prov.template);
+			_boot_dns.cfgvalue = function (section_id) {
+				const c_value = this.map.data.get(
+					this.map.config,
+					section_id,
+					"bootstrap_dns"
+				);
+				return c_value || prov.bootstrap_dns || "";
+			};
+			_boot_dns.write = function (section_id, formvalue) {
+				const resolver = this.map.data.get(
+					this.map.config,
+					section_id,
+					"resolver_url"
+				);
+				const regexp = pkg.templateToRegexp(_boot_dns.template);
+				if (regexp.test(resolver)) {
+					console.log(
+						pkg.Name,
+						section_id,
+						"bootstrap_dns",
+						formvalue,
+						this.cfgvalue(section_id)
+					);
+					if (formvalue)
+						L.uci.set(pkg.Name, section_id, "bootstrap_dns", formvalue);
+					else
+						L.uci.set(
+							pkg.Name,
+							section_id,
+							"bootstrap_dns",
+							this.cfgvalue(section_id)
+						);
+				}
+				_boot_dns.remove = _boot_dns.write;
+			};
 		});
-
-		o = s.option(form.Value, "bootstrap_dns", _("Bootstrap DNS"));
-		o.default = "";
-		o.modalonly = true;
-		o.optional = true;
 
 		o = s.option(form.Value, "listen_addr", _("Listen Address"));
 		o.datatype = "ipaddr('nomask')";

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,11 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:275
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:284
 msgid "%s%s%s proxy at %s on port %s.%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:267
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:276
 msgid "%s%s%s proxy on port %s.%s"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgid ""
 "use router for DNS resolution (%smore information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:334
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:335
 msgid "Bootstrap DNS"
 msgstr ""
 
@@ -134,6 +134,10 @@ msgstr ""
 msgid "DNS Forge (DE)"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:2
+msgid "DNS4EU"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/pub.doh.json:2
 msgid "DNSPod Public DNS (CN)"
 msgstr ""
@@ -142,7 +146,7 @@ msgstr ""
 msgid "DNSlify DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:361
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:399
 msgid "DSCP Codepoint"
 msgstr ""
 
@@ -162,11 +166,11 @@ msgstr ""
 msgid "Direct"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:393
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:408
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:387
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:402
 msgid "Disabling %s service"
 msgstr ""
 
@@ -182,11 +186,11 @@ msgstr ""
 msgid "DoH DNS (SB)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:374
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:389
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:368
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:383
 msgid "Enabling %s service"
 msgstr ""
 
@@ -220,7 +224,7 @@ msgstr ""
 msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:188
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:197
 msgid "Force DNS ports:"
 msgstr ""
 
@@ -234,11 +238,11 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:394
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:432
 msgid "Force use of HTTP/1"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:406
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:444
 msgid "Force use of IPv6 DNS resolvers"
 msgstr ""
 
@@ -272,7 +276,7 @@ msgstr ""
 msgid "HTTPS DNS Proxy - Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:178
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:187
 msgid "HTTPS DNS Proxy - Status"
 msgstr ""
 
@@ -331,12 +335,12 @@ msgstr ""
 msgid "LibreDNS (GR)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:339
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:377
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:56
 msgid "Listen Address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:345
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:383
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:57
 msgid "Listen Port"
 msgstr ""
@@ -346,11 +350,11 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:373
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:411
 msgid "Logging File Path"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:367
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:405
 msgid "Logging Verbosity"
 msgstr ""
 
@@ -378,7 +382,7 @@ msgstr ""
 msgid "Norway"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:204
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:213
 msgid "Not installed or not found"
 msgstr ""
 
@@ -399,6 +403,10 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:295
+msgid "Please %sdonate%s to support development of this project."
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:172
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:181
 msgid ""
@@ -409,7 +417,7 @@ msgstr ""
 msgid "Poland"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:378
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:416
 msgid "Polling Interval"
 msgstr ""
 
@@ -421,11 +429,27 @@ msgstr ""
 msgid "Protected Filter"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:18
+msgid "Protective (blocks malicous and fraudulent websites)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:22
+msgid "Protective with ad-blocking"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:26
+msgid "Protective with child protection"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:30
+msgid "Protective with child protection & ad-blocking"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:233
 msgid "Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:384
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:422
 msgid "Proxy Server"
 msgstr ""
 
@@ -437,11 +461,11 @@ msgstr ""
 msgid "Quad 9"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:336
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:351
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:330
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:345
 msgid "Restarting %s service"
 msgstr ""
 
@@ -457,11 +481,11 @@ msgstr ""
 msgid "RubyFish (CN)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:356
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:394
 msgid "Run As Group"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:351
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:389
 msgid "Run As User"
 msgstr ""
 
@@ -482,7 +506,7 @@ msgstr ""
 msgid "Security Filter"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:220
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:229
 msgid "See the %sREADME%s for details."
 msgstr ""
 
@@ -490,15 +514,15 @@ msgstr ""
 msgid "Select the DNSMASQ Configs to update"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:419
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:434
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:218
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:227
 msgid "Service Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:182
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:191
 msgid "Service Status"
 msgstr ""
 
@@ -524,19 +548,19 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:317
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:332
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:311
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:326
 msgid "Starting %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:355
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:370
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:349
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:364
 msgid "Stopping %s service"
 msgstr ""
 
@@ -569,6 +593,7 @@ msgid "US/New York"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:14
 msgid "Unfiltered"
 msgstr ""
 
@@ -592,19 +617,19 @@ msgstr ""
 msgid "Update select configs"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:389
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:427
 msgid "Use HTTP/1"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:400
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:438
 msgid "Use IPv6 resolvers"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:405
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:443
 msgid "Use any family DNS resolvers"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:393
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:431
 msgid "Use negotiated HTTP version"
 msgstr ""
 
@@ -619,21 +644,22 @@ msgstr ""
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:8
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:8
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:8
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json:8
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:8
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.mullvad.dns.json:9
 #: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:8
 msgid "Variant"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:186
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:195
 msgid "Version %s - Running."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:198
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:207
 msgid "Version %s - Stopped (Disabled)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:196
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:205
 msgid "Version %s - Stopped."
 msgstr ""
 

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/eu.joindns4.json
@@ -1,0 +1,36 @@
+{
+	"title": "DNS4EU",
+	"template": "https://{option}.joindns4.eu/dns-query",
+	"bootstrap_dns": "86.54.11.100,86.54.11.200,2a13:1001::86:54:11:100,2a13:1001::86:54:11:200",
+	"help_link": "https://www.joindns4.eu/for-public/",
+	"params": {
+		"option": {
+			"description": "Variant",
+			"type": "select",
+			"regex": "(unfiltered|protective|noads|child|child-noads)",
+			"options": [
+				{
+					"value": "unfiltered",
+					"description": "Unfiltered"
+				},
+				{
+					"value": "protective",
+					"description": "Protective (blocks malicous and fraudulent websites)"
+				},
+				{
+					"value": "noads",
+					"description": "Protective with ad-blocking"
+				},
+				{
+					"value": "child",
+					"description": "Protective with child protection"
+				},
+				{
+					"value": "child-noads",
+					"description": "Protective with child protection & ad-blocking"
+				}
+			],
+			"default": "unfiltered"
+		}
+	}
+}

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.opennameserver.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.opennameserver.json
@@ -1,0 +1,32 @@
+{
+	"title": "OpenNameServer",
+	"template": "https://{option}.opennameserver.org/dns-query",
+	"bootstrap_dns": "217.160.70.42,2a01:239:2fd:b700::1,213.202.211.221,2001:4ba0:cafe:3d2::1,81.169.136.222,2a01:238:4231:5200::1,185.181.61.24,2a03:94e0:1804::1",
+	"help_link": "https://opennameserver.org/",
+	"params": {
+		"option": {
+			"description": "Nameserver",
+			"type": "select",
+			"regex": "(|ns1|ns2|ns3|ns4)",
+			"options": [
+				{
+					"value": "ns1",
+					"description": "ns1: Germany - Baden-Baden"
+				},
+				{
+					"value": "ns2",
+					"description": "ns2: Germany - Düsseldorf"
+				},
+				{
+					"value": "ns3",
+					"description": "ns3: Germany - Berlin"
+				},
+				{
+					"value": "ns4",
+					"description": "ns4: Norway - Sandefjord"
+				}
+			],
+			"default": "ns1"
+		}
+	}
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 640vn, OpenWrt 24.10.2
Run tested: x86_64, Dell EMC Edge 640vn, OpenWrt 24.10.2

Description:
* update license ID and copyright in Makefile
* add a short README with link to full documentation
* switch doc link from melmac.net to melmac.ca
* add donate text/URL
* attempt to fix bootstrap DNS loading/saving from json
* add DNS4EU provider (thanks @rikroe)
* add OpenNameServer provider (thanks @Phoenix616)


(cherry picked from commit 45e3d1ac1908509f4d5ec7d79d5723697667af36)
