### PR TITLE
luci-app-frp*: Remove myself as maintainer

### DIFF
--- a/applications/luci-app-frpc/Makefile
+++ b/applications/luci-app-frpc/Makefile
@@ -6,7 +6,6 @@ LUCI_TITLE:=LuCI Support for frp client
 LUCI_DEPENDS:=+luci-base +frpc
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
 include ../../luci.mk
 

--- a/applications/luci-app-frps/Makefile
+++ b/applications/luci-app-frps/Makefile
@@ -6,7 +6,6 @@ LUCI_TITLE:=LuCI Support for frp server
 LUCI_DEPENDS:=+luci-base +frps
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
 include ../../luci.mk
 


### PR DESCRIPTION
frp is using a new config format, the old INI format is deprecated.
The new config format is using TOML and all option names are changed.
A complete rewrite is required to support new config format.

I have replace frp with WireGuard+firewall forwarding some years ago.


Now I have no time and no test environment to maintain these packages.
So remove myself as maintainer.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
