### PR TITLE
luci-mod-status,luci-mod-network: support oui to vendor resolving

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -303,13 +303,8 @@ return view.extend({
 		});
 	},
 
-	render: function(hosts_duids_pools) {
+	render: function([hosts, duids, pools, networks, macdata]) {
 		var has_dhcpv6 = L.hasSystemFeature('dnsmasq', 'dhcpv6') || L.hasSystemFeature('odhcpd'),
-		    hosts = hosts_duids_pools[0],
-		    duids = hosts_duids_pools[1],
-		    pools = hosts_duids_pools[2],
-		    networks = hosts_duids_pools[3],
-		    macdata = hosts_duids_pools[4],
 		    m, s, o, ss, so, dnss;
 
 		let noi18nstrings = {

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -38,7 +38,9 @@
 		"description": "Grant access to DHCP configuration",
 		"read": {
 			"ubus": {
-				"luci-rpc": [ "getDHCPLeases", "getDUIDHints", "getHostHints" ]
+				"luci-rpc": [ "getDHCPLeases", "getDUIDHints", "getHostHints" ],
+				"fingerprint": [ "fingerprint" ],
+				"file": [ "stat" ]
 			},
 			"uci": [ "dhcp" ]
 		},

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -11,6 +11,17 @@ var callLuciDHCPLeases = rpc.declare({
 	expect: { '': {} }
 });
 
+var callUfpList = rpc.declare({
+	object: 'fingerprint',
+	method: 'fingerprint',
+});
+
+var checkUfpInstalled = rpc.declare({
+	object: 'file',
+	method: 'stat',
+	params: [ 'path' ]
+});
+
 return baseclass.extend({
 	title: '',
 
@@ -19,10 +30,17 @@ return baseclass.extend({
 
 	load: function() {
 		return Promise.all([
-			callLuciDHCPLeases(),
-			network.getHostHints(),
-			L.resolveDefault(uci.load('dhcp'))
-		]);
+			checkUfpInstalled('/usr/sbin/ufpd')
+		]).then(data => {
+			var promises = [
+				callLuciDHCPLeases(),
+				network.getHostHints(),
+				data[0].type === 'file' ? callUfpList() : null,
+				L.resolveDefault(uci.load('dhcp'))
+			];
+
+			return Promise.all(promises);
+		});
 	},
 
 	handleCreateStaticLease: function(lease, ev) {
@@ -64,6 +82,7 @@ return baseclass.extend({
 		    leases6 = Array.isArray(data[0].dhcp6_leases) ? data[0].dhcp6_leases : [],
 		    machints = data[1].getMACHints(false),
 		    hosts = uci.sections('dhcp', 'host'),
+		    macaddr = data[2],
 		    isReadonlyView = !L.hasViewPermission();
 
 		for (var i = 0; i < hosts.length; i++) {
@@ -94,6 +113,7 @@ return baseclass.extend({
 
 		cbi_update_table(table, leases.map(L.bind(function(lease) {
 			var exp, rows;
+			var vendor;
 
 			if (lease.expires === false)
 				exp = E('em', _('unlimited'));
@@ -110,10 +130,15 @@ return baseclass.extend({
 			else if (lease.hostname)
 				host = lease.hostname;
 
+			if (macaddr) {
+				var lowermac = lease.macaddr.toLowerCase();
+				vendor = macaddr[lowermac].vendor ? macaddr[lowermac].vendor : null;
+			}
+
 			rows = [
 				host || '-',
 				lease.ipaddr,
-				lease.macaddr,
+				vendor ? lease.macaddr + ` (${vendor})` : lease.macaddr,
 				exp
 			];
 

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
@@ -33,7 +33,9 @@
 		"description": "Grant access to DHCP status display",
 		"read": {
 			"ubus": {
-				"luci-rpc": [ "getDHCPLeases" ]
+				"luci-rpc": [ "getDHCPLeases" ],
+				"fingerprint": [ "fingerprint" ],
+				"file": [ "stat" ]
 			}
 		}
 	},

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -49,7 +49,8 @@
 				"/sbin/ip -[46] rule show": [ "exec" ]
 			},
 			"ubus": {
-				"file": [ "exec" ]
+				"file": [ "exec", "stat" ],
+				"fingerprint": [ "fingerprint" ]
 			}
 		}
 	},


### PR DESCRIPTION
For easier definition of connected devices, this commit adds support to identify them by vendor name.

Package `upf-neigh` is needed to lookup the vendor name in a hash table. It implements a ubus-call `ubus call fingerprint fingerprint`:

```
root@<redacted> ~ # ubus call fingerprint fingerprint
{
        "7c:c2:55:XX:XX:XX": {
                "vendor": "Super Micro Computer, Inc."
        }
}
```
<img width="711" height="224" alt="image" src="https://github.com/user-attachments/assets/8910b57d-9496-418c-bb99-f1cf46f498b0" />

<img width="1047" height="406" alt="image" src="https://github.com/user-attachments/assets/7b58b4d9-f3fb-4682-be37-2baf3629158c" />


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86/64, openwrt 24.10, firefox-esr) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#2065
- [x] Description: (describe the changes proposed in this PR)
