### PR TITLE
[openwrt-24.10] luci-mod-network: backport DNR and max_{preferred,valid}_lifetime options

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -932,6 +932,27 @@ return view.extend({
 						}, this));
 					};
 
+					so = ss.taboption('ipv6-ra', form.Value, 'max_preferred_lifetime', _('IPv6 Preferred Prefix Lifetime'), _('Maximum preferred lifetime for a prefix.'));
+					so.optional = true;
+					so.placeholder = '45m';
+					so.value('5m', _('5m (5 minutes)'));
+					so.value('45m', _('45m (45 minutes - default)'));
+					so.value('3h', _('3h (3 hours)'));
+					so.value('12h', _('12h (12 hours)'));
+					so.value('7d', _('7d (7 days)'));
+					so.depends('ra', 'server');
+					so.depends({ ra: 'hybrid', master: '0' });
+
+					so = ss.taboption('ipv6-ra', form.Value, 'max_valid_lifetime', _('IPv6 Valid Prefix Lifetime'), _('Maximum valid lifetime for a prefix.'));
+					so.optional = true;
+					so.placeholder = '90m';
+					so.value('5m', _('5m (5 minutes)'));
+					so.value('90m', _('90m (90 minutes - default)'));
+					so.value('3h', _('3h (3 hours)'));
+					so.value('12h', _('12h (12 hours)'));
+					so.value('7d', _('7d (7 days)'));
+					so.depends('ra', 'server');
+					so.depends({ ra: 'hybrid', master: '0' });
 
 					so = ss.taboption('ipv6', form.RichListValue, 'dhcpv6', _('DHCPv6-Service'),
 						_('Configures the operation mode of the DHCPv6 service on this interface.'));
@@ -1031,24 +1052,6 @@ return view.extend({
 					so = ss.taboption('ipv6', form.Flag, 'ndproxy_slave', _('NDP-Proxy slave'), _('Set interface as NDP-Proxy external slave. Default is off.'));
 					so.depends({ ndp: 'relay', master: '0' });
 					so.depends({ ndp: 'hybrid', master: '0' });
-
-					so = ss.taboption('ipv6', form.Value, 'max_preferred_lifetime', _('IPv6 Preferred Prefix Lifetime'), _('Maximum preferred lifetime for a prefix.'));
-					so.optional = true;
-					so.placeholder = '45m';
-					so.value('5m', _('5m (5 minutes)'));
-					so.value('45m', _('45m (45 minutes - default)'));
-					so.value('3h', _('3h (3 hours)'));
-					so.value('12h', _('12h (12 hours)'));
-					so.value('7d', _('7d (7 days)'));
-
-					so = ss.taboption('ipv6', form.Value, 'max_valid_lifetime', _('IPv6 Valid Prefix Lifetime'), _('Maximum valid lifetime for a prefix.'));
-					so.optional = true;
-					so.placeholder = '90m';
-					so.value('5m', _('5m (5 minutes)'));
-					so.value('90m', _('90m (90 minutes - default)'));
-					so.value('3h', _('3h (3 hours)'));
-					so.value('12h', _('12h (12 hours)'));
-					so.value('7d', _('7d (7 days)'));
 				}
 
 				ifc.renderFormOptions(s);


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (aarch64, 24.10 snapshot, chrome) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)
   Backport DNR and max_{preferred,valid}_lifetime options from master branch.