### PR TITLE
luci-mod-network: add support for fast-dns-retry, use-stale-cache

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
@@ -684,6 +684,25 @@ return view.extend({
 		);
 		o.placeholder = '/etc/dnsmasq.servers';
 
+		s.taboption('forward', form.Flag, 'fast_dns_retry',
+			_('Fast DNS retry'),
+			_('Allow dnsmasq to generate its own retries (instead of relying on DNS clients).'));
+
+		o = s.taboption('forward', form.Value, 'fast_dns_retry_param',
+			_('Retry time settings'),
+			_('Set initial retry delay and retry duration in milliseconds.') + '<br />' +
+			customi18n(_('Syntax: {code_syntax}.'),
+				{code_syntax: '<code>&lt;initial retry delay&gt;[,&lt;retry duration&gt;]</code>'}) + '<br />' +
+			_('Examples:') + ' ' + '<code>500</code> / <code>500,5000</code>'
+		);
+		o.placeholder = '1000,10000';
+		o.depends('fast_dns_retry', '1');
+		o.validate = function (section_id, value) {
+			if (!value) return true;
+			if (!/^\d+(,\d+)?$/.test(value)) return _('Invalid parameter');
+			return true;
+		};
+
 		o = s.taboption('forward', form.Value, 'addmac',
 			_('Add requestor MAC'),
 			_('Add the MAC address of the requestor to DNS queries which are forwarded upstream.') + ' ' + '<br />' +

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
@@ -260,6 +260,20 @@ return view.extend({
 		recordtypes.forEach(r => {
 			o.value(r);
 		});
+
+		s.taboption('cache', form.Flag, 'use_stale_cache',
+			_('Use stale cache'),
+			_('Return a cached DNS record even if its TTL has expired. Dnsmasq refreshes the data with an upstream query after returning the stale record.') + '<br />' +
+			_('This can improve speed and reliability, at the expense of sometimes returning out-of-date data and less efficient cache utilisation.'));
+
+		o = s.taboption('cache', form.Value, 'stale_cache_param',
+			_('Max expiration time'),
+			_('The maximum time a record may stay expired and still be served, in seconds. By default nothing expired for longer than one day is served.') + '<br />' +
+			_('Setting to zero will serve stale cache data regardless of how long it has expired.'));
+		o.optional = true;
+		o.datatype = 'uinteger';
+		o.placeholder = 86400;
+		o.depends('use_stale_cache', '1');
 		// End cache
 
 		// Begin devices


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86/64, openwrt snapshot, Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [x] \( Optional ) Depends on: https://github.com/openwrt/openwrt/pull/20823
- [x] Description: (describe the changes proposed in this PR)

Note: I don't know if Weblate likes the help text of `Fast retry time setting`/`fast_dns_retry_param`

![pic1](https://github.com/user-attachments/assets/cbbaecbf-9cc7-4925-a59e-a482a92ff0ed)

![pic2](https://github.com/user-attachments/assets/aea87cb0-cf83-4202-a093-1e5a0f8ac2d4)
