### PR TITLE
luci-mod-network: Add flag for address_as_local

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -676,6 +676,11 @@ return view.extend({
 			_('Allocate IP addresses sequentially, starting from the lowest available address.'));
 		o.optional = true;
 
+		o = s.taboption('general', form.Flag, 'address_as_local',
+			_('Resolve addresses locally'),
+			_('Never send queries for FQDNs in the Address option to an upstream resolver.'));
+		o.optional = true;
+
 		o = s.taboption('filteropts', form.Flag, 'boguspriv',
 			_('Filter private'),
 			customi18n(


### PR DESCRIPTION
See openwrt/openwrt#18610 for more information. These pull requests should be merged together.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: ramips/mt7621, OpenWrt 24.10.2, Firefox :white_check_mark:
- [ ] ( Preferred ) Mention: @ the original code author for feedback
- [x] ( Preferred ) Screenshot or mp4 of changes:
   <img width="842" height="77" alt="image" src="https://github.com/user-attachments/assets/315d91bf-348e-4a2d-93a1-51ab6b18a3c7" />

- [ ] ( Optional ) Closes: e.g. openwrt/luci#issue-number
- [x] ( Optional ) Depends on: e.g. openwrt/openwrt#18610
- [x] Description: Adds a toggle for the behaviour described in openwrt/openwrt#18610. The toggle defaults to off (old behaviour) to avoid breaking existing workflows.