### PR TITLE
luci-base: add ability to hide section titles

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2156,6 +2156,17 @@ const CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSect
 	 */
 
 	/**
+	 * If set to true, the title caption of the form section element which
+	 * is normally rendered before the start of the section content will
+	 * not be rendered in the UI. The default is false, meaning that the
+	 * title is rendered.
+	 *
+	 * @name LuCI.form.TypedSection.prototype#hidetitle
+	 * @type boolean
+	 * @default false
+	 */
+
+	/**
 	 * If set to `true`, mapped section instances are treated as anonymous
 	 * UCI sections, which means that section instance elements will be
 	 * rendered without a title element and that no name is required when adding
@@ -2300,7 +2311,7 @@ const CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSect
 			'data-tab-title': (this.map.tabbed && !this.parentoption) ? this.title || this.sectiontype : null
 		});
 
-		if (this.title != null && this.title != '')
+		if (this.title != null && this.title != '' && !this.hidetitle)
 			sectionEl.appendChild(E('h3', {}, this.title));
 
 		if (this.description != null && this.description != '')
@@ -2530,7 +2541,7 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 			'class': 'table cbi-section-table'
 		});
 
-		if (this.title != null && this.title != '')
+		if (this.title != null && this.title != '' && !this.hidetitle)
 			sectionEl.appendChild(E('h3', {}, this.title));
 
 		if (this.description != null && this.description != '')
@@ -3514,6 +3525,17 @@ const CBINamedSection = CBIAbstractSection.extend(/** @lends LuCI.form.NamedSect
 	 */
 
 	/**
+	 * If set to true, the title caption of the form section element which
+	 * is normally rendered before the start of the section content will
+	 * not be rendered in the UI. The default is false, meaning that the
+	 * title is rendered.
+	 *
+	 * @name LuCI.form.NamedSection.prototype#hidetitle
+	 * @type boolean
+	 * @default false
+	 */
+
+	/**
 	 * Override the UCI configuration name to read the section IDs from. By
 	 * default, the configuration name is inherited from the parent `Map`.
 	 * By setting this property, a deviating configuration may be specified.
@@ -3568,7 +3590,7 @@ const CBINamedSection = CBIAbstractSection.extend(/** @lends LuCI.form.NamedSect
 			'data-tab-title': (this.map.tabbed && !this.parentoption) ? this.title || this.sectiontype : null
 		});
 
-		if (typeof(this.title) === 'string' && this.title !== '')
+		if (typeof(this.title) === 'string' && this.title !== '' && !this.hidetitle)
 			sectionEl.appendChild(E('h3', {}, this.title));
 
 		if (typeof(this.description) === 'string' && this.description !== '')


### PR DESCRIPTION
The rationale here is that tabbed CBIMaps were introduced in commit 082fd9ff10b.

With tabbed maps, code could typically look like this:
```js
	m = new form.Map('foobar', _('FooBar'));
	m.tabbed = true;
	s = m.section(form.TypedSection, 'foo', _('foo Settings'));
```
The problem is that the title of `s` will be used as the name of the tab rendered in `m`, but also rendered as an `<h3>` right below the tab. IOW, the same information will be presented twice, which looks weird.

Doing this instead...
```js
	m = new form.Map('foobar', _('FooBar'));
	m.tabbed = true;
	s = m.section(form.TypedSection, 'foo');
```
...means that the superfluous `<h3>` won't be rendered (since `s` has no title), but the tab will then simply have the name of the section ("foo"), which can't be translated (bad).

After this change, the tabbed map can be written like this:
```js
	m = new form.Map('foobar', _('FooBar'));
	m.tabbed = true;
	s = m.section(form.TypedSection, 'foo', _('foo Settings'));
	s.hidetitle = true;
```
Which will give the Map tab the name "foo Settings", but won't add a title for the TypedSection right under the tab.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (NanoPi R6S, master, Chrome)
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

Example screenshot showing the issue (see "Leases" tab and "Leases" header):
<img width="1889" height="1026" alt="Screenshot From 2025-10-22 02-30-12" src="https://github.com/user-attachments/assets/60a58de2-5c4e-46fa-bceb-d5405793143b" />
