### PR TITLE
luci-base, luci-app-firewall: enable range of MAC addresses

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/tools/firewall.js
@@ -516,8 +516,8 @@ return baseclass.extend({
 		const o = s.taboption(tab, this.CBIDynamicMultiValueList, name, label, description);
 
 		o.modalonly = true;
-		o.datatype = 'list(macaddr)';
-		o.placeholder = _('-- add MAC --');
+		o.datatype = 'list(neg(or(macaddr,macrange)))';
+		o.placeholder = _('-- add MAC or MAC range --');
 
 		L.sortedKeys(hosts).forEach(function(mac) {
 			o.value(mac, E([], [ mac, ' (', E('strong', {}, [

--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
@@ -378,7 +378,8 @@ return view.extend({
 		o.modalonly = true;
 		o.rmempty = true;
 
-		fwtool.addMACOption(s, 'advanced', 'src_mac', _('Source MAC address'), null, hosts);
+		fwtool.addMACOption(s, 'advanced', 'src_mac', _('Source MAC address (range)'),
+			_('Enter a MAC address or a range'), hosts);
 		fwtool.addIPOption(s, 'general', 'src_ip', _('Source address'), null, '', hosts, true);
 
 		o = s.taboption('general', form.Value, 'src_port', _('Source port'));

--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -770,6 +770,35 @@ const ValidatorFactory = baseclass.extend(/** @lends LuCI.validation.ValidatorFa
 				multicast ? _('valid multicast MAC address') : _('valid MAC address'));
 		},
 
+		macrange(multicast) {
+			const m = this.value.match(/^((?:[a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2})-((?:[a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2})$/);
+			let valid, mac1, mac2;
+
+			let tonumber = (mac) => {
+				const n = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+				return BigInt('0x' + n);
+			};
+
+			if (m == null)
+				return this.assert(false, multicast ? _('valid multicast MAC address range') : _('valid MAC address range'));
+
+			if (m[1]) {
+				mac1 = tonumber(m[1]);
+				valid = this.apply('macaddr', m[1], [multicast]);
+				if (!valid)
+					return this.assert(false, multicast ? _('valid multicast MAC address') : _('valid MAC address'));
+			}
+
+			if (m[2]) {
+				mac2 = tonumber(m[2]);
+				valid = this.apply('macaddr', m[2], [multicast]);
+				if (!valid)
+					return this.assert(false, multicast ? _('valid multicast MAC address') : _('valid MAC address'));
+			}
+
+			return this.assert(mac1 < mac2, multicast ? _('valid multicast MAC address range') : _('valid MAC address range'));
+		},
+
 		/**
 		 * Assert a valid hostname or IP address.
 		 * @function LuCI.validation.ValidatorFactory.types#host
@@ -1003,7 +1032,7 @@ const ValidatorFactory = baseclass.extend(/** @lends LuCI.validation.ValidatorFa
 			if (v == '.' || v == '..')
 				return this.assert(false, _('valid network device name, not "." or ".."'));
 
-			return this.assert(v.match(/^[^:\/%\s]{1,15}$/), _('valid network device name between 1 and 15 characters not containing ":", "/", "%" or spaces'));
+			return this.assert(v.match(/^[^:/%\s]{1,15}$/), _('valid network device name between 1 and 15 characters not containing ":", "/", "%" or spaces'));
 		},
 
 		/**


### PR DESCRIPTION
In order to handle a range of MAC addresses it seems to be useful being able to set it in luci.
Therefore these commits use the `src_mac` field to specify ranges like can be seen in the pictures.
Also negation can be used to exclude a certain range for being handled.

This PR depends on openwrt/firewall4#74

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86/64, openwrt-24.10, firefox) :white_check_mark:
- [x] Screenshot or mp4 of changes:

If a single MAC address is specified, it is validated by `macaddr` if a range is given it is validated by `macrange`
<img width="632" height="309" alt="Screenshot From 2025-10-17 11-14-10" src="https://github.com/user-attachments/assets/940abccb-d609-493a-9820-416a328647ed" />
invalid MAC address
<img width="618" height="272" alt="image" src="https://github.com/user-attachments/assets/fa0c34e3-e1be-48d6-8ab3-20eb3cc8bee0" />
valid MAC address
<img width="632" height="309" alt="Screenshot From 2025-10-17 11-17-00" src="https://github.com/user-attachments/assets/808c946b-45b2-4d77-97b1-728987f9d489" />
invalid range
<img width="627" height="263" alt="image" src="https://github.com/user-attachments/assets/e9eb8c45-2efe-46d4-bfb0-ab9bd92ecdee" />
valid range
<img width="622" height="268" alt="image" src="https://github.com/user-attachments/assets/aad77923-1835-4fba-a65f-fad3c9123f83" />
also negation is possible
<img width="632" height="309" alt="image" src="https://github.com/user-attachments/assets/5aa9cfd4-da7c-44c5-838c-32306e210788" />
upper address is lower than lower macaddr -> error

- [x] Depends on: e.g. openwrt/firewall4#74 in sister repo
- [x] Description: (describe the changes proposed in this PR)
