### PR TITLE
luci-mod-network: resolve  issues when connect 802.1X Wi-Fi

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -2100,8 +2100,8 @@ return view.extend({
 			const zoneval = zoneopt ? zoneopt.formvalue('_new_') : null;
 			const enc = L.isObject(bss.encryption) ? bss.encryption : null;
 			const is_wep = (enc && Array.isArray(enc.wep));
-			const is_psk = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).filter(function(a) { return a == 'psk'; }).length > 0);
-			const is_sae = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).filter(function(a) { return a == 'sae'; }).length > 0);
+			const is_psk = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).some(a => a == 'psk'));
+			const is_sae = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).some(a => a == 'sae'));
 
 			if (nameval == null || (passopt && passval == null))
 				return;
@@ -2218,7 +2218,7 @@ return view.extend({
 			const s2 = m2.section(form.NamedSection, '_new_');
 			const enc = L.isObject(bss.encryption) ? bss.encryption : null;
 			const is_wep = (enc && Array.isArray(enc.wep));
-			const is_psk = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).filter(function(a) { return a == 'psk' || a == 'sae'; }));
+			const is_psk = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).some(a => a == 'psk'  || a == 'sae'));
 			let replace, passphrase, name, bssid, zone;
 
 			function nameUsed(name) {


### PR DESCRIPTION
…onnection

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (aarch64, openwrt-24.10 , chrome latest) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

    is_psk returns an empty list ([]), causing the conditional statement to evaluate it as true during an 802.1X network connection. This erroneously triggers a password prompt.
<img width="1579" height="433" alt="wechat_2025-09-20_144006_909" src="https://github.com/user-attachments/assets/67a4c60f-7dbe-4815-b5b8-4a451583413b" />
