### PR TITLE
CI: fix formality permissions

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -5,8 +5,16 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   formalities:
     name: Test Formalities
     uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
+    with:
+      exclude_weblate: true
+    #   # Post formality check summaries to the PR.
+    #   # Repo's permissions need to be updated for actions to modify PRs:
+    #   # https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
+    #   post_comment: true
+    #   warn_on_no_modify: true


### PR DESCRIPTION
Fix formality permissions ~~and post formality check summaries to a PR.~~

~~Enable warning when PR edits by maintainers are not allowed.~~

Depends on:
- [x] https://github.com/openwrt/actions-shared-workflows/pull/70
- [ ] ~~Updating repo's permissions for actions to modify PRs:~~
      ~~https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment~~