### PR TITLE
luci-theme-material: fixes long-named items in the main menu

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -343,7 +343,6 @@ small {
 	float: left;
 	overflow-x: auto;
 	width: calc(0% + 15rem);
-	min-width: max-content;
 	height: calc(100% - 4rem);
 	background-color: var(--menu-bg-color);
 	transition: visibility 400ms, width 400ms;
@@ -649,6 +648,8 @@ body[class*="node-"] > .main > .main-left > .nav > .slide > .menu.active::before
 }
 
 .main > .main-left > .nav > .slide > .slide-menu > li > a {
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
 	text-decoration: none;
 	padding: .4rem 2rem;


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->
This change truncates long item names in the navigation menu.
@systemcrash

<img width="1508" height="763" alt="lucibefore" src="https://github.com/user-attachments/assets/06ffaac5-bb79-4715-90ce-0a196525a53d" />

<img width="1563" height="770" alt="luciafter" src="https://github.com/user-attachments/assets/d520d1c5-897a-4bf4-a92d-dc88ca4a05c8" />



- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (x86, openwrt 24.10, firefox) :white_check_mark:
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
