### PR TITLE
luci-mod-network: add global DUID cfg option

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1659,6 +1659,11 @@ return view.extend({
 			_('This prefix is randomly generated at first install.'));
 		o.datatype = 'cidr6';
 
+		o = s.option(form.Value, 'dhcp_default_duid', _('Default DUID'),
+			_('The default <abbr title="DHCP Unique Identifier">DUID</abbr> for this device, used when acting as a DHCP server or client. The client identifier can be overridden on a per-interface basis.') + '<br />' +
+			_('This identifier is randomly generated the first time the device is booted.'));
+		o.datatype = 'and(rangelength(6,260),hexstring)';
+
 		const l3mdevhelp1 = _('%s services running on this device in the default VRF context (ie., not bound to any VRF device) shall work across all VRF domains.');
 		const l3mdevhelp2 = _('Off means VRF traffic will be handled exclusively by sockets bound to VRFs.');
 


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (NanoPi R6S, OpenWrt master, Chrome) :white_check_mark:
- [x] \( Optional ) Depends on: https://github.com/openwrt/openwrt/pull/20359
- [x] Description: (describe the changes proposed in this PR)

This exposes the default DHCP DUID config option in the LuCI interface.

For reference, see:
https://github.com/openwrt/openwrt/pull/20359
https://github.com/openwrt/odhcpd/pull/274