### PR TITLE
luci-mod-network,-status: show DHCPv6 lease IAID

### DIFF
--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -355,6 +355,7 @@ struct lease_entry {
 	struct ether_addr mac;
 	char *hostname;
 	char *duid;
+	char *iaid;
 	union {
 		struct in_addr in;
 		struct in6_addr in6;
@@ -487,16 +488,14 @@ lease_next(void)
 				strtok(NULL, " \t\n"); /* iface */
 
 				e.duid = strtok(NULL, " \t\n"); /* duid */
-
 				if (!e.duid)
 					continue;
 
-				p = strtok(NULL, " \t\n"); /* iaid */
-
-				if (!p)
+				e.iaid = strtok(NULL, " \t\n"); /* iaid */
+				if (!e.iaid)
 					continue;
 
-				if (!strcmp(p, "ipv4")) {
+				if (!strcmp(e.iaid, "ipv4")) {
 					e.af = AF_INET;
 					e.mask = 32;
 				}
@@ -597,6 +596,7 @@ lease_next(void)
 
 				e.hostname = strtok(NULL, " \t\n");
 				e.duid     = strtok(NULL, " \t\n");
+				e.iaid     = NULL;
 
 				if (!e.hostname || !e.duid)
 					continue;
@@ -1963,6 +1963,9 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
 
 			if (lease->duid)
 				blobmsg_add_string(&blob, "duid", lease->duid);
+
+			if (lease->iaid)
+				blobmsg_add_string(&blob, "iaid", lease->iaid);
 
 			inet_ntop(lease->af, &lease->addr[0].in6, s, sizeof(s));
 			blobmsg_add_string(&blob, (af == AF_INET) ? "ipaddr" : "ip6addr", s);

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -58,6 +58,7 @@ CBILease6Status = form.DummyValue.extend({
 					E('th', { 'class': 'th' }, _('Hostname')),
 					E('th', { 'class': 'th' }, _('IPv6 address')),
 					E('th', { 'class': 'th' }, _('DUID')),
+					E('th', { 'class': 'th' }, _('IAID')),
 					E('th', { 'class': 'th' }, _('Lease time remaining'))
 				]),
 				E('tr', { 'class': 'tr placeholder' }, [
@@ -1417,6 +1418,7 @@ return view.extend({
 									host || '-',
 									lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
 									lease.duid,
+									lease.iaid,
 									exp
 								];
 							}),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -135,6 +135,7 @@ return baseclass.extend({
 				E('th', { 'class': 'th' }, _('Host')),
 				E('th', { 'class': 'th' }, _('IPv6 address')),
 				E('th', { 'class': 'th' }, _('DUID')),
+				E('th', { 'class': 'th' }, _('IAID')),
 				E('th', { 'class': 'th' }, _('Lease time remaining')),
 				isReadonlyView ? E([]) : E('th', { 'class': 'th cbi-section-actions' }, _('Static Lease'))
 			])
@@ -164,6 +165,7 @@ return baseclass.extend({
 				host || '-',
 				lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
 				lease.duid,
+				lease.iaid,
 				exp
 			];
 


### PR DESCRIPTION
The IAID is important information as it allows the user to know which interface on the client device a given DHCPv6 lease corresponds to. odhcpd already exposes this information (e.g. via "ubus call dhcp ipv6leases"), but it would be good to have access to the same information via the web interface, especially since odhcpd does take the IAID into account when allocating addresses.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (mvebu/cortexa9, OpenWRT 24.10, Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

<img width="1319" height="190" alt="Screenshot From 2025-09-17 01-41-13" src="https://github.com/user-attachments/assets/cbd339b1-f766-41e2-a012-885a4f26f77b" />

