### PR TITLE
protocols: l2tp: add option hostname

### DIFF
--- a/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/l2tp.js
+++ b/protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/l2tp.js
@@ -57,5 +57,7 @@ return network.registerProtocol('l2tp', {
 		o = s.taboption('advanced', form.Value, 'mtu', _('Override MTU'));
 		o.placeholder = dev ? (dev.getMTU() || '1500') : '1500';
 		o.datatype    = 'max(9200)';
+
+		o = s.taboption('advanced', form.Value, 'hostname', _('L2TP Hostname'));
 	}
 });


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (lantiq/xrx200, 24.10, firefox 140.3.1esr) :white_check_mark:
- [x] Mention: @systemcrash 
- [x] Depends on: openwrt/packages#27612
- [x] Description: This adds the possibility to set our own L2TP hostname in the advanced tab. It's needed if the peer only allows certain hostnames to connect.
