### PR TITLE
luci-app-wol: replace fs.stat/exec with safe RPC backend, fix ACLs

### DIFF
--- a/applications/luci-app-wol/root/usr/share/rpcd/acl.d/luci-app-wol.json
+++ b/applications/luci-app-wol/root/usr/share/rpcd/acl.d/luci-app-wol.json
@@ -3,14 +3,14 @@
 		"description": "Grant access to wake-on-lan executables",
 		"read": {
 			"ubus": {
-				"luci-rpc": [ "getHostHints" ]
+				"luci.wol": [ "stat" ],
+				"luci-rpc": [ "getHostHints", "getNetworkDevices" ]
 			},
 			"uci": [ "etherwake" ]
 		},
 		"write": {
-			"file": {
-				"/usr/bin/etherwake": [ "exec" ],
-				"/usr/bin/wol": [ "exec" ]
+			"ubus": {
+				"luci.wol": [ "exec" ]
 			}
 		}
 	}

--- a/applications/luci-app-wol/root/usr/share/rpcd/ucode/luci.wol
+++ b/applications/luci-app-wol/root/usr/share/rpcd/ucode/luci.wol
@@ -1,0 +1,57 @@
+#!/usr/bin/ucode
+
+'use strict';
+
+import { access, stat, popen } from 'fs';
+
+const etherwake = '/usr/bin/etherwake';
+const wakeonlan = '/usr/bin/wakeonlan';
+
+
+function shellquote(s) {
+    return "'" + replace(s, "'", "'\\''") + "'";
+}
+
+
+const methods = {
+	stat: {
+		call: function(request) {
+			const result = {};
+
+			result.etherwake = false;
+			result.wakeonlan = false;
+
+			if (access(etherwake, "x")) {
+				result.etherwake = true;
+			}
+
+			if (access(wakeonlan, "x")) {
+				result.wakeonlan = true;
+			}
+
+			return result;
+		}
+	},
+
+	exec: {
+		args: { name: 'string', args: [] },
+		call: function(request) {
+			const result = {};
+			if (request.args.name == etherwake || request.args.name == wakeonlan) {
+				parts = map(request.args.args, shellquote);
+				const fd = popen(request.args.name + ' ' + join(' ', parts));
+
+				result.stdout = fd.read('all');
+				result.stderr = '';
+				result.code = 0;
+			} else {
+				result.stdout = '';
+				result.stderr = 'disallowed';
+				result.code = 1;
+			}
+			return result;
+		}
+	}
+};
+
+return { "luci.wol": methods };


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: aarch64, OpenWrt 24.10.4, Opera One(version : 124.0.5705.42) :white_check_mark: 
- [x] \( Preferred ) Mention: @mdevolde
- [x] \( Preferred ) Screenshot or mp4 of changes:

<img width="977" height="391" alt="518189561-3d2b61e8-5241-49e5-9058-54c46eb06236" src="https://github.com/user-attachments/assets/f45465b8-fa11-4265-88ff-e5a4c7381036" />

<img width="984" height="391" alt="518201649-0ff4c5e8-3eb5-43c6-90fc-0a18e9200d47" src="https://github.com/user-attachments/assets/216288ad-6c71-48b4-a0da-2cf6ec31b14d" />


Screenshots of functional access to `luci-app-wol` for a restricted user (restricted to these permissions : read `unauthenticated`, read `luci-base`, read `luci-app-wol`, write `luci-app-wol`).

- [x] Description:

In its current state, if we create a restricted user as mentioned above, access to `luci-app-wol` does not work because it cannot verify that the two executables `/usr/bin/etherwake` and `/usr/bin/wol` exist via `fs.stat`.
Furthermore, it cannot be executed via `fs.exec` either, as ACLs are missing in `luci-app-wol.json` (`ubus file`).
Finally, an ACL concerning the use of `DeviceSelect` is also missing.

Instead of adding broad `ubus file.*` ACLs, a dedicated `luci.wol` backend has been added, providing two RPC methods:
- `stat` to verify that the two executables exist and are executable
- `exec` to execute one of these two executables, with parameters.

The missing ACL for using `DeviceSelect` has also been added (`getNetworkDevices`).

Adding this backend and the appropriate ACLs makes the `luci-app-wol` app functional, even for a restricted user, by assigning only the permissions necessary for it to work properly.

Signed-off-by: Martin Devolder <martin.devolder2@gmail.com>