### PR TITLE
luci-mod-network: Add warning for required package in mesh mode in wireless.js

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1121,7 +1121,32 @@ return view.extend({
 					const mode = ss.children.find(obj => obj.option === 'mode');
 					const bssid = ss.children.find(obj => obj.option === 'bssid');
 
-					if (have_mesh) mode.value('mesh', '802.11s');
+					if (have_mesh) {
+						mode.value('mesh', '802.11s');
+					} else {
+				        mode.value('mesh', '802.11s (not available)');
+				        const origRender = mode.renderWidget;
+				        mode.renderWidget = function(section_id, option_id, cfgvalue) {
+				            var node = origRender.apply(this, arguments);
+				            node.addEventListener('change', function(ev) {
+				                if (ev.target.value === 'mesh') {
+				                    L.ui.showModal(_('Required packeges are not available'), [
+				                        E('p', { 'class': 'alert-message warning' },
+				                            _('The following packages with a mesh support to run the 802.11s are required: "wpad-mbedtls/wpa-supplicant-mbedtls"')),
+				                        E('div', { 'class': 'right' }, [
+				                            E('button', {
+				                                'class': 'btn',
+				                                'click': function() { L.ui.hideModal(); }
+				                            }, _('Close'))
+				                        ])
+				                    ]);
+				                    ev.target.value = '';
+				                }
+				            });
+				
+				            return node;
+				        };
+				    }
 					mode.value('ahdemo', _('Pseudo Ad-Hoc (ahdemo)'));
 					mode.value('monitor', _('Monitor'));
 


### PR DESCRIPTION
Devices (e.g. Arcadyan AW1000 / Qualcomm IPQ807x platforms) expose the “802.11s (Mesh)” mode in LuCI even when only wpad-basic-mbedtls is installed.

However, hostapd from wpad-basic-mbedtls does *not* provide mesh (802.11s) support. Selecting Mesh mode in the UI silently fails, resulting in:
 - mesh interface showing channel “36 (0.000 GHz)”
 - no SSID beaconing
 - hostapd / wpa_supplicant reload loops
 - netifd reporting "command failed: Not supported (-95)"

Installing e.g. full `wpad-mbedtls` resolves the issue immediately.

This commit adds a clear warning message in LuCI that 802.11s Mesh requires
the full `wpad-mbedtls` package, helping users avoid confusing failures, especially on devices where mesh previously worked or where the UI hides the complexity.
The warning appears only when the user selects "802.11s" mode.

No functional changes for any other modes.

More description in:
https://github.com/openwrt/openwrt/issues/20391

Signed-off-by: GithPK <pkoltun@op.pl>


<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Tested on: (ARMv8 Processor rev 4, OpenWrt SNAPSHOT r31645-3b21f97641, edge) :white_check_mark:
- [X] Description: (describe the changes proposed in this PR)
