### PR TITLE
luci-base: don't render until luci-loaded is done

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -1893,6 +1893,15 @@
 			DOM.content(vp, E('div', { 'class': 'spinning' }, _('Loading view…')));
 
 			return Promise.resolve(this.load())
+				.then(function (...args) {
+					if (L.loaded) {
+						return Promise.resolve(...args);
+					} else {
+						return new Promise(function (resolve) {
+							document.addEventListener('luci-loaded', resolve.bind(null, ...args), { once: true });
+						});
+					}
+				})
 				.then(LuCI.prototype.bind(this.render, this))
 				.then(LuCI.prototype.bind(function(nodes) {
 					const vp = document.getElementById('view');
@@ -2688,8 +2697,11 @@
 		initDOM() {
 			originalCBIInit();
 			Poll.start();
+			L.loaded = true;
 			document.dispatchEvent(new CustomEvent('luci-loaded'));
 		},
+
+		loaded: false,
 
 		/**
 		 * The `env` object holds environment settings used by LuCI, such


### PR DESCRIPTION
Because the setupDOM/initDOM methods do strange things related to the old lua server rendered templates
(like remove all the elements currently hidden by dependencies...), we want to be sure that these have finished before the view itself renders.

This also ensures that any caching (e.g. from probeSystemFeatures) is finished before the view render.

This is a hacky fix that we've been using on 23.05, but it's not clear to me what the best one is. I'm raising it as a draft for comment; if someone thinks this is an acceptable solution, I'll add a simple reproduction of a bug and test on master.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
