### PR TITLE
themes: scale down icons for network interfaces

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2188,6 +2188,11 @@ th[data-sort-direction="desc"]::after { content: "\a0\25bc"; }
 	white-space: normal;
 }
 
+#cbi-network-interface .ifacebox img {
+	width: 24px;
+	height: 24px;
+}
+
 .ifacebadge {
 	display: inline-block;
 	flex-direction: row;

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -2085,6 +2085,11 @@ td > .ifacebadge,
 	padding: .25em;
 }
 
+#cbi-network-interface .ifacebox img {
+	width: 24px;
+	height: 24px;
+}
+
 .cbi-image-button {
 	margin-left: .5rem;
 }

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -704,6 +704,11 @@ p > a {
 	white-space: nowrap;
 }
 
+#cbi-network-interface .ifacebox img {
+	width: 24px;
+	height: 24px;
+}
+
 .ifacebadge {
 	display: inline-flex;
 	align-items: center;

--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -1654,6 +1654,11 @@ select + .cbi-button {
 	min-width: 35%;
 }
 
+#cbi-network-interface .ifacebox img {
+	width: 24px;
+	height: 24px;
+}
+
 
 .zonebadge {
 	padding: 2px;


### PR DESCRIPTION
Many LuCI icons doubled in size during migration to vector graphics in commit ae5d91da903b6f1d3086d6082ca622231e34f555 (16px to 32px).

Sizing of their instances is mostly controlled by CSS, but there's an exception - network interface boxes of *Interfaces* page in LuCI. Current CSS doesn't specify any particular size requirements to follow, so the icons just scale with the images served, thus effectively doubling in width and height compared to state before the vectorization commit. Such a big icons look odd and take up too much space, especially for bridge interfaces with many ports.

Instead of reverting to the original 16×16px, this commit proposes compromise of 24×24px as most of other icons within LuCI became a bit bigger as well.

Changes were tested on all 4 themes using OpenWrt 24.10.2 (with a custom build of LuCI packages).
Selector `#cbi-network-interface` is necessary otherwise *Port status* on *Overview* page gets smaller icons as well.

<table>
  <tr>
    <th>Before this commit</th>
    <th>After this commit</th>
  </tr>
  <tr>
    <td colspan="2">Desktop</td>
  </tr>
  <tr>
    <td><img width="1634" height="688" alt="luci_network_desktop_before" src="https://github.com/user-attachments/assets/d9c71069-79c0-49df-9b77-6464830f91ba" /></td>
    <td><img width="1639" height="681" alt="luci_network_desktop_after" src="https://github.com/user-attachments/assets/4ca01760-78f1-4664-8cd8-5dded2739979" /></td>
  </tr>
  <tr>
    <td colspan="2">Mobile</td>
  </tr>
  <tr>
    <td><img width="635" height="870" alt="luci_network_mobile_before" src="https://github.com/user-attachments/assets/f74f717b-e37b-4231-bb81-193df0656d81" /></td>
    <td><img width="635" height="841" alt="luci_network_mobile_after" src="https://github.com/user-attachments/assets/7411b047-d9d3-4f2b-8825-203c43d2c22d" /></td>
  </tr>
</table>