### PR TITLE
luci-app-usteer: fix menu showing on login screen

### DIFF
--- a/applications/luci-app-usteer/root/usr/share/luci/menu.d/luci-app-usteer.json
+++ b/applications/luci-app-usteer/root/usr/share/luci/menu.d/luci-app-usteer.json
@@ -1,10 +1,13 @@
 {
-  "admin/network/usteer": {
-    "title": "Usteer",
-    "order": 80,
-    "action": {
-      "type": "view",
-      "path": "usteer/usteer"
-    }
-  }
+	"admin/network/usteer": {
+		"title": "Usteer",
+		"order": 80,
+		"action": {
+			"type": "view",
+			"path": "usteer/usteer"
+		},
+		"depends": {
+			"acl": [ "luci-app-usteer" ]
+		}
+	}
 }


### PR DESCRIPTION
Currently menu entry is always shown even at the login screen.
Fix this by setting acl dependency.

Aslo fix the indent.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: mediatek/filogic, SNAPSHOT, Firefox :white_check_mark:
- [x] \( Preferred ) Mention: @Ramon00  feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
