### PR TITLE
luci-mod-status: Fix legacy rule detection false positive

### DIFF
--- a/modules/luci-mod-status/Makefile
+++ b/modules/luci-mod-status/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Status Pages
 LUCI_DEPENDS:=+luci-base +libiwinfo +rpcd-mod-iwinfo
 
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_BUILD_DEPENDS:=iwinfo
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
@@ -146,8 +146,16 @@ return view.extend({
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(fs.exec_direct('/usr/sbin/nft', [ '--terse', '--json', 'list', 'ruleset' ], 'json'), {}),
-			L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-save'), ''),
-			L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-save'), '')
+			fs.stat('/usr/sbin/iptables-legacy-save').then(function(stat) {
+                return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-legacy-save'), '');
+            }).catch(function(err) {
+                return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-save'), '');
+            }),
+            fs.stat('/usr/sbin/ip6tables-legacy-save').then(function(stat) {
+                return L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-legacy-save'), '');
+            }).catch(function(err) {
+                return L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-save'), '');
+            })
 		]);
 	},
 


### PR DESCRIPTION
Refine legacy rule detection to avoid false positives generated by the iptables-nft compatibility layer on fw4 systems.

The logic now prioritizes `iptables-legacy-save` for accuracy, while retaining `iptables-save` as a fallback to ensure backward compatibility with fw3.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: aarch64, OpenWrt 23.05 / Snapshot (ImmortalWrt), Chromium-based(Edge) browser: 141
- [x] \( Preferred ) Mention: @jow- the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

<img width="719" height="188" alt="{0893D638-5A58-45F1-81E2-0C2DA843F54D}" src="https://github.com/user-attachments/assets/c49bc8cc-3cdb-4afe-8a00-1b37e9c21ffd" />

Problem:

On systems running fw4 (nftables), the "Legacy rules detected" warning is incorrectly triggered by nftables-native applications like Tailscale, which create their own firewall chains.

The current implementation in the nftables/iptables status view calls the generic iptables-save command. On a fw4 system with the iptables-nft compatibility layer, this command reads the current nftables ruleset and translates it into the old iptables format.

The checkLegacyRules function's simple check (.match(/\n-A /)) sees these translated rules (e.g., -A INPUT -j ts-input) and incorrectly flags them as "legacy rules," causing a persistent and confusing false positive warning for users.

Solution:

This commit refines the detection mechanism with a backward-compatible approach. The load() function now dynamically checks for the existence of iptables-legacy-save before executing a command.

If iptables-legacy-save exists (which is typical for a fw4 system in a mixed environment or with the legacy package installed), it is used to directly query the legacy ip_tables kernel subsystem. This provides a precise detection of actual legacy rules and is unaffected by the iptables-nft compatibility layer, thus fixing the false positive warning.

 If iptables-legacy-save does not exist, the code gracefully falls back to the original behavior of calling the generic iptables-save. This ensures full compatibility with older fw3 systems that only have this command available.

This dynamic check makes the warning accurate and useful again on modern fw4 systems without regressing functionality on older fw3 installations.