### PR TITLE
luci-app-firewall: move NAT6 to general like NAT4

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -173,9 +173,22 @@ return view.extend({
 			var masq_dest = uci.get('firewall', section_id, 'masq_dest')
 			if ((!family || family.indexOf('6') == -1) && (masq_src || masq_dest))
 				return _('Limited masquerading enabled');
-
 			return null;
 		};
+
+		if (fw4) {
+			o = s.taboption('general', form.Flag, 'masq6', _('IPv6 Masquerading'),
+				_('Enable network address and port translation IPv6 (NAT6 or NAPT6) for outbound traffic on this zone. Typically not needed, as native IPv6 routing is usually used instead of NAT6.'));
+			o.modalonly = true;
+			o.tooltip = function(section_id) {
+				var family = uci.get('firewall', section_id, 'family')
+				var masq_src = uci.get('firewall', section_id, 'masq_src')
+				var masq_dest = uci.get('firewall', section_id, 'masq_dest')
+				if ((!family || family.indexOf('6') >= 0) && (masq_src || masq_dest))
+					return _('Limited masquerading enabled');
+				return null;
+			};
+		}
 
 		o = s.taboption('general', form.Flag, 'mtu_fix', _('MSS clamping'));
 		o.modalonly = true;
@@ -237,20 +250,6 @@ return view.extend({
 		o.datatype = 'neg(cidr("true"))';
 		o.modalonly = true;
 		o.multiple = true;
-
-		if (fw4) {
-			o = s.taboption('advanced', form.Flag, 'masq6', _('IPv6 Masquerading'),
-				_('Enable network address and port translation IPv6 (NAT6 or NAPT6) for outbound traffic on this zone.'));
-			o.modalonly = true;
-			o.tooltip = function(section_id) {
-				var family = uci.get('firewall', section_id, 'family')
-				var masq_src = uci.get('firewall', section_id, 'masq_src')
-				var masq_dest = uci.get('firewall', section_id, 'masq_dest')
-				if ((!family || family.indexOf('6') >= 0) && (masq_src || masq_dest))
-					return _('Limited masquerading enabled');
-				return null;
-			};
-		}
 
 		o = s.taboption('advanced', form.ListValue, 'family', _('Restrict to address family'));
 		o.value('', _('IPv4 and IPv6'));


### PR DESCRIPTION
move NAT6 to general like NAT4.
This makes the NAT6 flag more visually apparent.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/64, openwrt master, Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)

<img width="979" height="337" alt="image" src="https://github.com/user-attachments/assets/9d1926fb-415f-4f9e-878c-f38da5a5548e" />

<img width="891" height="491" alt="image" src="https://github.com/user-attachments/assets/5bfee7e7-3a84-41ab-8d3e-68b9efc9a303" />
