### PR TITLE
[24.10] luci-app-adblock-fast: update to 1.2.0-r20

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=10
+PKG_RELEASE:=20
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-adblock-fast/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.3
Run tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.3

Description:
* sync version with principal package


(cherry picked from commit b9c9b470ec02749e90113a46f93005e5e4ad20db)
