### PR TITLE
luci-mod-network: add carrier info to interface page

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -70,9 +70,11 @@ function render_status(node, ifc, with_device) {
 	const changecount = with_device ? 0 : count_changes(ifc.getName());
 	const maindev = ifc.getL3Device() ?? ifc.getDevice();
 	const macaddr = maindev ? maindev.getMAC() : null;
+	const carrier = maindev ? maindev.getCarrier(): null;
 	const cond00 = !changecount && !ifc.isDynamic() && !ifc.isAlias();
 	const cond01 = cond00 && macaddr;
 	const cond02 = cond00 && maindev;
+	const cond03 = cond00 && carrier;
 
 	function addEntries(label, array) {
 		return Array.isArray(array) ? array.flatMap((item) => [label, item]) : [label, null];
@@ -81,6 +83,7 @@ function render_status(node, ifc, with_device) {
 	return L.itemlist(node, [
 		_('Protocol'), with_device ? null : (desc || '?'),
 		_('Device'), with_device ? (maindev ? maindev.getShortName() : E('em', _('Not present'))) : null,
+		_('Carrier'), (cond03) ? _('Present') : _('Absent'),
 		_('Uptime'), (!changecount && ifc.isUp()) ? '%t'.format(ifc.getUptime()) : null,
 		_('MAC'), (cond01) ? macaddr : null,
 		_('RX'), (cond02) ? '%.2mB (%d %s)'.format(maindev.getRXBytes(), maindev.getRXPackets(), _('Pkts.')) : null,


### PR DESCRIPTION
Currently the LuCI does not show whether a carrier is available on the interface or not. On ethernet devices the carrier indicates whether a cable is plugged in or not. I repeatedly encounter the issue of someone accidentally touching the cable on the router, which then is not plugged in correctly. This makes debugging easier. This commit adds this functionality.

Cabel connected:
<img width="1152" height="131" alt="carrier" src="https://github.com/user-attachments/assets/54e93381-4a71-4250-8c30-ca1c95a5b0dd" />

Cabel disconnected:
<img width="1238" height="99" alt="carrier" src="https://github.com/user-attachments/assets/f1c80f6c-8a1d-473e-8e04-1cbe0a067e7f" />



- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
