### PR TITLE
luci-mod-network: Add warning for required package in mesh mode in wireless.js 

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1037,10 +1037,10 @@ return view.extend({
 				o.value('sta', _('Client'));
 				o.value('adhoc', _('Ad-Hoc'));
 
-				let warn = ss.taboption('general', form.Value, '_mesh_warning', _('Warning:'));
+				let warn = ss.taboption('general', form.Value, '_mesh_warning', _(' Warning:'));
 				warn.depends('mode', 'mesh');
 				warn.readonly = true;
-				warn.default = _('Required package: wpad-mbedtls ');
+				warn.default = _(' Required package: wpad-mbedtls');
 				warn.rmempty = false;
 				
 				o = ss.taboption('general', form.Value, 'mesh_id', _('Mesh Id'));


### PR DESCRIPTION
Some devices (e.g. Arcadyan AW1000 / Qualcomm IPQ807x platforms) expose the “802.11s (Mesh)” mode in LuCI even when only wpad-basic-mbedtls is installed.

However, hostapd from wpad-basic-mbedtls does *not* provide mesh (802.11s) support. Selecting Mesh mode in the UI silently fails, resulting in:
 - mesh interface showing channel “36 (0.000 GHz)”
 - no SSID beaconing
 - hostapd / wpa_supplicant reload loops
 - netifd reporting "command failed: Not supported (-95)"

Installing full `wpad-mbedtls` resolves the issue immediately.

This commit adds a clear warning message in LuCI that 802.11s Mesh requires the full `wpad-mbedtls` package, helping users avoid confusing failures, especially on devices where mesh previously worked or where the UI hides the complexity. The warning appears only when the user selects "802.11s" mode.

No functional changes for any other modes.

More description in:
https://github.com/openwrt/openwrt/issues/20391

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- :white_check_mark: This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- :white_check_mark: Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- :white_check_mark: Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- :white_check_mark: Tested on: (AW1000, ARMv8 Processor rev 4, OpenWrt SNAPSHOT r31645-3b21f97641, EDGE) :white_check_mark:
- :white_check_mark: Closes: openwrt/luci issue #20391
- :white_check_mark: Description: (describe the changes proposed in this PR)
