### PR TITLE
luci-mod-status: use ubus for odhcpd leases

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -39,47 +39,6 @@ return baseclass.extend({
 		return E([]);
 	},
 
-	handleCreateStaticLease(lease, ev) {
-		ev.currentTarget.classList.add('spinning');
-		ev.currentTarget.disabled = true;
-		ev.currentTarget.blur();
-
-		const cfg = uci.add('dhcp', 'host');
-		uci.set('dhcp', cfg, 'name', lease.hostname);
-		uci.set('dhcp', cfg, 'ip', lease.ipaddr);
-		uci.set('dhcp', cfg, 'mac', [lease.macaddr.toUpperCase()]);
-
-		return uci.save()
-			.then(L.bind(L.ui.changes.init, L.ui.changes))
-			.then(L.bind(L.ui.changes.displayChanges, L.ui.changes));
-	},
-
-	handleCreateStaticLease6(lease, ev) {
-		ev.currentTarget.classList.add('spinning');
-		ev.currentTarget.disabled = true;
-		ev.currentTarget.blur();
-
-		const cfg = uci.add('dhcp', 'host');
-		const ip6addr = lease.ip6addrs?.[0]?.replace(/\/128$/, '');
-		const ip6arr = ip6addr ? validation.parseIPv6(ip6addr) : null;
-
-		// Combine DUID and IAID if both available
-		// (note that we know that lease.duid is set here)
-		let duid_iaid = lease.duid.toUpperCase();
-		if (lease.iaid)
-			duid_iaid += `%${lease.iaid}`.toUpperCase();
-
-		uci.set('dhcp', cfg, 'name', lease.hostname);
-		uci.set('dhcp', cfg, 'duid', [duid_iaid]);
-		uci.set('dhcp', cfg, 'mac', [lease.macaddr]);
-		if (ip6arr)
-			uci.set('dhcp', cfg, 'hostid', (ip6arr[6] * 0xFFFF + ip6arr[7]).toString(16));
-
-		return uci.save()
-			.then(L.bind(L.ui.changes.init, L.ui.changes))
-			.then(L.bind(L.ui.changes.displayChanges, L.ui.changes));
-	},
-
 	renderLeases(dhcp_leases, host_hints, macaddr) {
 		const leases = Array.isArray(dhcp_leases.dhcp_leases) ? dhcp_leases.dhcp_leases : [];
 		const leases6 = Array.isArray(dhcp_leases.dhcp6_leases) ? dhcp_leases.dhcp6_leases : [];
@@ -229,4 +188,44 @@ return baseclass.extend({
 		]);
 	},
 
+	handleCreateStaticLease(lease, ev) {
+		ev.currentTarget.classList.add('spinning');
+		ev.currentTarget.disabled = true;
+		ev.currentTarget.blur();
+
+		const cfg = uci.add('dhcp', 'host');
+		uci.set('dhcp', cfg, 'name', lease.hostname);
+		uci.set('dhcp', cfg, 'ip', lease.ipaddr);
+		uci.set('dhcp', cfg, 'mac', [lease.macaddr.toUpperCase()]);
+
+		return uci.save()
+			.then(L.bind(L.ui.changes.init, L.ui.changes))
+			.then(L.bind(L.ui.changes.displayChanges, L.ui.changes));
+	},
+
+	handleCreateStaticLease6(lease, ev) {
+		ev.currentTarget.classList.add('spinning');
+		ev.currentTarget.disabled = true;
+		ev.currentTarget.blur();
+
+		const cfg = uci.add('dhcp', 'host');
+		const ip6addr = lease.ip6addrs?.[0]?.replace(/\/128$/, '');
+		const ip6arr = ip6addr ? validation.parseIPv6(ip6addr) : null;
+
+		// Combine DUID and IAID if both available
+		// (note that we know that lease.duid is set here)
+		let duid_iaid = lease.duid.toUpperCase();
+		if (lease.iaid)
+			duid_iaid += `%${lease.iaid}`.toUpperCase();
+
+		uci.set('dhcp', cfg, 'name', lease.hostname);
+		uci.set('dhcp', cfg, 'duid', [duid_iaid]);
+		uci.set('dhcp', cfg, 'mac', [lease.macaddr]);
+		if (ip6arr)
+			uci.set('dhcp', cfg, 'hostid', (ip6arr[6] * 0xFFFF + ip6arr[7]).toString(16));
+
+		return uci.save()
+			.then(L.bind(L.ui.changes.init, L.ui.changes))
+			.then(L.bind(L.ui.changes.displayChanges, L.ui.changes));
+	},
 });

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -68,7 +68,7 @@ return baseclass.extend({
 			duid_iaid += `%${lease.iaid}`;
 
 		uci.set('dhcp', cfg, 'name', lease.hostname);
-		uci.set('dhcp', cfg, 'duid', duid_iaid);
+		uci.set('dhcp', cfg, 'duid', [duid_iaid]);
 		uci.set('dhcp', cfg, 'mac', [lease.macaddr]);
 		if (ip6arr)
 			uci.set('dhcp', cfg, 'hostid', (ip6arr[6] * 0xFFFF + ip6arr[7]).toString(16));

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -21,6 +21,7 @@ return baseclass.extend({
 
 	isMACStatic: {},
 	isDUIDStatic: {},
+	isDUIDIAIDStatic: {},
 
 	load() {
 		return Promise.all([
@@ -63,9 +64,10 @@ return baseclass.extend({
 		const ip6arr = ip6addr ? validation.parseIPv6(ip6addr) : null;
 
 		// Combine DUID and IAID if both available
-		let duid_iaid = lease.duid ? lease.duid.toUpperCase() : null;
-		if (duid_iaid && lease.iaid)
-			duid_iaid += `%${lease.iaid}`;
+		// (note that we know that lease.duid is set here)
+		let duid_iaid = lease.duid.toUpperCase();
+		if (lease.iaid)
+			duid_iaid += `%${lease.iaid}`.toUpperCase();
 
 		uci.set('dhcp', cfg, 'name', lease.hostname);
 		uci.set('dhcp', cfg, 'duid', [duid_iaid]);
@@ -89,19 +91,17 @@ return baseclass.extend({
 
 		for (const host of uci.sections('dhcp', 'host')) {
 
-			if (host.mac) {
-				for (const mac of L.toArray(host.mac).map(m => m.toUpperCase())) {
-					this.isMACStatic[mac] = true;
-				}
+			for (const mac of L.toArray(host.mac).map(m => m.toUpperCase())) {
+				this.isMACStatic[mac] = true;
 			}
-			if (host.duid) {
-				if (Array.isArray(host.duid)){
-					host.duid.map(m => {
-						this.isDUIDStatic[m.toUpperCase()] = true;
-					})
-				} else {
-					this.isDUIDStatic[host.duid.toUpperCase()] = true;
-				}
+
+			for (const duid_iaid of L.toArray(host.duid).map(m => m.toUpperCase())) {
+				const parts = duid_iaid.split('%').length;
+
+				if (parts == 1)
+					this.isDUIDStatic[duid_iaid] = true;
+				else if (parts == 2)
+					this.isDUIDIAIDStatic[duid_iaid] = true;
 			}
 		};
 
@@ -189,11 +189,23 @@ return baseclass.extend({
 			else if (hint)
 				host = hint[1];
 
+			const duid = lease.duid?.toUpperCase();
+			const iaid = lease.iaid?.toUpperCase();
+
+			// Note: "disabled: false" doesn't work
+			let disabled = null;
+			if (!duid)
+				disabled = true;
+			else if (duid && this.isDUIDStatic[duid])
+				disabled = true;
+			else if (duid && iaid && this.isDUIDIAIDStatic[`${duid}%${iaid}`])
+				disabled = true;
+
 			const columns = [
 				host || '-',
 				lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
-				lease?.duid,
-				lease?.iaid,
+				duid || '-',
+				iaid || '-',
 				exp
 			];
 
@@ -202,7 +214,7 @@ return baseclass.extend({
 					'class': 'cbi-button cbi-button-apply',
 					'click': L.bind(this.handleCreateStaticLease6, this, lease),
 					'data-tooltip': _('Reserve a specific IP address for this device'),
-					'disabled': this.isDUIDStatic[lease?.duid?.toUpperCase()]
+					'disabled': disabled
 				}, [ _('Reserve IP') ]));
 			}
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -69,6 +69,18 @@ return baseclass.extend({
 			}
 		};
 
+		const table4 = this.createTable4(leases4);
+		const table6 = this.createTable6(leases6);
+
+		return E([
+			E('h3', _('Active DHCPv4 Leases')),
+			table4,
+			E('h3', _('Active DHCPv6 Leases')),
+			table6
+		]);
+	},
+
+	createTable4(leases4) {
 		const table4 = E('table', { 'id': 'status_leases4', 'class': 'table leases4' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Hostname')),
@@ -121,6 +133,10 @@ return baseclass.extend({
 			return columns;
 		}, this)), E('em', _('There are no active leases')));
 
+		return table4;
+	},
+
+	createTable6(leases6) {
 		const table6 = E('table', { 'id': 'status_leases6', 'class': 'table leases6' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Host')),
@@ -184,12 +200,7 @@ return baseclass.extend({
 			return columns;
 		}, this)), E('em', _('There are no active leases')));
 
-		return E([
-			E('h3', _('Active DHCPv4 Leases')),
-			table4,
-			E('h3', _('Active DHCPv6 Leases')),
-			table6
-		]);
+		return table6;
 	},
 
 	handleCreateStaticLease4(lease, ev) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -40,9 +40,9 @@ return baseclass.extend({
 	},
 
 	renderLeases(dhcp_leases, host_hints, macaddr) {
-		const leases = Array.isArray(dhcp_leases.dhcp_leases) ? dhcp_leases.dhcp_leases : [];
-		const leases6 = Array.isArray(dhcp_leases.dhcp6_leases) ? dhcp_leases.dhcp6_leases : [];
-		if (leases.length == 0 && leases6.length == 0)
+		const leases4 = L.toArray(dhcp_leases.dhcp_leases);
+		const leases6 = L.toArray(dhcp_leases.dhcp6_leases);
+		if (leases4.length == 0 && leases6.length == 0)
 			return E([]);
 		const machints = host_hints.getMACHints(false);
 		const hosts = uci.sections('dhcp', 'host');
@@ -64,7 +64,7 @@ return baseclass.extend({
 			}
 		};
 
-		const table = E('table', { 'id': 'status_leases', 'class': 'table lases' }, [
+		const table4 = E('table', { 'id': 'status_leases4', 'class': 'table leases4' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Hostname')),
 				E('th', { 'class': 'th' }, _('IPv4 address')),
@@ -75,7 +75,7 @@ return baseclass.extend({
 			])
 		]);
 
-		cbi_update_table(table, leases.map(L.bind(function(lease) {
+		cbi_update_table(table4, leases4.map(L.bind(function(lease) {
 			let exp;
 			let vendor;
 
@@ -108,7 +108,7 @@ return baseclass.extend({
 			if (!isReadonlyView && lease.macaddr != null) {
 				columns.push(E('button', {
 					'class': 'cbi-button cbi-button-apply',
-					'click': L.bind(this.handleCreateStaticLease, this, lease),
+					'click': L.bind(this.handleCreateStaticLease4, this, lease),
 					'data-tooltip': _('Reserve a specific IP address for this device'),
 					'disabled': this.isMACStatic[lease.macaddr.toUpperCase()]
 				}, [ _('Reserve IP') ]));
@@ -181,14 +181,14 @@ return baseclass.extend({
 		}, this)), E('em', _('There are no active leases')));
 
 		return E([
-			E('h3', _('Active DHCP Leases')),
-			table,
+			E('h3', _('Active DHCPv4 Leases')),
+			table4,
 			E('h3', _('Active DHCPv6 Leases')),
 			table6
 		]);
 	},
 
-	handleCreateStaticLease(lease, ev) {
+	handleCreateStaticLease4(lease, ev) {
 		ev.currentTarget.classList.add('spinning');
 		ev.currentTarget.disabled = true;
 		ev.currentTarget.blur();

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -39,7 +39,7 @@ return baseclass.extend({
 		return E([]);
 	},
 
-	renderLeases(dhcp_leases, host_hints, macaddr) {
+	renderLeases(dhcp_leases, host_hints, ufp_list) {
 		const leases4 = L.toArray(dhcp_leases.dhcp_leases);
 		const leases6 = L.toArray(dhcp_leases.dhcp6_leases);
 		if (leases4.length == 0 && leases6.length == 0)
@@ -77,7 +77,6 @@ return baseclass.extend({
 
 		cbi_update_table(table4, leases4.map(L.bind(function(lease) {
 			let exp;
-			let vendor;
 
 			if (lease.expires === false)
 				exp = E('em', _('unlimited'));
@@ -94,14 +93,14 @@ return baseclass.extend({
 			else if (lease.hostname)
 				host = lease.hostname;
 
-			if (macaddr)
-				vendor = macaddr[lease.macaddr.toLowerCase()]?.vendor ?? null;
+			const vendor = ufp_list?.[lease.macaddr.toLowerCase()]?.vendor ?? null;
+			const mac_desc = vendor ? `${lease.macaddr} (${vendor})` : lease.macaddr;
 
 			const columns = [
 				host || '-',
 				lease.ipaddr,
-				vendor ? lease.macaddr + ` (${vendor})` : lease.macaddr,
-				lease.duid ? lease.duid : null,
+				mac_desc,
+				lease.duid || '-',
 				exp,
 			];
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -11,10 +11,29 @@ const callLuciDHCPLeases = rpc.declare({
 	expect: { '': {} }
 });
  
+const callODHCPD6Leases = rpc.declare({
+	object: 'dhcp',
+	method: 'ipv6leases',
+	expect: { 'device': {} }
+});
+
 const callUfpList = rpc.declare({
 	object: 'fingerprint',
 	method: 'fingerprint',
 });
+
+function DUIDtoMAC(duid) {
+	if (duid == null || duid == '')
+		return null;
+
+	var mac = null;
+	if (duid.match(/^00010001[a-f0-9]{20}$/i))
+		mac = duid.substring(16,);
+	else if (duid.match(/^00030001[a-f0-9]{12}$/i))
+		mac = duid.substring(8,);
+
+	return mac ? mac.match(/.{1,2}/g).join(":").toUpperCase() : null;
+}
 
 return baseclass.extend({
 	title: '',
@@ -30,25 +49,26 @@ return baseclass.extend({
 	load() {
 		return Promise.all([
 			callLuciDHCPLeases(),
+			L.hasSystemFeature('odhcpd', 'dhcpv6') ? L.resolveDefault(callODHCPD6Leases()) : null,
 			network.getHostHints(),
 			L.hasSystemFeature('ufpd') ? callUfpList() : null,
 			L.resolveDefault(uci.load('dhcp'))
 		]);
 	},
 
-	render([dhcp_leases, host_hints, ufp_list]) {
+	render([dnsmasq_leases, odhcpd_leases6, host_hints, ufp_list]) {
 		this.mac_hints = host_hints.getMACHints(false);
 		this.ufp_list = ufp_list;
 
 		if (L.hasSystemFeature('dnsmasq') || L.hasSystemFeature('odhcpd'))
-			return this.renderLeases(dhcp_leases);
+			return this.renderLeases(dnsmasq_leases, odhcpd_leases6);
 
 		return E([]);
 	},
 
-	renderLeases(dhcp_leases) {
-		const leases4 = L.toArray(dhcp_leases.dhcp_leases);
-		const leases6 = L.toArray(dhcp_leases.dhcp6_leases);
+	renderLeases(dnsmasq_leases, odhcpd_leases6) {
+		const leases4 = L.toArray(dnsmasq_leases.dhcp_leases);
+		const leases6 = L.toArray(dnsmasq_leases.dhcp6_leases);
 
 		if (leases4.length == 0 && leases6.length == 0)
 			return E([]);
@@ -70,13 +90,15 @@ return baseclass.extend({
 		};
 
 		const table4 = this.createTable4(leases4);
-		const table6 = this.createTable6(leases6);
+		const dnsmasq_table6 = this.createDnsmasqTable6(leases6);
+		const odhcpd_table6 = this.createOdhcpdTable6(odhcpd_leases6);
 
 		return E([
 			E('h3', _('Active DHCPv4 Leases')),
 			table4,
 			E('h3', _('Active DHCPv6 Leases')),
-			table6
+			dnsmasq_table6,
+			odhcpd_table6
 		]);
 	},
 
@@ -136,7 +158,7 @@ return baseclass.extend({
 		return table4;
 	},
 
-	createTable6(leases6) {
+	createDnsmasqTable6(leases6) {
 		const table6 = E('table', { 'id': 'status_leases6', 'class': 'table leases6' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Host')),
@@ -150,7 +172,6 @@ return baseclass.extend({
 
 		cbi_update_table(table6, leases6.map(L.bind(function(lease) {
 			let exp;
-
 			if (lease.expires === false)
 				exp = E('em', _('unlimited'));
 			else if (lease.expires <= 0)
@@ -203,6 +224,88 @@ return baseclass.extend({
 		return table6;
 	},
 
+	createOdhcpdTable6(iface_leases6) {
+		if (!iface_leases6)
+			return null;
+
+		const table6 = E('table', { 'id': 'status_leases6', 'class': 'table leases6' }, [
+			E('tr', { 'class': 'tr table-titles' }, [
+				E('th', { 'class': 'th' }, _('Interface')),
+				E('th', { 'class': 'th' }, _('Host')),
+				E('th', { 'class': 'th' }, _('IPv6 addresses')),
+				E('th', { 'class': 'th' }, _('DUID')),
+				E('th', { 'class': 'th' }, _('IAID')),
+				E('th', { 'class': 'th' }, _('FR')),
+				E('th', { 'class': 'th' }, _('Lease time remaining')),
+				this.isReadonlyView ? E([]) : E('th', { 'class': 'th cbi-section-actions' }, _('Static Lease'))
+			])
+		]);
+
+		const leases6 = Object.entries(iface_leases6).flatMap(([iface, { leases }]) =>
+			leases.map(lease => {
+				lease.iface = iface;
+				lease.duid = lease.duid.toUpperCase();
+				lease.iaid = lease.iaid.toString(16).toUpperCase();
+				lease.duid_iaid = `${lease.duid}%${lease.iaid}`;
+				lease.ip6addrs = lease['ipv6-addr'].map(addr => addr.address);
+				lease.reconf = lease['accept-reconf'];
+				lease.macaddr = DUIDtoMAC(lease.duid);
+				return lease;
+			})
+		);
+
+		cbi_update_table(table6, leases6.map(L.bind(function(lease) {
+			let exp;
+			if (lease.valid == 0xffffffff)
+				exp = E('em', _('unlimited'));
+			else if (lease.valid <= 0)
+				exp = E('em', _('expired'));
+			else
+				exp = '%t'.format(lease.valid);
+
+			const hint = lease.macaddr ? this.mac_hints.filter(function(h) { return h[0] == lease.macaddr })[0] : null;
+
+			let host = null;
+			if (hint && lease.hostname && lease.hostname != hint[1] && lease.ip6addrs[0] != hint[1])
+				host = '%s (%s)'.format(lease.hostname, hint[1]);
+			else if (lease.hostname)
+				host = lease.hostname;
+			else if (hint)
+				host = hint[1];
+
+			// Note: "disabled: false" doesn't work
+			let disabled = null;
+			if (this.isDUIDStatic[lease.duid])
+				disabled = true;
+			if (this.isDUIDIAIDStatic[lease.duid_iaid])
+				disabled = true;
+
+			const columns = [
+				lease.iface,
+				host || '-',
+				lease.ip6addrs.join('<br />'),
+				lease.duid,
+				lease.iaid,
+				lease.reconf ? _('Yes') : _('No'),
+				exp
+			];
+
+			if (!this.isReadonlyView) {
+				columns.push(E('button', {
+					'class': 'cbi-button cbi-button-apply',
+					'click': L.bind(this.handleCreateStaticLease6, this, lease),
+					'data-tooltip': _('Reserve a specific IP address for this device'),
+					'disabled': disabled
+				}, [ _('Reserve IP') ]));
+			}
+
+			return columns;
+
+		}, this)), E('em', _('There are no active leases')));
+
+		return table6;
+	},
+
 	handleCreateStaticLease4(lease, ev) {
 		ev.currentTarget.classList.add('spinning');
 		ev.currentTarget.disabled = true;
@@ -235,7 +338,8 @@ return baseclass.extend({
 
 		uci.set('dhcp', cfg, 'name', lease.hostname);
 		uci.set('dhcp', cfg, 'duid', [duid_iaid]);
-		uci.set('dhcp', cfg, 'mac', [lease.macaddr]);
+		if (lease.macaddr)
+			uci.set('dhcp', cfg, 'mac', [lease.macaddr]);
 		if (ip6arr)
 			uci.set('dhcp', cfg, 'hostid', (ip6arr[6] * 0xFFFF + ip6arr[7]).toString(16));
 

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
@@ -34,6 +34,7 @@
 		"read": {
 			"ubus": {
 				"luci-rpc": [ "getDHCPLeases" ],
+				"dhcp": [ "ipv4leases", "ipv6leases" ],
 				"fingerprint": [ "fingerprint" ]
 			}
 		}


### PR DESCRIPTION
This is just a RFC for now (and it's based on top of https://github.com/openwrt/luci/pull/8083 rather than `master`).

Basically, it changes `luci-mod-status` so that it calls `odhcpd` directly over `ubus` to get the status of DHCPv4/DHCPv6 leases (yes, I know that `odhcpd` isn't responsible for DHCPv4 in a default install).

Before this change, all lease status is provided via the `rpcd-mod-luci` plugin in `rpcd`, which will dig through `leasefiles` to get the status of leases (and it'll still do that for `dnsmasq`-based leases). Communicating directly with `odhcpd` is quicker, simpler and provides access to information which wasn't exposed in the interface before (like per-lease interface information, force reconf status, etc).

This isn't complete right now (for example, it'll render 4 tables, showing both what was returned from `odhcpd` and what was returned from `rpcd`, but that's for comparison, also needs more testing).

However, I'm posting this here now so that I can get some early feedback. Ultimately I'd like to implement a similar change to `luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js`, after which the `odhcpd`-specific code in `rpcd-mod-luci` won't really be necessary anymore.

It might look like a lot of duplication, but there's enough little differences between the data returned from `odhcpd` and `rpcd` (and also the resulting HTML tables carry different information), that there's not much code that can be shared between the different table generation functions.

Down the line, I guess this would also make it easier to split `40_dhcp.js` into three separate files, one for `dnsmasq`, one for `odhcpd-DHCPv4` and one for `odhcpd-DHCPv6` (if that's desirable, cf. https://github.com/openwrt/luci/pull/6713).

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (NanoPi R6S, Master, Chrome) :white_check_mark:
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [x] Description: (describe the changes proposed in this PR)
