### PR TITLE
luci-proto-wireguard: add IPv6 prefix field

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -172,6 +172,10 @@ return network.registerProtocol('wireguard', {
         o.datatype = 'cidr6';
         o.optional = true;
 
+        o = s.taboption('general', form.Value, 'pd_prefix', _('PD Prefix'), _('IPv6 prefix obtained via Prefix Delegation for use by clients'));
+        o.datatype = 'cidr6';
+        o.optional = true;
+
         o = s.taboption('general', form.Flag, 'nohostroute', _('No Host Routes'), _('Optional. Do not create host routes to peers.'));
         o.optional = true;
 


### PR DESCRIPTION
Add support for configuring IPv6 prefix delegation in WireGuard protocol interface.

This patch adds an `ip6prefix` input field to the WireGuard protocol configuration UI, positioned directly below the existing `addresses` field.

### Changes:
- Add `ip6prefix` field using `form.DynamicList` to support