### PR TITLE
collections/luci-nginx: reorganize dependencies into sorted single lines

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -12,9 +12,15 @@ LUCI_BASENAME:=nginx
 LUCI_TITLE:=LuCI interface with Nginx as Webserver
 LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
 LUCI_DEPENDS:= \
-	+nginx +nginx-mod-luci +luci-mod-admin-full +luci-theme-bootstrap \
-	+luci-app-firewall +luci-app-package-manager +luci-proto-ppp +IPV6:luci-proto-ipv6 \
-	+rpcd-mod-rrdns
+	+IPV6:luci-proto-ipv6 \
+	+luci-app-firewall \
+	+luci-app-package-manager \
+	+luci-mod-admin-full \
+	+luci-proto-ppp \
+	+luci-theme-bootstrap \
+	+nginx \
+	+nginx-mod-luci \
+	+rpcd-mod-rrdns \
 
 PKG_LICENSE:=Apache-2.0
 PKG_PROVIDES:=luci-ssl-nginx


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: local build machine menuconfig selection works as intended by change :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Refers to discussion in: openwrt/luci#7985
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description:
  Just splits the dependencies in single lines and sorts them alphabetically as all the other meta packages have it already.