### PR TITLE
luci-mod-network: test strength of wpa_key

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -13,6 +13,25 @@
 
 const isReadonlyView = !L.hasViewPermission();
 
+function check_password_strength(section_id, value) {
+	var strength = document.querySelector('[data-name="_wpa_key"]'),
+	strongRegex = new RegExp("^(?=.{8,})(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*\\W).*$", "g"),
+	mediumRegex = new RegExp("^(?=.{7,})(((?=.*[A-Z])(?=.*[a-z]))|((?=.*[A-Z])(?=.*[0-9]))|((?=.*[a-z])(?=.*[0-9]))).*$", "g"),
+	enoughRegex = new RegExp("(?=.{6,}).*", "g");
+
+	if (strength && value.length) {
+		var strengthChild = strength.childNodes[1].childNodes[1];
+		if (strongRegex.test(value))
+			strengthChild.innerHTML = '%s: <span style="color:green">%s</span>'.format(_('Password strength'), _('Strong'));
+		else if (mediumRegex.test(value))
+			strengthChild.innerHTML = '%s: <span style="color:orange">%s</span>'.format(_('Password strength'), _('Medium'));
+		else
+			strengthChild.innerHTML = '%s: <span style="color:red">%s</span>'.format(_('Password strength'), _('Weak'));
+	}
+
+	return true;
+}
+
 function count_changes(section_id) {
 	const changes = ui.changes.changes?.wireless;
 	if (!Array.isArray(changes)) return 0;
@@ -1589,7 +1608,7 @@ return view.extend({
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa2', 'wpa3', 'wpa3-mixed'] });
 
 
-				o = ss.taboption('encryption', form.Value, '_wpa_key', _('Key'));
+				o = ss.taboption('encryption', form.Value, '_wpa_key', _('Key'), ' ');
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['0'] });
 				add_dependency_permutations(o, { mode: ['sta', 'adhoc', 'mesh', 'sta-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'] });
 				o.depends('encryption', 'sae');
@@ -1597,6 +1616,7 @@ return view.extend({
 				o.datatype = 'wpakey';
 				o.rmempty = true;
 				o.password = true;
+				o.validate = check_password_strength;
 
 				o.cfgvalue = function(section_id) {
 					const key = uci.get('wireless', section_id, 'key');


### PR DESCRIPTION

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86/64, openwrt-24.10, firefox) :white_check_mark:
- [x] \( Preferred ) Screenshot or mp4 of changes:
<img width="405" height="66" alt="image" src="https://github.com/user-attachments/assets/97294715-29f9-4d85-abf6-968019d9e37e" />

<img width="390" height="61" alt="image" src="https://github.com/user-attachments/assets/93adf35b-9932-4dca-af08-052cf307d3cd" />

<img width="392" height="60" alt="image" src="https://github.com/user-attachments/assets/87007375-5f79-476f-93ae-f1b51727834a" />

- [x] Description: (describe the changes proposed in this PR)

This commit uses the function 'checkPassword' from `password.js` in `luci-mod-system` in a modified version to display the strength of the wpa_key.
