### PR TITLE
Fix typo on DSL spectrum page

### DIFF
--- a/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js
+++ b/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js
@@ -42,7 +42,7 @@ return view.extend({
 						'width': 1024},
 						["chart2"])
 				),
-				E('div', {'class': 'cbi-section-descr', 'style': 'text-align:center'}, _('The graph shows th amount of bits actually allocated per subcarrier in the uplink and downlink direction')),
+				E('div', {'class': 'cbi-section-descr', 'style': 'text-align:center'}, _('The graph shows the amount of bits actually allocated per subcarrier in the uplink and downlink direction')),
 			]),
 			E('div', {'class': 'cbi-section'}, [
 				E('div', {'style': "height: 360px; width:1024px"},

--- a/modules/luci-mod-dsl/po/ar/dsl.po
+++ b/modules/luci-mod-dsl/po/ar/dsl.po
@@ -252,7 +252,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/bg/dsl.po
+++ b/modules/luci-mod-dsl/po/bg/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/bn_BD/dsl.po
+++ b/modules/luci-mod-dsl/po/bn_BD/dsl.po
@@ -247,7 +247,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ca/dsl.po
+++ b/modules/luci-mod-dsl/po/ca/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/cs/dsl.po
+++ b/modules/luci-mod-dsl/po/cs/dsl.po
@@ -253,7 +253,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Graf zobrazuje počet bitů, ve skutečnosti přidělených na dílčí nosné ve "

--- a/modules/luci-mod-dsl/po/da/dsl.po
+++ b/modules/luci-mod-dsl/po/da/dsl.po
@@ -249,7 +249,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/de/dsl.po
+++ b/modules/luci-mod-dsl/po/de/dsl.po
@@ -255,7 +255,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Der Graph zeigt die Anzahl der Bits, die pro Unterträger in Uplink- und "

--- a/modules/luci-mod-dsl/po/el/dsl.po
+++ b/modules/luci-mod-dsl/po/el/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/es/dsl.po
+++ b/modules/luci-mod-dsl/po/es/dsl.po
@@ -261,7 +261,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "El gráfico muestra la cantidad de bits realmente asignados por subportadora "

--- a/modules/luci-mod-dsl/po/fi/dsl.po
+++ b/modules/luci-mod-dsl/po/fi/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/fr/dsl.po
+++ b/modules/luci-mod-dsl/po/fr/dsl.po
@@ -249,7 +249,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ga/dsl.po
+++ b/modules/luci-mod-dsl/po/ga/dsl.po
@@ -256,7 +256,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Taispeánann an graf ú méid na ngiotán a leithdháiltear go hiarbhír ar gach "

--- a/modules/luci-mod-dsl/po/he/dsl.po
+++ b/modules/luci-mod-dsl/po/he/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/hi/dsl.po
+++ b/modules/luci-mod-dsl/po/hi/dsl.po
@@ -247,7 +247,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/hu/dsl.po
+++ b/modules/luci-mod-dsl/po/hu/dsl.po
@@ -251,7 +251,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/it/dsl.po
+++ b/modules/luci-mod-dsl/po/it/dsl.po
@@ -255,7 +255,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Il grafico mostra la quantità di bit effettivamente allocati per "

--- a/modules/luci-mod-dsl/po/ja/dsl.po
+++ b/modules/luci-mod-dsl/po/ja/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ko/dsl.po
+++ b/modules/luci-mod-dsl/po/ko/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/lt/dsl.po
+++ b/modules/luci-mod-dsl/po/lt/dsl.po
@@ -258,7 +258,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Grafike rodomas bitų kiekis, faktiškai paskirstytas, kiekvienam sub-ryšio "

--- a/modules/luci-mod-dsl/po/mr/dsl.po
+++ b/modules/luci-mod-dsl/po/mr/dsl.po
@@ -247,7 +247,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ms/dsl.po
+++ b/modules/luci-mod-dsl/po/ms/dsl.po
@@ -251,7 +251,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/nb_NO/dsl.po
+++ b/modules/luci-mod-dsl/po/nb_NO/dsl.po
@@ -254,7 +254,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/nl/dsl.po
+++ b/modules/luci-mod-dsl/po/nl/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/pl/dsl.po
+++ b/modules/luci-mod-dsl/po/pl/dsl.po
@@ -256,7 +256,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Wykres pokazuje liczbę bitów faktycznie przydzielonych na podnośną w "

--- a/modules/luci-mod-dsl/po/pt/dsl.po
+++ b/modules/luci-mod-dsl/po/pt/dsl.po
@@ -255,7 +255,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "O gráfico mostra a quantidade de bits realmente alocados por subcarreira na "

--- a/modules/luci-mod-dsl/po/pt_BR/dsl.po
+++ b/modules/luci-mod-dsl/po/pt_BR/dsl.po
@@ -249,7 +249,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ro/dsl.po
+++ b/modules/luci-mod-dsl/po/ro/dsl.po
@@ -250,7 +250,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ru/dsl.po
+++ b/modules/luci-mod-dsl/po/ru/dsl.po
@@ -256,7 +256,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "График показывает количество битов, фактически выделенных на поднесущую в "

--- a/modules/luci-mod-dsl/po/sk/dsl.po
+++ b/modules/luci-mod-dsl/po/sk/dsl.po
@@ -248,7 +248,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/sv/dsl.po
+++ b/modules/luci-mod-dsl/po/sv/dsl.po
@@ -250,7 +250,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/ta/dsl.po
+++ b/modules/luci-mod-dsl/po/ta/dsl.po
@@ -255,7 +255,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "வரைபடம் அப்லிங்க் மற்றும் டவுன்லிங்க் திசையில் ஒரு துணைக் கேரியருக்கு உண்மையில் ஒதுக்கப்பட்ட "

--- a/modules/luci-mod-dsl/po/templates/dsl.pot
+++ b/modules/luci-mod-dsl/po/templates/dsl.pot
@@ -240,7 +240,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/tr/dsl.po
+++ b/modules/luci-mod-dsl/po/tr/dsl.po
@@ -255,7 +255,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Grafik, yukarı bağlantı ve aşağı bağlantı yönünde alt taşıyıcı başına fiilen "

--- a/modules/luci-mod-dsl/po/uk/dsl.po
+++ b/modules/luci-mod-dsl/po/uk/dsl.po
@@ -256,7 +256,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 "Графік показує кількість бітів, фактично виділених на піднесучу у висхідному "

--- a/modules/luci-mod-dsl/po/vi/dsl.po
+++ b/modules/luci-mod-dsl/po/vi/dsl.po
@@ -249,7 +249,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 

--- a/modules/luci-mod-dsl/po/zh_Hans/dsl.po
+++ b/modules/luci-mod-dsl/po/zh_Hans/dsl.po
@@ -249,7 +249,7 @@ msgstr "以下图表以图形方式展示了对于评估DSL连接至关重要的
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr "该图表显示了上行和下行方向上每个子载波实际分配的位数"
 

--- a/modules/luci-mod-dsl/po/zh_Hant/dsl.po
+++ b/modules/luci-mod-dsl/po/zh_Hant/dsl.po
@@ -249,7 +249,7 @@ msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:45
 msgid ""
-"The graph shows th amount of bits actually allocated per subcarrier in the "
+"The graph shows the amount of bits actually allocated per subcarrier in the "
 "uplink and downlink direction"
 msgstr ""
 


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile **(There is no PKG_VERSION in this Makefile?)**
- [x] Tested on: (architecture: **mips**, openwrt version: **24.10.2**, browser: Chromium + LibreWolf) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

Before:
<img width="1328" height="1126" alt="Before" src="https://github.com/user-attachments/assets/e3ccf3d9-5795-477f-b64e-a398bfef06f5" />

After:
<img width="1328" height="1126" alt="After" src="https://github.com/user-attachments/assets/466cf122-e346-4596-8a9c-b508a692842f" />
