### PR TITLE
 luci-app-statistics: Feature add UI to configure TLS for collectd mqtt

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/mqtt.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/mqtt.js
@@ -68,6 +68,19 @@ return baseclass.extend({
         o.value('false', _('False'));
         o.modalonly = true;
         o.optional = true;
+        
+        o = ss.option(form.ListValue, 'TLSProtocol', _('TLSProtocol'));
+        o.depends('blocktype', 'Publish');
+        o.value('tlsv1.2', _('TLS 1.2'));
+        o.value('tlsv1.3', _('TLS 1.3'));
+        o.modalonly = true;
+        o.optional = true;
+
+        o = ss.option(form.Value, 'CACert', _('CACert'));
+        o.depends({'TLSProtocol': 'tls', '!contains': true });
+        o.optional = true;
+        o.modalonly = true;
+        o.default = '/etc/ssl/certs/ca-certificates.crt';
 
         o = ss.option(form.ListValue, 'CleanSession', _('CleanSession'));
         o.depends('blocktype', 'Subscribe');

--- a/applications/luci-app-statistics/root/usr/libexec/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/libexec/stat-genconfig
@@ -260,6 +260,8 @@ function config_mqtt(c) {
 					str += s['StoreRates'] ? `\t\tRetain ${s.StoreRates}\n` : '';
 					str += s['CleanSession'] ? `\t\tRetain ${s.CleanSession}\n` : '';
 					str += s['Topic'] ? `\t\tTopic "${s.Topic}"\n` : '';
+					str += s['CACert'] ? `\t\tCACert "${s.CACert}"\n` : '';
+					str += s['TLSProtocol'] ? `\t\tTLSProtocol "${s.TLSProtocol}"\n` : '';
 
 					str += isPublish ? `\t</Publish>\n` : `\t</Subscribe>\n`;
 			}


### PR DESCRIPTION
Currently the Luci MQTT interface doesn't let the user setup TLS for encrypted MQTT publishing, this PR updates the collectd.conf generation script and the web UI so that these settings can be configured.

~I'll admit I have not actually tested the WebUI portion as I'm not sure how to compile or install it, but I did stare at the changes for several minutes to make sure they looked right if someone can easily test this or point me at how to do it that'd be great. The changes to the script itself I've tested on the E8450 and they work, and I was able to connect via TLS to my broker~
Fully tested now on E8450 router, running 24.10.2 on Chrome.

See here: https://forum.openwrt.org/t/configuring-collectd-mqtt-pluggin-to-send-encrypted-data/239644

I did not roll the PKG_VERSION as the Makefile didn't have one, at least not in the make file I looked at.

- [ :white_check_mark: ] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [ :white_check_mark: ] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [ :white_check_mark: ] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ❓]  Incremented :up: any `PKG_VERSION` in the Makefile
- [ :white_check_mark: ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ :white_check_mark: ] Description: (describe the changes proposed in this PR)
