### PR TITLE
luci-app-tinyproxy: Loosen constraint on upstream target

### DIFF
--- a/applications/luci-app-tinyproxy/htdocs/luci-static/resources/view/tinyproxy/tinyproxy.js
+++ b/applications/luci-app-tinyproxy/htdocs/luci-static/resources/view/tinyproxy/tinyproxy.js
@@ -299,7 +299,7 @@ return view.extend({
 
 		ta.rmempty = true;
 		ta.placeholder = '0.0.0.0/0';
-		ta.datatype = 'host(1)';
+		ta.datatype = 'string';
 
 
 		v = s.option(form.Value, 'via', _('Via proxy'),


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (ARMv8, OpenWrt 24.10.4, Firefox 144) :white_check_mark:
- [x] \( Optional ) Closes: openwrt/luci#7958
- [x] Description: (describe the changes proposed in this PR)

---

Upstream target datatype is too strict, rejecting values starting with a dot, which selects all subdomains of provided domain.

From tinyproxy [docs](https://tinyproxy.github.io/):

> The site can be specified in various forms as a hostname, domain name or as an IP range:
> 
>     name matches host exactly
>     .name matches any host in domain "name"
>     . matches any host with no domain (in 'empty' domain)
>     IP/bits matches network/mask
>     IP/mask matches network/mask

I looked at available datatypes in `modules/luci-compat/luasrc/cbi/datatypes.lua` and `modules/luci-base/htdocs/luci-static/resources/validation.js` and there is no suitable predefined type, so I changed it to `string`