### PR TITLE
[WIP,RFC] get odhcpd leases via ubus

### DIFF
--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -1972,10 +1972,11 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
 			if (lease->iaid)
 				blobmsg_add_string(&blob, "iaid", lease->iaid);
 
-			inet_ntop(lease->af, &lease->addr[0].in6, s, sizeof(s));
-			blobmsg_add_string(&blob, (af == AF_INET) ? "ipaddr" : "ip6addr", s);
+			if (lease->af == AF_INET) {
+				inet_ntop(lease->af, &lease->addr[0].in, s, sizeof(s));
+				blobmsg_add_string(&blob, "ipaddr", s);
 
-			if (af == AF_INET6) {
+			} else if (lease->af == AF_INET6) {
 				a2 = blobmsg_open_array(&blob, "ip6addrs");
 
 				for (n = 0; n < lease->n_addr; n++) {

--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -1979,8 +1979,10 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
 					if (lease->mask != 128)
 						continue;
 
+					t = blobmsg_open_table(&blob, NULL);
 					inet_ntop(lease->af, &lease->addr[n].in6, s, sizeof(s));
-					blobmsg_add_string(&blob, NULL, s);
+					blobmsg_add_string(&blob, "address", s);
+					blobmsg_close_table(&blob, t);
 				}
 				blobmsg_close_array(&blob, a2);
 

--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -1913,7 +1913,7 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
                          struct ubus_request_data *req, const char *method,
                          struct blob_attr *msg)
 {
-	char s[INET6_ADDRSTRLEN + strlen("/128")];
+	char s[INET6_ADDRSTRLEN];
 	struct blob_attr *tb[__RPC_L_MAX];
 	struct lease_entry *lease;
 	int af, family = 0;
@@ -1978,11 +1978,10 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
 				a2 = blobmsg_open_array(&blob, "ipv6-addr");
 
 				for (n = 0; n < lease->n_addr; n++) {
+					if (lease->mask != 128)
+						continue;
+
 					inet_ntop(lease->af, &lease->addr[n].in6, s, sizeof(s));
-
-					l = strlen(s);
-					snprintf(s + l, sizeof(s) - l, "/%hhu", lease->mask);
-
 					blobmsg_add_string(&blob, NULL, s);
 				}
 

--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -352,7 +352,7 @@ static struct {
 struct lease_entry {
 	int af, n_addr;
 	char buf[512];
-	int32_t expire;
+	uint32_t valid;
 	struct ether_addr mac;
 	char *hostname;
 	char *duid;
@@ -521,11 +521,11 @@ lease_next(void)
 				n = strtol(p, NULL, 10);
 
 				if (n > lease_state.now)
-					e.expire = n - lease_state.now;
+					e.valid = n - lease_state.now;
 				else if (n >= 0)
-					e.expire = 0;
+					e.valid = 0;
 				else
-					e.expire = -1;
+					e.valid = UINT32_MAX;
 
 				strtok(NULL, " \t\n"); /* id */
 
@@ -566,11 +566,11 @@ lease_next(void)
 				n = strtol(p, NULL, 10);
 
 				if (n > lease_state.now)
-					e.expire = n - lease_state.now;
+					e.valid = n - lease_state.now;
 				else if (n > 0)
-					e.expire = 0;
+					e.valid = 0;
 				else
-					e.expire = -1;
+					e.valid = UINT32_MAX;
 
 				p = strtok(NULL, " \t\n");
 
@@ -1952,10 +1952,7 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
 
 			o = blobmsg_open_table(&blob, NULL);
 
-			if (lease->expire == -1)
-				blobmsg_add_u8(&blob, "expires", 0);
-			else
-				blobmsg_add_u32(&blob, "expires", lease->expire);
+			blobmsg_add_u32(&blob, "valid", lease->valid);
 
 			if (lease->hostname)
 				blobmsg_add_string(&blob, "hostname", lease->hostname);

--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -1974,7 +1974,7 @@ rpc_luci_get_dhcp_leases(struct ubus_context *ctx, struct ubus_object *obj,
 				blobmsg_add_string(&blob, "ipaddr", s);
 
 			} else if (lease->af == AF_INET6) {
-				a2 = blobmsg_open_array(&blob, "ip6addrs");
+				a2 = blobmsg_open_array(&blob, "ipv6-addr");
 
 				for (n = 0; n < lease->n_addr; n++) {
 					inet_ntop(lease->af, &lease->addr[n].in6, s, sizeof(s));

--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -1849,9 +1849,6 @@ rpc_luci_get_duid_hints(struct ubus_context *ctx, struct ubus_object *obj,
 
 		o = blobmsg_open_table(&blob, lease->duid);
 
-		inet_ntop(AF_INET6, &lease->addr[0].in6, s, sizeof(s));
-		blobmsg_add_string(&blob, "ip6addr", s);
-
 		a = blobmsg_open_array(&blob, "ip6addrs");
 
 		for (n = 0; n < lease->n_addr; n++) {

--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/20_lan.js
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/20_lan.js
@@ -91,7 +91,7 @@ return baseclass.extend({
 
 		const devices = [];
 		leases.map(lease => {
-			devices[lease.expires] = {
+			devices[lease.valid] = {
 				hostname: lease.hostname || '?',
 				ipv4: lease.ipaddr || '-',
 				macaddr: lease.macaddr || '00:00:00:00:00:00',

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1516,7 +1516,7 @@ return view.extend({
 								    name = hint ? (hint.name || L.toArray(hint.ipaddrs || hint.ipv4)[0] || L.toArray(hint.ip6addrs || hint.ipv6)[0]) : null,
 								    host = null;
 
-								if (name && lease.hostname && lease.hostname != name && lease.ip6addr != name)
+								if (name && lease.hostname && lease.hostname != name && (!lease.ip6addrs || !lease.ip6addrs[0] || lease.ip6addrs[0] != name))
 									host = '%s (%s)'.format(lease.hostname, name);
 								else if (lease.hostname)
 									host = lease.hostname;
@@ -1525,7 +1525,7 @@ return view.extend({
 
 								return [
 									host || '-',
-									lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
+									lease.ip6addrs ? lease.ip6addrs.join('<br />') : '-',
 									lease.duid,
 									lease.iaid,
 									exp

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1411,7 +1411,7 @@ return view.extend({
 			_('The DHCPv6-DUID (DHCP unique identifier) of this host.'));
 		so.datatype = 'and(rangelength(20,36),hexstring)';
 		Object.keys(duids).forEach(function(duid) {
-			so.value(duid, '%s (%s)'.format(duid, duids[duid].hostname || duids[duid].macaddr || duids[duid].ip6addr || '?'));
+			so.value(duid, '%s (%s)'.format(duid, duids[duid].hostname || duids[duid].macaddr || ((duids[duid].ip6addrs && duids[duid].ip6addrs[0]) ? duids[duid].ip6addrs[0] : '?')));
 		});
 
 		so = ss.option(form.Value, 'hostid',

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1516,7 +1516,7 @@ return view.extend({
 								    name = hint ? (hint.name || L.toArray(hint.ipaddrs || hint.ipv4)[0] || L.toArray(hint.ip6addrs || hint.ipv6)[0]) : null,
 								    host = null;
 
-								if (name && lease.hostname && lease.hostname != name && (!lease.ip6addrs || !lease.ip6addrs[0] || lease.ip6addrs[0] != name))
+								if (name && lease.hostname && lease.hostname != name && (!lease['ipv6-addr'] || !lease['ipv6-addr'] || lease['ipv6-addr'][0] != name))
 									host = '%s (%s)'.format(lease.hostname, name);
 								else if (lease.hostname)
 									host = lease.hostname;
@@ -1525,7 +1525,7 @@ return view.extend({
 
 								return [
 									host || '-',
-									lease.ip6addrs ? lease.ip6addrs.join('<br />') : '-',
+									lease['ipv6-addr'] ? lease['ipv6-addr'].join('<br />') : '-',
 									lease.duid,
 									lease.iaid,
 									exp

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1523,9 +1523,19 @@ return view.extend({
 								else if (name)
 									host = name;
 
+								var addr_str = '-';
+								if (lease['ipv6-addr'] && lease['ipv6-addr'].length > 0) {
+									addr_str = lease['ipv6-addr'].join('<br />');
+								} else if (lease['ipv6-prefix'] && lease['ipv6-prefix'].length > 0) {
+									var prefixes = [];
+									for (const prefix of lease['ipv6-prefix'])
+										prefixes.push(prefix['address'] + '/' + prefix['prefix-length']);
+									addr_str = prefixes.join('<br />');
+								}
+
 								return [
 									host || '-',
-									lease['ipv6-addr'] ? lease['ipv6-addr'].join('<br />') : '-',
+									addr_str,
 									lease.duid,
 									lease.iaid ? lease.iaid.toString() : '?',
 									exp

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1516,7 +1516,9 @@ return view.extend({
 								    name = hint ? (hint.name || L.toArray(hint.ipaddrs || hint.ipv4)[0] || L.toArray(hint.ip6addrs || hint.ipv6)[0]) : null,
 								    host = null;
 
-								if (name && lease.hostname && lease.hostname != name && (!lease['ipv6-addr'] || !lease['ipv6-addr'] || lease['ipv6-addr'][0] != name))
+								var hint_addr = (lease['ipv6-addr'] && lease['ipv6-addr'].length > 0) ? lease['ipv6-addr'][0]['address'] : null;
+
+								if (name && lease.hostname && lease.hostname != name && hint_addr != name)
 									host = '%s (%s)'.format(lease.hostname, name);
 								else if (lease.hostname)
 									host = lease.hostname;
@@ -1525,7 +1527,10 @@ return view.extend({
 
 								var addr_str = '-';
 								if (lease['ipv6-addr'] && lease['ipv6-addr'].length > 0) {
-									addr_str = lease['ipv6-addr'].join('<br />');
+									var addrs = [];
+									for (const addr of lease['ipv6-addr'])
+										addrs.push(addr['address']);
+									addr_str = addrs.join('<br />');
 								} else if (lease['ipv6-prefix'] && lease['ipv6-prefix'].length > 0) {
 									var prefixes = [];
 									for (const prefix of lease['ipv6-prefix'])

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1468,12 +1468,12 @@ return view.extend({
 							var exp;
 							var vendor;
 
-							if (lease.expires === false)
+							if (lease.valid == 0xffffffff)
 								exp = E('em', _('unlimited'));
-							else if (lease.expires <= 0)
+							else if (lease.valid <= 0)
 								exp = E('em', _('expired'));
 							else
-								exp = '%t'.format(lease.expires);
+								exp = '%t'.format(lease.valid);
 
 							for (let mac in macdata) {
 								if (mac.toUpperCase() === lease.macaddr) {
@@ -1505,12 +1505,12 @@ return view.extend({
 							leases6.map(function(lease) {
 								var exp;
 
-								if (lease.expires === false)
+								if (lease.valid == 0xffffffff)
 									exp = E('em', _('unlimited'));
-								else if (lease.expires <= 0)
+								else if (lease.valid <= 0)
 									exp = E('em', _('expired'));
 								else
-									exp = '%t'.format(lease.expires);
+									exp = '%t'.format(lease.valid);
 
 								var hint = lease.macaddr ? hosts[lease.macaddr] : null,
 								    name = hint ? (hint.name || L.toArray(hint.ipaddrs || hint.ipv4)[0] || L.toArray(hint.ip6addrs || hint.ipv6)[0]) : null,

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1527,7 +1527,7 @@ return view.extend({
 									host || '-',
 									lease['ipv6-addr'] ? lease['ipv6-addr'].join('<br />') : '-',
 									lease.duid,
-									lease.iaid,
+									lease.iaid ? lease.iaid.toString() : '?',
 									exp
 								];
 							}),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -64,7 +64,7 @@ return baseclass.extend({
 		ev.currentTarget.blur();
 
 		var cfg = uci.add('dhcp', 'host'),
-		    ip6arr = lease['ipv6-addr'][0] ? validation.parseIPv6(lease['ipv6-addr'][0]) : null;
+		    ip6arr = lease['ipv6-addr'][0]['address'] ? validation.parseIPv6(lease['ipv6-addr'][0]['address']) : null;
 
 		uci.set('dhcp', cfg, 'name', lease.hostname);
 		uci.set('dhcp', cfg, 'duid', lease.duid.toUpperCase());
@@ -179,7 +179,9 @@ return baseclass.extend({
 			var hint = lease.macaddr ? machints.filter(function(h) { return h[0] == lease.macaddr })[0] : null,
 			    host = null;
 
-			if (hint && lease.hostname && lease.hostname != hint[1] && (!lease['ipv6-addr'] || !lease['ipv6-addr'][0] || lease['ipv6-addr'][0] != hint[1]))
+			var hint_addr = (lease['ipv6-addr'] && lease['ipv6-addr'].length > 0) ? lease['ipv6-addr'][0]['address'] : null;
+
+			if (hint && lease.hostname && lease.hostname != hint[1] && hint_addr != hint[1])
 				host = '%s (%s)'.format(lease.hostname, hint[1]);
 			else if (lease.hostname)
 				host = lease.hostname;
@@ -188,7 +190,10 @@ return baseclass.extend({
 
 			var addr_str = '-';
 			if (lease['ipv6-addr'] && lease['ipv6-addr'].length > 0) {
-				addr_str = lease['ipv6-addr'].join('<br />');
+				var addrs = [];
+				for (const addr of lease['ipv6-addr'])
+					addrs.push(addr['address']);
+				addr_str = addrs.join('<br />');
 			} else if (lease['ipv6-prefix'] && lease['ipv6-prefix'].length > 0) {
 				var prefixes = [];
 				for (const prefix of lease['ipv6-prefix'])
@@ -204,7 +209,7 @@ return baseclass.extend({
 				exp
 			];
 
-			if (!isReadonlyView && lease.duid != null && lease['ipv6-addr']) {
+			if (!isReadonlyView && lease.duid != null && hint_addr != null) {
 				var duid = lease.duid.toUpperCase();
 				rows.push(E('button', {
 					'class': 'cbi-button cbi-button-apply',

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -179,7 +179,7 @@ return baseclass.extend({
 			var hint = lease.macaddr ? machints.filter(function(h) { return h[0] == lease.macaddr })[0] : null,
 			    host = null;
 
-			if (hint && lease.hostname && lease.hostname != hint[1] && lease.ip6addr != hint[1])
+			if (hint && lease.hostname && lease.hostname != hint[1] && (!lease.ip6addrs || !lease.ip6addrs[0] || lease.ip6addrs[0] != hint[1]))
 				host = '%s (%s)'.format(lease.hostname, hint[1]);
 			else if (lease.hostname)
 				host = lease.hostname;
@@ -188,13 +188,13 @@ return baseclass.extend({
 
 			rows = [
 				host || '-',
-				lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
+				lease.ip6addrs ? lease.ip6addrs.join('<br />') : '-',
 				lease.duid,
 				lease.iaid,
 				exp
 			];
 
-			if (!isReadonlyView && lease.duid != null) {
+			if (!isReadonlyView && lease.duid != null && lease.ip6addrs) {
 				var duid = lease.duid.toUpperCase();
 				rows.push(E('button', {
 					'class': 'cbi-button cbi-button-apply',

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -186,9 +186,19 @@ return baseclass.extend({
 			else if (hint)
 				host = hint[1];
 
+			var addr_str = '-';
+			if (lease['ipv6-addr'] && lease['ipv6-addr'].length > 0) {
+				addr_str = lease['ipv6-addr'].join('<br />');
+			} else if (lease['ipv6-prefix'] && lease['ipv6-prefix'].length > 0) {
+				var prefixes = [];
+				for (const prefix of lease['ipv6-prefix'])
+					prefixes.push(prefix['address'] + '/' + prefix['prefix-length']);
+				addr_str = prefixes.join('<br />');
+			}
+
 			rows = [
 				host || '-',
-				lease['ipv6-addr'] ? lease['ipv6-addr'].join('<br />') : '-',
+				addr_str,
 				lease.duid,
 				lease.iaid ? lease.iaid.toString() : '?',
 				exp

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -190,7 +190,7 @@ return baseclass.extend({
 				host || '-',
 				lease['ipv6-addr'] ? lease['ipv6-addr'].join('<br />') : '-',
 				lease.duid,
-				lease.iaid,
+				lease.iaid ? lease.iaid.toString() : '?',
 				exp
 			];
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -64,7 +64,7 @@ return baseclass.extend({
 		ev.currentTarget.blur();
 
 		var cfg = uci.add('dhcp', 'host'),
-		    ip6arr = lease.ip6addrs[0] ? validation.parseIPv6(lease.ip6addrs[0]) : null;
+		    ip6arr = lease['ipv6-addr'][0] ? validation.parseIPv6(lease['ipv6-addr'][0]) : null;
 
 		uci.set('dhcp', cfg, 'name', lease.hostname);
 		uci.set('dhcp', cfg, 'duid', lease.duid.toUpperCase());
@@ -179,7 +179,7 @@ return baseclass.extend({
 			var hint = lease.macaddr ? machints.filter(function(h) { return h[0] == lease.macaddr })[0] : null,
 			    host = null;
 
-			if (hint && lease.hostname && lease.hostname != hint[1] && (!lease.ip6addrs || !lease.ip6addrs[0] || lease.ip6addrs[0] != hint[1]))
+			if (hint && lease.hostname && lease.hostname != hint[1] && (!lease['ipv6-addr'] || !lease['ipv6-addr'][0] || lease['ipv6-addr'][0] != hint[1]))
 				host = '%s (%s)'.format(lease.hostname, hint[1]);
 			else if (lease.hostname)
 				host = lease.hostname;
@@ -188,13 +188,13 @@ return baseclass.extend({
 
 			rows = [
 				host || '-',
-				lease.ip6addrs ? lease.ip6addrs.join('<br />') : '-',
+				lease['ipv6-addr'] ? lease['ipv6-addr'].join('<br />') : '-',
 				lease.duid,
 				lease.iaid,
 				exp
 			];
 
-			if (!isReadonlyView && lease.duid != null && lease.ip6addrs) {
+			if (!isReadonlyView && lease.duid != null && lease['ipv6-addr']) {
 				var duid = lease.duid.toUpperCase();
 				rows.push(E('button', {
 					'class': 'cbi-button cbi-button-apply',

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -115,12 +115,12 @@ return baseclass.extend({
 			var exp, rows;
 			var vendor;
 
-			if (lease.expires === false)
+			if (lease.valid == 0xffffffff)
 				exp = E('em', _('unlimited'));
-			else if (lease.expires <= 0)
+			else if (lease.valid <= 0)
 				exp = E('em', _('expired'));
 			else
-				exp = '%t'.format(lease.expires);
+				exp = '%t'.format(lease.valid);
 
 			var hint = lease.macaddr ? machints.filter(function(h) { return h[0] == lease.macaddr })[0] : null,
 			    host = null;
@@ -169,12 +169,12 @@ return baseclass.extend({
 		cbi_update_table(table6, leases6.map(L.bind(function(lease) {
 			var exp, rows;
 
-			if (lease.expires === false)
+			if (lease.valid == 0xffffffff)
 				exp = E('em', _('unlimited'));
-			else if (lease.expires <= 0)
+			else if (lease.valid <= 0)
 				exp = E('em', _('expired'));
 			else
-				exp = '%t'.format(lease.expires);
+				exp = '%t'.format(lease.valid);
 
 			var hint = lease.macaddr ? machints.filter(function(h) { return h[0] == lease.macaddr })[0] : null,
 			    host = null;

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -8,6 +8,7 @@
 var callLuciDHCPLeases = rpc.declare({
 	object: 'luci-rpc',
 	method: 'getDHCPLeases',
+	params: [ 'family' ],
 	expect: { '': {} }
 });
 
@@ -33,7 +34,8 @@ return baseclass.extend({
 			checkUfpInstalled('/usr/sbin/ufpd')
 		]).then(data => {
 			var promises = [
-				callLuciDHCPLeases(),
+				callLuciDHCPLeases(4),
+				callLuciDHCPLeases(6),
 				network.getHostHints(),
 				data[0].type === 'file' ? callUfpList() : null,
 				L.resolveDefault(uci.load('dhcp'))
@@ -79,10 +81,10 @@ return baseclass.extend({
 
 	renderLeases: function(data) {
 		var leases = Array.isArray(data[0].dhcp_leases) ? data[0].dhcp_leases : [],
-		    leases6 = Array.isArray(data[0].dhcp6_leases) ? data[0].dhcp6_leases : [],
-		    machints = data[1].getMACHints(false),
+		    leases6 = Array.isArray(data[1].dhcp6_leases) ? data[1].dhcp6_leases : [],
+		    machints = data[2].getMACHints(false),
 		    hosts = uci.sections('dhcp', 'host'),
-		    macaddr = data[2],
+		    macaddr = data[3],
 		    isReadonlyView = !L.hasViewPermission();
 
 		for (var i = 0; i < hosts.length; i++) {


### PR DESCRIPTION
This is just a WIP/RFC so far, but right now `rpcd-mod-luci` digs around in the lease files created by `dnsmasq` and `odhcpd` (and it does so twice for each time the leases are updated in the web view).

So, I've wanted for a long time to get `rpcd-mod-luci` to communicate with `odhcpd` via `ubus` (no plans to do something similar for `dnsmasq`) to get current leases.

This PR is my first rough stab at it, and I'd appreciate some feedback before I spend any more time on it. Does it make sense?
