### PR TITLE
luci-app-adblock: Move Refresh button close to top of dnsreport page

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
@@ -370,20 +370,7 @@ return view.extend({
 					E('div', { 'class': 'cbi-value-title', 'id': 'blocked', 'style': 'float:left;color:#37c' }, (content[0].blocked || '-') + ' (' + (content[0].percent || '-') + ')')
 				])
 			]),
-			E('div', { 'class': 'cbi-section' }, [
-				E('div', { 'class': 'left' }, [
-					E('h3', _('Top Statistics')),
-					tbl_top
-				])
-			]),
-			E('br'),
-			E('div', { 'class': 'cbi-section' }, [
-				E('div', { 'class': 'left' }, [
-					E('h3', _('Latest DNS Requests')),
-					tbl_requests
-				])
-			]),
-			E('div', { 'class': 'cbi-page-actions' }, [
+E('div', { 'class': 'cbi-page-actions' }, [
 				E('button', {
 					'class': 'btn cbi-button cbi-button-apply',
 					'style': 'float:none;margin-right:.4em;',
@@ -416,6 +403,19 @@ return view.extend({
 						return handleAction('refresh');
 					})
 				}, [_('Refresh...')])
+			]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('div', { 'class': 'left' }, [
+					E('h3', _('Top Statistics')),
+					tbl_top
+				])
+			]),
+			E('br'),
+			E('div', { 'class': 'cbi-section' }, [
+				E('div', { 'class': 'left' }, [
+					E('h3', _('Latest DNS Requests')),
+					tbl_requests
+				])
 			])
 		]);
 		if (uci.get('adblock', 'global', 'adb_map') === '1') {


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [ ] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: LuCI openwrt-24.10 branch Chrome :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

Move Refresh button close to top of dnsreport page to scroll less on refreshes

<img width="1808" height="914" alt="image" src="https://github.com/user-attachments/assets/19dbd1a9-a323-4f56-9583-25ab03517dd5" />
