### PR TITLE
collections: Add luci-app-attendedsysupgrade as default

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -15,6 +15,7 @@ LUCI_DEPENDS:= \
 	+IPV6:luci-proto-ipv6 \
 	+luci-app-firewall \
 	+luci-app-package-manager \
+	+luci-app-attendedsysupgrade \
 	+luci-mod-admin-full \
 	+luci-proto-ppp \
 	+luci-theme-bootstrap \

--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -17,7 +17,8 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
 LUCI_DEPENDS:=+luci-light \
 	+libustream-openssl \
 	+openssl-util \
-	+luci-app-package-manager
+	+luci-app-package-manager \
+	+luci-app-attendedsysupgrade
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -13,7 +13,8 @@ LUCI_TITLE:=LuCI with HTTPS support (mbedtls as SSL backend)
 LUCI_DEPENDS:=+luci-light \
 	+libustream-mbedtls \
 	+px5g-mbedtls \
-	+luci-app-package-manager
+	+luci-app-package-manager \
+	+luci-app-attendedsysupgrade
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -13,7 +13,8 @@ LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
 LUCI_DESCRIPTION:=Standard OpenWrt set including package management and attended sysupgrades support
 LUCI_DEPENDS:= \
 	+luci-light \
-	+luci-app-package-manager
+	+luci-app-package-manager \
+	+luci-app-attendedsysupgrade
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Add the luci-app-attendedsysupgrade package as default package when luci-app-package-manager is already added.

This should spread the usage of ASU more in the next release.

This adds the following 3 packages to the default LuCi image: 
```
5131 bin/packages/aarch64_cortex-a53/base/rpcd-mod-rpcsys-2025.11.07~91700007-r1.apk
8781 bin/packages/aarch64_cortex-a53/luci/luci-app-attendedsysupgrade-25.302.55139~cf868f4.apk
1322 bin/packages/aarch64_cortex-a53/packages/attendedsysupgrade-common-9.apk
```


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (mediatek/filogic main) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
