### PR TITLE
luci-base: form.js depends(): make value optional

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -189,7 +189,7 @@ const CBIJSONConfig = baseclass.extend({
  * @hideconstructor
  * @classdesc
  *
- * The `AbstractElement` class serves as abstract base for the different form
+ * The `AbstractElement` class serves as an abstract base for the different form
  * elements implemented by `LuCI.form`. It provides the common logic for
  * loading and rendering values, for nesting elements and for defining common
  * properties.
@@ -300,17 +300,17 @@ const CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement
 	},
 
 	/**
-	 * Format the given named property as title string.
+	 * Format the given named property as a title string.
 	 *
 	 * This function looks up the given named property and formats its value
-	 * suitable for use as element caption or description string. It also
+	 * suitable for use as an element caption or description string. It also
 	 * strips any HTML tags from the result.
 	 *
 	 * If the property value is a string, it is passed to `String.format()`
 	 * along with any additional parameters passed to `titleFn()`.
 	 *
 	 * If the property value is a function, it is invoked with any additional
-	 * `titleFn()` parameters as arguments and the obtained return value is
+	 * `titleFn()` parameters as arguments, and the obtained return value is
 	 * converted to a string.
 	 *
 	 * In all other cases, `null` is returned.
@@ -398,10 +398,10 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * parameters. This function is essentially a convenience wrapper around
 	 * `querySelectorAll()`.
 	 *
-	 * This function is sensitive to the amount of arguments passed to it;
+	 * This function is sensitive to the number of arguments passed to it;
 	 * if only one argument is specified, it is used as selector-expression
 	 * as-is. When two arguments are passed, the first argument is treated
-	 * as attribute name, the second one as attribute value to match.
+	 * as an attribute name, the second one as an attribute value to match.
 	 *
 	 * As an example, `map.findElements('input')` would find all `<input>`
 	 * nodes while `map.findElements('type', 'text')` would find any DOM node
@@ -441,10 +441,10 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * parameters. This function is essentially a convenience wrapper around
 	 * `findElements()` which only returns the first found node.
 	 *
-	 * This function is sensitive to the amount of arguments passed to it;
+	 * This function is sensitive to the number of arguments passed to it;
 	 * if only one argument is specified, it is used as selector-expression
 	 * as-is. When two arguments are passed, the first argument is treated
-	 * as attribute name, the second one as attribute value to match.
+	 * as an attribute name, the second one as an attribute value to match.
 	 *
 	 * As an example, `map.findElement('input')` would find the first `<input>`
 	 * node while `map.findElement('type', 'text')` would find the first DOM
@@ -475,7 +475,7 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * Tie another UCI configuration to the map.
 	 *
 	 * By default, a map instance will only load the UCI configuration file
-	 * specified in the constructor but sometimes access to values from
+	 * specified in the constructor, but sometimes access to values from
 	 * further configuration files is required. This function allows for such
 	 * use cases by registering further UCI configuration files which are
 	 * needed by the map.
@@ -533,9 +533,9 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * load function of each child element.
 	 *
 	 * @returns {Promise<void>}
-	 * Returns a promise resolving once the entire form completed loading all
+	 * Returns a promise resolving once the entire form is completed loading all
 	 * data. The promise may reject with an error if any configuration failed
-	 * to load or if any of the child elements' load functions rejected with
+	 * to load or if any of the child elements' load functions are rejected with
 	 * an error.
 	 */
 	load() {
@@ -695,8 +695,8 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * The name or the full ID of the option element to look up.
 	 *
 	 * @param {string} [section_id]
-	 * The ID of the UCI section containing the option to look up. May be
-	 * omitted if a full ID is passed as first argument.
+	 * The ID of the UCI section that contains the option to look up. May be
+	 * omitted if a full ID is passed as the first argument.
 	 *
 	 * @param {string} [config_name]
 	 * The name of the UCI configuration the option instance belongs to.
@@ -704,7 +704,7 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 *
 	 * @returns {Array<LuCI.form.AbstractValue,string>|null}
 	 * Returns a two-element array containing the form option instance as
-	 * first item and the corresponding UCI section ID as second item.
+	 * the first item and the corresponding UCI section ID as the second item.
 	 * Returns `null` if the option could not be found.
 	 */
 	lookupOption(name, section_id, config_name) {
@@ -788,10 +788,10 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
  *
  * A `JSONMap` class functions similar to [LuCI.form.Map]{@link LuCI.form.Map}
  * but uses a multidimensional JavaScript object instead of UCI configuration
- * as data source.
+ * as a data source.
  *
  * @param {Object<string, Object<string, *>|Array<Object<string, *>>>} data
- * The JavaScript object to use as data source. Internally, the object is
+ * The JavaScript object to use as a data source. Internally, the object is
  * converted into an UCI-like format. Its top-level keys are treated like UCI
  * section types while the object or array-of-object values are treated as
  * section contents.
@@ -802,7 +802,7 @@ const CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
  * corresponding headline element will not be rendered.
  *
  * @param {string} [description]
- * The description text of the form which is usually rendered as text
+ * The description text of the form which is usually rendered as a text
  * paragraph below the form title and before the actual form contents.
  * If omitted, the corresponding paragraph element will not be rendered.
  */
@@ -921,7 +921,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	},
 
 	/**
-	 * Parse this sections form input.
+	 * Parse these sections form input.
 	 *
 	 * The `parse()` function recursively walks the section element tree and
 	 * triggers input value reading and validation for each encountered child
@@ -969,7 +969,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	 *
 	 * @param {string} [description]
 	 * An additional description text for the corresponding tab pane. It is
-	 * displayed as text paragraph below the tab but before the tab pane
+	 * displayed as a text paragraph below the tab but before the tab pane
 	 * contents. If omitted, no description will be rendered.
 	 *
 	 * @throws {Error}
@@ -1069,7 +1069,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	/**
 	 * Query underlying option configuration values.
 	 *
-	 * This function is sensitive to the amount of arguments passed to it;
+	 * This function is sensitive to the number of arguments passed to it;
 	 * if only one argument is specified, the configuration values of all
 	 * options within this section are returned as a dictionary.
 	 *
@@ -1085,7 +1085,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	 * @returns {null|string|string[]|Object<string, null|string|string[]>}
 	 * Returns either a dictionary of option names and their corresponding
 	 * configuration values or just a single configuration value, depending
-	 * on the amount of passed arguments.
+	 * on the number of passed arguments.
 	 */
 	cfgvalue(section_id, option) {
 		const rv = (arguments.length == 1) ? {} : null;
@@ -1100,9 +1100,9 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	},
 
 	/**
-	 * Query underlying option widget input values.
+	 * Query the underlying option widget input values.
 	 *
-	 * This function is sensitive to the amount of arguments passed to it;
+	 * This function is sensitive to the number of arguments passed to it;
 	 * if only one argument is specified, the widget input values of all
 	 * options within this section are returned as a dictionary.
 	 *
@@ -1118,7 +1118,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	 * @returns {null|string|string[]|Object<string, null|string|string[]>}
 	 * Returns either a dictionary of option names and their corresponding
 	 * widget input values or just a single widget input value, depending
-	 * on the amount of passed arguments.
+	 * on the number of passed arguments.
 	 */
 	formvalue(section_id, option) {
 		const rv = (arguments.length == 1) ? {} : null;
@@ -1138,7 +1138,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	/**
 	 * Obtain underlying option LuCI.ui widget instances.
 	 *
-	 * This function is sensitive to the amount of arguments passed to it;
+	 * This function is sensitive to the number of arguments passed to it;
 	 * if only one argument is specified, the LuCI.ui widget instances of all
 	 * options within this section are returned as a dictionary.
 	 *
@@ -1154,7 +1154,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	 * @returns {null|LuCI.ui.AbstractElement|Object<string, null|LuCI.ui.AbstractElement>}
 	 * Returns either a dictionary of option names and their corresponding
 	 * widget input values or just a single widget input value, depending
-	 * on the amount of passed arguments.
+	 * on the number of passed arguments.
 	 */
 	getUIElement(section_id, option) {
 		const rv = (arguments.length == 1) ? {} : null;
@@ -1171,7 +1171,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	/**
 	 * Obtain underlying option objects.
 	 *
-	 * This function is sensitive to the amount of arguments passed to it;
+	 * This function is sensitive to the number of arguments passed to it;
 	 * if no option name is specified, all options within this section are
 	 * returned as a dictionary.
 	 *
@@ -1184,7 +1184,7 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 	 * @returns {null|LuCI.form.AbstractValue|Object<string, LuCI.form.AbstractValue>}
 	 * Returns either a dictionary of option names and their corresponding
 	 * option instance objects or just a single object instance value,
-	 * depending on the amount of passed arguments.
+	 * depending on the number of passed arguments.
 	 */
 	getOption(option) {
 		const rv = (arguments.length == 0) ? {} : null;
@@ -1257,9 +1257,9 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 		for (let i = 0, sid = sids[0]; (sid = sids[i]) != null; i++) {
 			for (let j = 0, o = this.children[0]; (o = this.children[j]) != null; j++) {
 				let isActive = o.isActive(sid);
-				const isSatisified = o.checkDepends(sid);
+				const isSatisfied = o.checkDepends(sid);
 
-				if (isActive != isSatisified) {
+				if (isActive != isSatisfied) {
 					o.setActive(sid, !isActive);
 					isActive = !isActive;
 					changed = true;
@@ -1337,7 +1337,7 @@ function isContained(x, y) {
  * @hideconstructor
  * @classdesc
  *
- * The `AbstractValue` class serves as abstract base for the different form
+ * The `AbstractValue` class serves as an abstract base for the different form
  * option styles implemented by `LuCI.form`. It provides the common logic for
  * handling option input values, for dependencies among options and for
  * validation constraints that should be applied to entered values.
@@ -1417,7 +1417,7 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 * Specifies a custom validation function to test the user input for
 	 * validity. The validation function must return `true` to accept the
 	 * value. Any other return value type is converted to a string and
-	 * displayed to the user as validation error message.
+	 * displayed to the user as a validation error message.
 	 *
 	 * If the user entered input does not pass the validation function, the
 	 * option element is marked as invalid.
@@ -1456,8 +1456,8 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	/**
 	 * Override the UCI option name to read the value from.
 	 *
-	 * By default, the elements name, which is passed as third argument to
-	 * the constructor, is used as UCI option name. By setting this property,
+	 * By default, the elements name, which is passed as the third argument to
+	 * the constructor, is used as the UCI option name. By setting this property,
 	 * a deviating UCI option may be specified.
 	 *
 	 * The default of null means use the option element name.
@@ -1468,7 +1468,7 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 */
 
 	/**
-	 * Mark grid section option element as editable.
+	 * Mark the grid section option element as editable.
 	 *
 	 * Options which are displayed in the table portion of a `GridSection`
 	 * instance are rendered as readonly text by default. By setting the
@@ -1485,7 +1485,7 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 */
 
 	/**
-	 * Move grid section option element into the table, the modal popup or both.
+	 * Move the grid section option element into the table, the modal popup or both.
 	 *
 	 * If this property is `null` (the default), the option element is
 	 * displayed in both the table preview area and the per-section instance
@@ -1556,13 +1556,13 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 * Multiple constraints (that is, multiple calls to `depends()`) are
 	 * treated as alternatives, forming a logical "or" expression.
 	 *
-	 * By passing an object of name => value pairs as first argument, it is
+	 * By passing an object of name => value pairs as the first argument, it is
 	 * possible to depend on multiple options simultaneously, forming
 	 * a logical "and" expression.
 	 *
-	 * Option names may be given in "dot notation" which allows to reference
+	 * Option names may be given in "dot notation" which allows referencing
 	 * option elements outside the current form section. If a name without
-	 * dot is specified, it refers to an option within the same configuration
+	 * a dot is specified, it refers to an option within the same configuration
 	 * section. If specified as <code>configname.sectionid.optionname</code>,
 	 * options anywhere within the same form may be specified.
 	 *
@@ -1632,8 +1632,8 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 * dependencies which must be satisfied (a logical "and" expression).
 	 *
 	 * @param {string|RegExp} [value]
-	 * When invoked with a plain option name as first argument, this parameter
-	 * specifies the expected value. In case an object is passed as first
+	 * When invoked with a plain option name as the first argument, this parameter
+	 * specifies the expected value. In case an object is passed as the first
 	 * argument, this parameter is ignored.
 	 */
 	depends(field, value) {
@@ -1715,7 +1715,7 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 		const config_name = this.uciconfig ?? this.section.uciconfig ?? this.map.config;
 		const cfgvalue = L.toArray(this.cfgvalue(section_id))[0];
 		let default_defval = null;
-		let satisified_defval = null;
+		let satisfied_defval = null;
 
 		for (const value in this.defaults) {
 			if (!this.defaults[value] || this.defaults[value].length == 0) {
@@ -1723,19 +1723,19 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 				continue;
 			}
 			else if (this.map.isDependencySatisfied(this.defaults[value], config_name, section_id)) {
-				satisified_defval = value;
+				satisfied_defval = value;
 				break;
 			}
 		}
 
-		if (satisified_defval == null)
-			satisified_defval = default_defval;
+		if (satisfied_defval == null)
+			satisfied_defval = default_defval;
 
 		const node = this.map.findElement('id', this.cbid(section_id));
-		if (node && node.getAttribute('data-changed') != 'true' && satisified_defval != null && cfgvalue == null)
-			dom.callClassMethod(node, 'setValue', satisified_defval);
+		if (node && node.getAttribute('data-changed') != 'true' && satisfied_defval != null && cfgvalue == null)
+			dom.callClassMethod(node, 'setValue', satisfied_defval);
 
-		this.default = satisified_defval;
+		this.default = satisfied_defval;
 	},
 
 	/**
@@ -1913,8 +1913,8 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 *
 	 * @returns {*}
 	 * The method shall return `true` to accept the given value. Any other
-	 * return value is treated as failure, converted to a string and displayed
-	 * as error message to the user.
+	 * return value is treated as a failure, converted to a string and displayed
+	 * as an error message to the user.
 	 */
 	validate(section_id, value) {
 		return true;
@@ -2130,7 +2130,7 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
  * value of the `addremove` property.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [section()]{@link LuCI.form.Map#section}.
  *
  * @param {string} section_type
@@ -2158,7 +2158,7 @@ const CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSect
 	/**
 	 * If set to `true`, mapped section instances are treated as anonymous
 	 * UCI sections, which means that section instance elements will be
-	 * rendered without title element and that no name is required when adding
+	 * rendered without a title element and that no name is required when adding
 	 * new sections. The default is `false`.
 	 *
 	 * @name LuCI.form.TypedSection.prototype#anonymous
@@ -2168,7 +2168,7 @@ const CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSect
 
 	/**
 	 * When set to `true`, instead of rendering section instances one below
-	 * another, treat each instance as separate tab pane and render a tab menu
+	 * another, treat each instance as a separate tab pane and render a tab menu
 	 * at the top of the form section element, allowing the user to switch
 	 * among instances. The default is `false`.
 	 *
@@ -2178,10 +2178,10 @@ const CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSect
 	 */
 
 	/**
-	 * Override the caption used for the section add button at the bottom of
+	 * Override the caption used for the section add a button at the bottom of
 	 * the section form element. Set to a string, it will be used as-is.
 	 * Set to a function, the function will be invoked and its return value
-	 * is used as caption, after converting it to a string. If this property
+	 * is used as a caption, after converting it to a string. If this property
 	 * is not set, the default is `Add`.
 	 *
 	 * @name LuCI.form.TypedSection.prototype#addbtntitle
@@ -2369,7 +2369,7 @@ const CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSect
  * value of the `addremove` property.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [section()]{@link LuCI.form.Map#section}.
  *
  * @param {string} section_type
@@ -2388,9 +2388,9 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 	 * Override the per-section instance title caption shown in the first
 	 * column of the table unless `anonymous` is set to true. Set to a
 	 * string, it will be used as a `String.format()` pattern with the name of
-	 * the underlying UCI section as first argument. Set to a function, the
-	 * function will be invoked with the section name as first argument and
-	 * its return value used as caption, after converting it to a string.
+	 * the underlying UCI section as the first argument. Set to a function, the
+	 * function will be invoked with the section name as the first argument and
+	 * its return value used as a caption, after converting it to a string.
 	 * If this property is not set, the default is the name of the underlying
 	 * UCI configuration section.
 	 *
@@ -2403,9 +2403,9 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 	 * Override the per-section instance modal popup title caption shown when
 	 * clicking the `More…` button in a section specifying `max_cols`. Set
 	 * to a string, it will be used as a `String.format()` pattern with the name
-	 * of the underlying UCI section as first argument. Set to a function,
-	 * the function will be invoked with the section name as first argument and
-	 * its return value is used as caption, after converting it to a string.
+	 * of the underlying UCI section as the first argument. Set to a function,
+	 * the function will be invoked with the section name as the first argument, and
+	 * its return value is used as a caption after converting it to a string.
 	 * If this property is not set, the default is the name of the underlying
 	 * UCI configuration section.
 	 *
@@ -2415,7 +2415,7 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 	 */
 
 	/**
-	 * Specify a maximum amount of columns to display. By default, one table
+	 * Specify a maximum number of columns to display. By default, one table
 	 * column is rendered for each child option of the form section element.
 	 * When this option is set to a positive number, then no more columns than
 	 * the given amount are rendered. When the number of child options exceeds
@@ -2452,12 +2452,12 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 	 * Enables a per-section instance row `Edit` button which triggers a certain
 	 * action when clicked. Set to a string, the string value is used
 	 * as a `String.format()` pattern with the name of the underlying UCI section
-	 * as first format argument. The result is then interpreted as a URL which
+	 * as the first format argument. The result is then interpreted as a URL which
 	 * LuCI will navigate to when the user clicks the edit button.
 	 *
-	 * If set to a function, this function will be registered as click event
+	 * If set to a function, this function will be registered as a click event
 	 * handler on the rendered edit button, receiving the section instance
-	 * name as first and the DOM click event as second argument.
+	 * name as the first and the DOM click event as the second argument.
 	 *
 	 * @name LuCI.form.TableSection.prototype#extedit
 	 * @type string|function
@@ -2475,8 +2475,8 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 	 */
 
 	/**
-	 * Set to `true`, the header row with the options descriptions will
-	 * not be displayed. By default, descriptions row is automatically displayed
+	 * Set to `true`, the header row with the descriptions of options will
+	 * not be displayed. By default, the row of descriptions is automatically displayed
 	 * when at least one option has a description.
 	 *
 	 * @name LuCI.form.TableSection.prototype#nodescriptions
@@ -3319,7 +3319,7 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
  * Layout wise, a grid section looks mostly identical to table sections.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [section()]{@link LuCI.form.Map#section}.
  *
  * @param {string} section_type
@@ -3354,7 +3354,7 @@ const CBIGridSection = CBITableSection.extend(/** @lends LuCI.form.GridSection.p
 	 *
 	 * @param {string} [description]
 	 * An additional description text for the corresponding tab pane. It is
-	 * displayed as text paragraph below the tab but before the tab pane
+	 * displayed as a text paragraph below the tab but before the tab pane
 	 * contents. If omitted, no description will be rendered.
 	 *
 	 * @throws {Error}
@@ -3480,7 +3480,7 @@ const CBIGridSection = CBITableSection.extend(/** @lends LuCI.form.GridSection.p
  * `TypedSection` which allows exactly one section node.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [section()]{@link LuCI.form.Map#section}.
  *
  * @param {string} section_id
@@ -3527,7 +3527,7 @@ const CBINamedSection = CBIAbstractSection.extend(/** @lends LuCI.form.NamedSect
 	/**
 	 * The `NamedSection` class overrides the generic `cfgsections()`
 	 * implementation to return a one-element array containing the mapped
-	 * section ID as sole element. User code should not normally change this.
+	 * section ID as a sole element. User code should not normally change this.
 	 *
 	 * @returns {string[]}
 	 * Returns a one-element array containing the mapped section ID.
@@ -3630,7 +3630,7 @@ const CBINamedSection = CBIAbstractSection.extend(/** @lends LuCI.form.NamedSect
  * {@link LuCI.ui.Combobox} class as underlying widget.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -3681,7 +3681,7 @@ const CBIValue = CBIAbstractValue.extend(/** @lends LuCI.form.Value.prototype */
 	 *
 	 * @param {Node|string} val
 	 * The caption for the choice value. May be a DOM node, a document fragment
-	 * or a plain text string. If omitted, the `key` value is used as caption.
+	 * or a plain text string. If omitted, the `key` value is used as a caption.
 	 */
 	value(key, val) {
 		this.keylist ??= [];
@@ -3843,7 +3843,7 @@ const CBIValue = CBIAbstractValue.extend(/** @lends LuCI.form.Value.prototype */
  * predefined choices. It builds upon the {@link LuCI.ui.DynamicList} widget.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -3910,7 +3910,7 @@ const CBIDynamicList = CBIValue.extend(/** @lends LuCI.form.DynamicList.prototyp
  * It builds upon the {@link LuCI.ui.Select} widget.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4003,7 +4003,7 @@ const CBIListValue = CBIValue.extend(/** @lends LuCI.form.ListValue.prototype */
  * It builds upon the {@link LuCI.form.ListValue} widget.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4132,7 +4132,7 @@ const CBIRichListValue = CBIListValue.extend(/** @lends LuCI.form.ListValue.prot
  * values. The currently chosen value is displayed to the side of the slider.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4258,7 +4258,7 @@ const CBIRangeSliderValue = CBIValue.extend(/** @lends LuCI.form.RangeSliderValu
  * implement a simple checkbox element.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4416,7 +4416,7 @@ const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */
  * select dropdown element.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4453,7 +4453,7 @@ const CBIMultiValue = CBIDynamicList.extend(/** @lends LuCI.form.MultiValue.prot
 	 */
 
 	/**
-	 * Allows to specify the [display_items]{@link LuCI.ui.Dropdown.InitOptions}
+	 * Allows specifying the [display_items]{@link LuCI.ui.Dropdown.InitOptions}
 	 * property of the underlying dropdown widget. If omitted, the value of
 	 * the `size` property is used or `3` when `size` is also unspecified.
 	 *
@@ -4463,7 +4463,7 @@ const CBIMultiValue = CBIDynamicList.extend(/** @lends LuCI.form.MultiValue.prot
 	 */
 
 	/**
-	 * Allows to specify the [dropdown_items]{@link LuCI.ui.Dropdown.InitOptions}
+	 * Allows specifying the [dropdown_items]{@link LuCI.ui.Dropdown.InitOptions}
 	 * property of the underlying dropdown widget. If omitted, the value of
 	 * the `size` property is used or `-1` when `size` is also unspecified.
 	 *
@@ -4505,7 +4505,7 @@ const CBIMultiValue = CBIDynamicList.extend(/** @lends LuCI.form.MultiValue.prot
  * {@link LuCI.ui.Textarea}.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4541,7 +4541,7 @@ const CBITextValue = CBIValue.extend(/** @lends LuCI.form.TextValue.prototype */
 	 */
 
 	/**
-	 * Allows to specify the [cols]{@link LuCI.ui.Textarea.InitOptions}
+	 * Allows specifying the [cols]{@link LuCI.ui.Textarea.InitOptions}
 	 * property of the underlying textarea widget.
 	 *
 	 * @name LuCI.form.TextValue.prototype#cols
@@ -4550,7 +4550,7 @@ const CBITextValue = CBIValue.extend(/** @lends LuCI.form.TextValue.prototype */
 	 */
 
 	/**
-	 * Allows to specify the [rows]{@link LuCI.ui.Textarea.InitOptions}
+	 * Allows specifying the [rows]{@link LuCI.ui.Textarea.InitOptions}
 	 * property of the underlying textarea widget.
 	 *
 	 * @name LuCI.form.TextValue.prototype#rows
@@ -4559,7 +4559,7 @@ const CBITextValue = CBIValue.extend(/** @lends LuCI.form.TextValue.prototype */
 	 */
 
 	/**
-	 * Allows to specify the [wrap]{@link LuCI.ui.Textarea.InitOptions}
+	 * Allows specifying the [wrap]{@link LuCI.ui.Textarea.InitOptions}
 	 * property of the underlying textarea widget.
 	 *
 	 * @name LuCI.form.TextValue.prototype#wrap
@@ -4599,7 +4599,7 @@ const CBITextValue = CBIValue.extend(/** @lends LuCI.form.TextValue.prototype */
  * renders the underlying UCI option or default value as readonly text.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4693,7 +4693,7 @@ const CBIDummyValue = CBIValue.extend(/** @lends LuCI.form.DummyValue.prototype 
  * renders the underlying UCI option or default value as readonly text.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4719,13 +4719,13 @@ const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototyp
 	/**
 	 * Override the rendered button caption.
 	 *
-	 * By default, the option title - which is passed as fourth argument to the
-	 * constructor - is used as caption for the button element. When setting
+	 * By default, the option title - which is passed as the fourth argument to the
+	 * constructor - is used as a caption for the button element. When setting
 	 * this property to a string, it is used as a `String.format()` pattern with
-	 * the underlying UCI section name passed as first format argument. When
-	 * set to a function, it is invoked passing the section ID as sole argument
+	 * the underlying UCI section name passed as the first format argument. When
+	 * set to a function, it is invoked passing the section ID as the sole argument,
 	 * and the resulting return value is converted to a string before being
-	 * used as button caption.
+	 * used as a button caption.
 	 *
 	 * The default of `null` means the option title is used as caption.
 	 *
@@ -4759,8 +4759,8 @@ const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototyp
 	 *
 	 * When this property is set to a function, it is invoked instead of
 	 * performing the default actions. The handler function will receive the
-	 * DOM click element as first and the underlying configuration section ID
-	 * as second argument.
+	 * DOM click element as the first and the underlying configuration section ID
+	 * as the second argument.
 	 *
 	 * @name LuCI.form.ButtonValue.prototype#onclick
 	 * @type function
@@ -4816,7 +4816,7 @@ const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototyp
  * distorted form layout when rendering the option element.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4860,7 +4860,7 @@ const CBIHiddenValue = CBIValue.extend(/** @lends LuCI.form.HiddenValue.prototyp
  * offers the ability to browse, upload and select remote files.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.
@@ -4904,7 +4904,7 @@ const CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype 
 	 */
 
 	/**
-	 * Toggle display of hidden files.
+	 * Toggle displaying of hidden files.
 	 *
 	 * Display hidden files when rendering the remote directory listing.
 	 * Note that this is merely a cosmetic feature: hidden files are always
@@ -4935,7 +4935,7 @@ const CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype 
 	/**
 	 * Toggle remote file delete functionality.
 	 *
-	 * When set to `true`, the underlying widget provides a buttons which let
+	 * When set to `true`, the underlying widget provides buttons which let
 	 * the user delete files from remote directories. Note that this is merely
 	 * a cosmetic feature: remote delete permissions are controlled by the
 	 * session ACL rules.
@@ -5000,7 +5000,7 @@ const CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype 
  * element container, allowing to nest form sections into other sections.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
- * The configuration form this section is added to. It is automatically passed
+ * The configuration form to which this section is added to. It is automatically passed
  * by [option()]{@link LuCI.form.AbstractSection#option} or
  * [taboption()]{@link LuCI.form.AbstractSection#taboption} when adding the
  * option to the section.

--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -28,7 +28,7 @@
 	 *
 	 * `LuCI.baseclass` is the abstract base class all LuCI classes inherit from.
 	 *
-	 * It provides simple means to create subclasses of given classes and
+	 * It provides a simple means to create subclasses of given classes and
 	 * implements prototypal inheritance.
 	 */
 	const superContext = {};
@@ -191,11 +191,11 @@
 			 * Walks up the parent class chain and looks for a class member
 			 * called `key` in any of the parent classes this class inherits
 			 * from. Returns the member value of the superclass or calls the
-			 * member as function and returns its return value when the
+			 * member as a function and returns its return value when the
 			 * optional `callArgs` array is given.
 			 *
 			 * This function has two signatures and is sensitive to the
-			 * amount of arguments passed to it:
+			 * number of arguments passed to it:
 			 *  - `super('key')` -
 			 *	Returns the value of `key` when found within one of the
 			 *	parent classes.
@@ -212,7 +212,7 @@
 			 * @param {Array<*>} [callArgs]
 			 * An optional array of function call parameters to use. When
 			 * this parameter is specified, the found member value is called
-			 * as function using the values of this array as arguments.
+			 * as a function using the values of this array as arguments.
 			 *
 			 * @throws {ReferenceError}
 			 * Throws a `ReferenceError` when `callArgs` are specified and
@@ -633,7 +633,7 @@
 		 *
 		 * @property {function} [progress]
 		 * An optional request callback function which receives ProgressEvent
-		 * instances as sole argument during the HTTP request transfer.
+		 * instances as the sole argument during the HTTP request transfer.
 		 */
 
 		/**
@@ -999,7 +999,7 @@
 	 * @classdesc
 	 *
 	 * The `Poll` class allows registering and unregistering poll actions,
-	 * as well as starting, stopping and querying the state of the polling
+	 * as well as starting, stopping, and querying the state of the polling
 	 * loop.
 	 */
 	const Poll = Class.singleton(/** @lends LuCI.poll.prototype */ {
@@ -1164,7 +1164,7 @@
 	 * @hideconstructor
 	 * @classdesc
 	 *
-	 * The `dom` class provides convenience method for creating and
+	 * The `dom` class provides a convenience method for creating and
 	 * manipulating DOM elements.
 	 *
 	 * To import the class in views, use `'require dom'`, to import it in
@@ -1282,20 +1282,20 @@
 		 * The `Node` argument to append the children to.
 		 *
 		 * @param {*} [children]
-		 * The children to append to the given node.
+		 * The children are to append to the given node.
 		 *
 		 * When `children` is an array, then each item of the array
-		 * will be either appended as child element or text node,
+		 * will be either appended as a child element or text node,
 		 * depending on whether the item is a DOM `Node` instance or
 		 * some other non-`null` value. Non-`Node`, non-`null` values
 		 * will be converted to strings first before being passed as
 		 * argument to `createTextNode()`.
 		 *
 		 * When `children` is a function, it will be invoked with
-		 * the passed `node` argument as sole parameter and the `append`
+		 * the passed `node` argument as the sole parameter and the `append`
 		 * function will be invoked again, with the given `node` argument
 		 * as first and the return value of the `children` function as
-		 * second parameter.
+		 *  the second parameter.
 		 *
 		 * When `children` is a DOM `Node` instance, it will be
 		 * appended to the given `node`.
@@ -1352,17 +1352,17 @@
 		 * The children to replace into the given node.
 		 *
 		 * When `children` is an array, then each item of the array
-		 * will be either appended as child element or text node,
+		 * will be either appended as a child element or text node,
 		 * depending on whether the item is a DOM `Node` instance or
 		 * some other non-`null` value. Non-`Node`, non-`null` values
 		 * will be converted to strings first before being passed as
 		 * argument to `createTextNode()`.
 		 *
 		 * When `children` is a function, it will be invoked with
-		 * the passed `node` argument as sole parameter and the `append`
+		 * the passed `node` argument as the sole parameter and the `append`
 		 * function will be invoked again, with the given `node` argument
 		 * as first and the return value of the `children` function as
-		 * second parameter.
+		 * the second parameter.
 		 *
 		 * When `children` is a DOM `Node` instance, it will be
 		 * appended to the given `node`.
@@ -1412,15 +1412,15 @@
 		 * If the `key` parameter is an `Object`, this parameter will be
 		 * ignored.
 		 *
-		 * When `val` is of type function, it will be registered as event
+		 * When `val` is of type function, it will be registered as an event
 		 * handler on the given `node` with the `key` parameter being the
 		 * event name.
 		 *
 		 * When `val` is of type object, it will be serialized as JSON and
-		 * added as attribute to the given `node`, using the given `key`
-		 * as attribute name.
+		 * added as an attribute to the given `node`, using the given `key`
+		 * as an attribute name.
 		 *
-		 * When `val` is of any other type, it will be added as attribute
+		 * When `val` is of any other type, it will be added as an attribute
 		 * to the given `node` as-is, with the underlying `setAttribute()`
 		 * call implicitly turning it into a string.
 		 */
@@ -1471,10 +1471,10 @@
 		 * When the value of `html` is of type array, a `DocumentFragment`
 		 * node is created and each item of the array is first converted
 		 * to a DOM `Node` by passing it through `create()` and then added
-		 * as child to the fragment.
+		 * as a child to the fragment.
 		 *
 		 * When the value of `html` is a DOM `Node` instance, no new
-		 * element will be created but the node will be used as-is.
+		 * element will be created, but the node will be used as-is.
 		 *
 		 * When the value of `html` is a string starting with `<`, it will
 		 * be passed to `dom.parse()` and the resulting value is used.
@@ -1638,7 +1638,7 @@
 		},
 
 		/**
-		 * Binds the given class instance ot the specified DOM `Node`.
+		 * Binds the given class instance to the specified DOM `Node`.
 		 *
 		 * This function uses the `dom.data()` facility to attach the
 		 * passed instance of a Class to a node. This is needed for
@@ -1909,7 +1909,7 @@
 		 * `Promise.resolve()` so it may return Promises if needed.
 		 *
 		 * The return value of the function (or the resolved values
-		 * of the promise returned by it) will be passed as first
+		 * of the promise returned by it) will be passed as the first
 		 * argument to `render()`.
 		 *
 		 * This function is supposed to be overwritten by subclasses,
@@ -2160,7 +2160,7 @@
 	let sysFeatures = null;
 	let preloadClasses = null;
 
-	/* "preload" builtin classes to make the available via require */
+	/* "preload" builtin classes to make them available via require */
 	const classes = {
 		baseclass: Class,
 		dom: DOM,
@@ -2212,7 +2212,7 @@
 		/**
 		 * Captures the current stack trace and throws an error of the
 		 * specified type as a new exception. Also logs the exception as
-		 * error to the debug console if it is available.
+		 * an error to the debug console if it is available.
 		 *
 		 * @instance
 		 * @memberof LuCI
@@ -2581,7 +2581,7 @@
 		 * @memberof LuCI
 		 *
 		 * @param {string} feature
-		 * The feature to test. For detailed list of known feature flags,
+		 * The feature to test. For a detailed list of known feature flags,
 		 * see `/modules/luci-base/root/usr/share/rpcd/ucode/luci`.
 		 *
 		 * @param {string} [subfeature]
@@ -2693,7 +2693,7 @@
 
 		/**
 		 * The `env` object holds environment settings used by LuCI, such
-		 * as request timeouts, base URLs etc.
+		 * as request timeouts, base URLs, etc.
 		 *
 		 * @instance
 		 * @memberof LuCI
@@ -2771,7 +2771,7 @@
 		},
 
 		/**
-		 * Construct a URL with path relative to the script path of the server
+		 * Construct a URL with a path relative to the script path of the server
 		 * side LuCI application (usually `/cgi-bin/luci`).
 		 *
 		 * The resulting URL is guaranteed to contain only the characters
@@ -2868,7 +2868,7 @@
 		 * The value to test
 		 *
 		 * @return {boolean}
-		 * Returns `true` if the given value is of type object and
+		 * Returns `true` if the given value is of a type object and
 		 * not `null`, else returns `false`.
 		 */
 		isObject(val) {
@@ -2940,11 +2940,11 @@
 		},
 
 		/**
-		 * Compares two values numerically and returns -1, 0 or 1 depending
-		 * on whether the first value is smaller, equal to or larger than the
+		 * Compares two values numerically and returns -1, 0, or 1 depending
+		 * on whether the first value is smaller, equal to, or larger than the
 		 * second one respectively.
 		 *
-		 * This function is meant to be used as comparator function for
+		 * This function is meant to be used as a comparator function for
 		 * Array.sort().
 		 *
 		 * @type {function}
@@ -2983,11 +2983,11 @@
 
 		/**
 		 * Converts the given value to an array. If the given value is of
-		 * type array, it is returned as-is, values of type object are
+		 * type array, it is returned as-is, values of a type object are
 		 * returned as one-element array containing the object, empty
-		 * strings and `null` values are returned as empty array, all other
+		 * strings and `null` values are returned as an empty array, all other
 		 * values are converted using `String()`, trimmed, split on white
-		 * space and returned as array.
+		 * space and returned as an array.
 		 *
 		 * @instance
 		 * @memberof LuCI
@@ -3137,7 +3137,7 @@
 		 * @param {boolean} [post=false]
 		 * When set to `false` or not specified, poll requests will be made
 		 * using the GET method. When set to `true`, POST requests will be
-		 * issued. In case of POST requests, the request body will contain
+		 * issued. In the case of POST requests, the request body will contain
 		 * an argument `token` with the current value of `LuCI.env.token` by
 		 * default, regardless of the parameters specified with `args`.
 		 *
@@ -3285,7 +3285,7 @@
 	 * @classdesc
 	 *
 	 * The `LuCI.xhr` class is a legacy compatibility shim for the
-	 * functionality formerly provided by `xhr.js`. It is registered as global
+	 * functionality formerly provided by `xhr.js`. It is registered as a global
 	 * `window.XHR` symbol for compatibility with legacy code.
 	 *
 	 * New code should use {@link LuCI.request} instead to implement HTTP

--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -669,7 +669,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 *
 	 * @returns {null|string}
 	 * Returns a string containing the netmask corresponding to the bit count
-	 * or `null` when the given amount of bits exceeds the maximum possible
+	 * or `null` when the given number of bits exceeds the maximum possible
 	 * value of `32` for IPv4 or `128` for IPv6.
 	 */
 	prefixToMask: prefixToMask,
@@ -804,7 +804,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * Registers a new {@link LuCI.network.Protocol Protocol} subclass
 	 * with the given methods and returns the resulting subclass value.
 	 *
-	 * This functions internally calls
+	 * This function internally calls
 	 * {@link LuCI.Class.extend Class.extend()} on the `Network.Protocol`
 	 * base class.
 	 *
@@ -872,7 +872,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * `NO_DEVICE`.
 	 *
 	 * @param {string} message
-	 * The message to use as translation for the given protocol error code.
+	 * The message to use as a translation for the given protocol error code.
 	 *
 	 * @returns {boolean}
 	 * Returns `true` if the error code description has been added or `false`
@@ -1334,7 +1334,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * The device name to test.
 	 *
 	 * @returns {boolean}
-	 * Returns `true` if the given name is in the ignore pattern list,
+	 * Returns `true` if the given name is in the ignored pattern list,
 	 * else returns `false`.
 	 */
 	isIgnoredDevice: function(name) {
@@ -1565,7 +1565,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * Get IPv4 wan networks.
 	 *
 	 * This function looks up all networks having a default `0.0.0.0/0` route
-	 * and returns them as array.
+	 * and returns them as an array.
 	 *
 	 * @returns {Promise<Array<LuCI.network.Protocol>>}
 	 * Returns a promise resolving to an array of `Protocol` subclass
@@ -1590,7 +1590,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * Get IPv6 wan networks.
 	 *
 	 * This function looks up all networks having a default `::/0` route
-	 * and returns them as array.
+	 * and returns them as an array.
 	 *
 	 * @returns {Promise<Array<LuCI.network.Protocol>>}
 	 * Returns a promise resolving to an array of `Protocol` subclass
@@ -1766,7 +1766,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * class instance describing the found hosts.
 	 *
 	 * @returns {Promise<LuCI.network.Hosts>}
-	 * Returns a `Hosts` instance describing host known on the system.
+	 * Returns a `Hosts` instance describing a host known on the system.
 	 */
 	getHostHints: function() {
 		return initNetworkState().then(function() {
@@ -1983,7 +1983,7 @@ Hosts = baseclass.extend(/** @lends LuCI.network.Hosts.prototype */ {
  * @hideconstructor
  * @classdesc
  *
- * The `Network.Protocol` class serves as base for protocol specific
+ * The `Network.Protocol` class serves as the base for protocol-specific
  * subclasses which describe logical UCI networks defined by `config
  * interface` sections in `/etc/config/network`.
  */
@@ -2137,7 +2137,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 * until the lease expires.
 	 *
 	 * @returns {number}
-	 * Returns the amount of seconds until the lease expires or `-1`
+	 * Returns the number of seconds until the lease expires or `-1`
 	 * if it isn't applicable to the associated protocol.
 	 */
 	getExpiry: function() {
@@ -2480,7 +2480,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 * The name of the interface to be created.
 	 *
 	 * @returns {Promise<void>}
-	 * Returns a promise resolving if new interface is creatable, else
+	 * Returns a promise resolving if a new interface is creatable, else
 	 * rejects with an error message string.
 	 */
 	isCreateable: function(ifname) {
@@ -2509,7 +2509,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 * A "virtual" protocol is a protocol which spawns its own interfaces
 	 * on demand instead of using existing physical interfaces.
 	 *
-	 * Examples for virtual protocols are `6in4` which `gre` spawn tunnel
+	 * Examples for virtual protocols are `6in4` which `gre` spawn a tunnel
 	 * network device on startup, examples for non-virtual protocols are
 	 * `dhcp` or `static` which apply IP configuration to existing interfaces.
 	 *
@@ -2547,8 +2547,8 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	/**
 	 * Checks whether this logical interface is dynamic.
 	 *
-	 * A dynamic interface is an interface which has been created at runtime,
-	 * e.g. as sub-interface of another interface, but which is not backed by
+	 * A dynamic interface is an interface that has been created at runtime.
+	 * E.g. as a sub-interface of another interface, but which is not backed by
 	 * any user configuration. Such dynamic interfaces cannot be edited but
 	 * only brought down or restarted.
 	 *
@@ -3143,10 +3143,10 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 	},
 
 	/**
-	 * Get the amount of transmitted bytes.
+	 * Get the number of transmitted bytes.
 	 *
 	 * @returns {number}
-	 * Returns the amount of bytes transmitted by the network device.
+	 * Returns the number of bytes transmitted by the network device.
 	 */
 	getTXBytes: function() {
 		var stat = this._devstate('stats');
@@ -3154,10 +3154,10 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 	},
 
 	/**
-	 * Get the amount of received bytes.
+	 * Get the number of received bytes.
 	 *
 	 * @returns {number}
-	 * Returns the amount of bytes received by the network device.
+	 * Returns the number of bytes received by the network device.
 	 */
 	getRXBytes: function() {
 		var stat = this._devstate('stats');
@@ -3165,10 +3165,10 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 	},
 
 	/**
-	 * Get the amount of transmitted packets.
+	 * Get the number of transmitted packets.
 	 *
 	 * @returns {number}
-	 * Returns the amount of packets transmitted by the network device.
+	 * Returns the number of packets transmitted by the network device.
 	 */
 	getTXPackets: function() {
 		var stat = this._devstate('stats');
@@ -3176,10 +3176,10 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 	},
 
 	/**
-	 * Get the amount of received packets.
+	 * Get the number of received packets.
 	 *
 	 * @returns {number}
-	 * Returns the amount of packets received by the network device.
+	 * Returns the number of packets received by the network device.
 	 */
 	getRXPackets: function() {
 		var stat = this._devstate('stats');
@@ -3382,7 +3382,7 @@ WifiDevice = baseclass.extend(/** @lends LuCI.network.WifiDevice.prototype */ {
 	 *
 	 * @returns {string}
 	 * Returns the UCI section name (e.g. `radio0`) of the corresponding
-	 * radio configuration which also serves as unique logical identifier
+	 * radio configuration, which also serves as a unique logical identifier
 	 * for the wireless phy.
 	 */
 	getName: function() {
@@ -3983,11 +3983,11 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * supported by the driver.
 	 *
 	 * @property {number} inactive
-	 * The amount of milliseconds the peer has been inactive, e.g. due
+	 * The number of milliseconds the peer has been inactive, e.g. due
 	 * to power-saving.
 	 *
 	 * @property {number} connected_time
-	 * The amount of milliseconds the peer is associated to this network.
+	 * The number of milliseconds the peer is associated to this network.
 	 *
 	 * @property {number} [thr]
 	 * The estimated throughput of the peer, May be `0` or absent if not
@@ -4080,22 +4080,22 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * @memberof LuCI.network
 	 *
 	 * @property {number} [drop_misc]
-	 * The amount of received misc. packages that have been dropped, e.g.
+	 * The number of received misc. packages that have been dropped, e.g.
 	 * due to corruption or missing authentication. Only applicable to
 	 * receiving rates.
 	 *
 	 * @property {number} packets
-	 * The amount of packets that have been received or sent.
+	 * The number of packets that have been received or sent.
 	 *
 	 * @property {number} bytes
-	 * The amount of bytes that have been received or sent.
+	 * The number of bytes that have been received or sent.
 	 *
 	 * @property {number} [failed]
-	 * The amount of failed transmission attempts. Only applicable to
+	 * The number of failed transmission attempts. Only applicable to
 	 * transmit rates.
 	 *
 	 * @property {number} [retries]
-	 * The amount of retried transmissions. Only applicable to transmit
+	 * The number of retried transmissions. Only applicable to transmit
 	 * rates.
 	 *
 	 * @property {boolean} is_ht
@@ -4118,7 +4118,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * Specifies whether the transmission rate used 40MHz wide channel.
 	 * Only applicable to HT or VHT rates.
 	 *
-	 * Note: this option exists for backwards compatibility only and its
+	 * Note: this option exists for backwards compatibility only, and its
 	 * use is discouraged. The `mhz` field should be used instead to
 	 * determine the channel width.
 	 *
@@ -4145,8 +4145,8 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * Specifies whether this rate is an EHT (IEEE 802.11be) rate.
 	 * 
 	 * @property {number} [eht_gi]
-	 * Specifies whether the guard interval used for the transmission.
-	 * Only applicable to  EHT rates.
+	 * Specifies whether the guard interval is used for the transmission.
+	 * Only applicable to EHT rates.
 	 *
 	 * @property {number} [eht_dcm]
 	 * Specifies whether dual concurrent modulation is used for the transmission.
@@ -4216,11 +4216,11 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	},
 
 	/**
-	 * Query the current average bit-rate of all peers associated to this
+	 * Query the current average bit-rate of all peers associated with this
 	 * wireless network.
 	 *
 	 * @returns {null|number}
-	 * Returns the average bit rate among all peers associated to the network
+	 * Returns the average bit rate among all peers associated with the network
 	 * as reported by `ubus` runtime information or `null` if the information
 	 * is not available.
 	 */
@@ -4449,7 +4449,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * with. Default is `1` which corresponds to `Unspecified reason`.
 	 *
 	 * @param {number} [ban_time=0]
-	 * Specifies the amount of milliseconds to ban the client from
+	 * Specifies the number of milliseconds to ban the client from
 	 * reconnecting. By default, no ban time is set which allows the client
 	 * to re-associate / reauthenticate immediately.
 	 *


### PR DESCRIPTION
The `depends()` has two overloaded versions:
* `depends(field, value)` i.e. with two args
* `depends({'field1': 'val1', 'field2': 'val2'})` i.e. with one `Object` arg
The JsDoc doesn't allow to describe overloading but we can show that the second arg is optional. Then this calls of `depends({})` won't be reported by IDE as wrong.

Additionally I added some fixes typos and missing articles because IDE reports a lot about them and this distracts from code.