### PR TITLE
luci-base: improve docs for uci.get_bool

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/uci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/uci.js
@@ -711,8 +711,9 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * Many configuration files contain boolean settings, such as
 	 * `enabled` or `advanced_mode`, where there is no consistent
 	 * definition for the values.  This function allows users to
-	 * enter any of the values `"yes"`, `"on"`, `"true"` or `1` in
-	 * their config files and we return the expected boolean result.
+	 * enter any of the values `"yes"`, `"on"`, `"true"`, `"enabled"`
+	 * or `1` in their config files and we return the expected boolean
+	 * result.
 	 *
 	 * Character case is not significant, so for example, any of
 	 * "YES", "Yes" or "yes" will be interpreted as a `true` value.
@@ -730,6 +731,10 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * @returns {boolean}
 	 * - Returns boolean `true` if the configuration value is defined
 	 *   and looks like a true value, otherwise returns `false`.
+	 *
+	 * See the
+	 * {@link https://openwrt.org/docs/guide-developer/config-scripting#reading_booleans|Developers Guide}
+	 * for more.
 	 */
 	get_bool(conf, type, opt) {
 		let value = this.get(conf, type, opt);


### PR DESCRIPTION
The get_bool function documentation was missing an option value, so add it.  Provide a link into the developer's guide on how it's used in scripts, for better background.

---
Stumbled upon this while perusing

https://openwrt.org/docs/guide-developer/config-scripting#reading_booleans
https://github.com/openwrt/openwrt/blob/5ab6e6011feb5d3fd782a8fe19c5ce3acfecf712/package/base-files/files/lib/functions.sh#L153
https://github.com/openwrt/packages/blame/6423781254b9f3e52c6102fb2cbcd9f99f2445a3/net/mwan3/files/usr/share/rpcd/ucode/mwan3#L32

I need to fix ucode uci to have a `get_bool`, too...