### PR TITLE
luci-mod-status: add gateway display for ipv6

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
@@ -117,7 +117,8 @@ return view.extend({
 
 	parseRoute: function(s, networks, v6) {
 		var lines = s.trim().split(/\n/),
-		    res = [];
+		    res = [],
+		    k = 0;
 
 		for (var i = 0; i < lines.length; i++) {
 			var m = lines[i].match(/^(?:([a-z_]+|\d+) )?(default|[0-9a-f:.\/]+) (.+)$/),
@@ -138,11 +139,16 @@ return view.extend({
 			res.push([
 				E('span', { 'class': 'ifacebadge' }, [ net ? net : '(%s)'.format(flags.dev) ]),
 				dest,
-				(v6 ? flags.from : flags.via) || '-',
+				flags.via || '-',
 				String(flags.metric || 0),
 				flags.table || 'main',
-				flags.proto,
+				flags.proto
 			]);
+
+			if (v6) {
+				res[k].splice(3, 0, flags.from || '-');
+				k++;
+			}
 		}
 
 		return res;
@@ -221,6 +227,7 @@ return view.extend({
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th', 'title': device_title }, [ _('Device') ]),
 				E('th', { 'class': 'th', 'title': target_title }, [ _('Target') ]),
+				E('th', { 'class': 'th', 'title': gateway_title }, [ _('Gateway') ]),
 				E('th', { 'class': 'th', 'title': source_title }, [ _('Source') ]),
 				E('th', { 'class': 'th', 'title': metric_title }, [ _('Metric') ]),
 				E('th', { 'class': 'th', 'title': table_title }, [ _('Table') ]),


### PR DESCRIPTION
add gateway display for ipv6 like ipv4
<img width="965" height="835" alt="routes js" src="https://github.com/user-attachments/assets/69c0e499-f064-473b-8cf6-c9932b147a29" />
