### PR TITLE
luci-base: standards compliant dropdown fix for mobile keyboards

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -1092,6 +1092,7 @@ const UIDropdown = UIElement.extend(/** @lends LuCI.ui.Dropdown.prototype */ {
 				'maxlength': this.options.maxlength,
 				'placeholder': this.options.custom_placeholder ?? this.options.placeholder,
 				'inputmode': 'text',
+				'enterkeyhint': 'done'
 			});
 
 			if (this.options.datatype || this.options.validate)


### PR DESCRIPTION
I saw that the issue in #7819 was addressed in PR #7876, but the fix was implemented by adding the `inputmode` attribute.   However, this attribute only indicates that “The user agent should display a virtual keyboard capable of text input in the user's locale” (from [WHATWG HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode), and it’s not a reliable solution for changing the virtual keyboard’s confirmation key to a return key.

This PR builds on the previous #7876 by adding the `enterkeyhint` attribute, which is explicitly defined in the W3C HTML 5.2 specification to control the behavior of the virtual keyboard’s confirmation key (source: [W3C HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute).  

This commit did not remove the `inputmode` attribute because, although it no longer aligns with the HTML 5.2 specification, it offers better compatibility with older browser versions. Additionally, the specification clearly states that when `inputmode` and `enterkeyhint` are used together, supported browsers will prioritize the more reliable `enterkeyhint` to control the behavior and appearance of the virtual keyboard’s confirmation key.
