### PR TITLE
luci-app-watchcat: allow multiple IP addresses in ping hosts field

### DIFF
--- a/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
+++ b/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
@@ -56,16 +56,6 @@ return view.extend({
 		o.depends({ mode: "restart_iface" });
 		o.depends({ mode: "run_script" });
 
-		o.load = function(section_id) {
-			return (String(this.map.data.get('watchcat', section_id, 'pinghosts') || '')
-			.trim().split(/\s+/).filter(Boolean))
-		}
-
-		o.write = function(section_id, formvalue) {
-			this.map.data.set('watchcat', section_id, 'pinghosts',
-			(formvalue || []).map(v => String(v).trim()).filter(Boolean).join(' '))
-		}
-
 		o = s.taboption('general', form.ListValue, 'addressfamily',
 				_('Address family for pinging the host'));
 		o.default = 'any';


### PR DESCRIPTION
The watchcat service backend already supports monitoring multiple IP addresses, but the LuCI web interface was blocking this functionality through its UI validation.

This PR fixes the input validation to accept space-separated IP addresses/hostnames instead of restricting users to a single entry.

**Changes**
- Changed datatype from 'host' to 'list(host)' in the ping hosts field
- Updated default value to show multiple IPs example: '8.8.8.8 1.1.1.1'

**Testing**
Users can now enter multiple monitoring targets like "8.8.8.8 1.1.1.1 google.com" in the Host To Check field. Each host in the list is validated individually.
This aligns the web interface capabilities with what the watchcat service actually supports.

<img width="573" height="562" alt="imagen" src="https://github.com/user-attachments/assets/e9e881ad-2332-4cc6-85f2-765099a7eee0" />

Depends on: https://github.com/openwrt/packages/pull/27756