### PR TITLE
luci-theme-bootstrap: disable Dark Reader

### DIFF
--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -30,6 +30,7 @@
 			</script>
 		{% endif %}
 		<meta name="viewport" content="initial-scale=1.0">
+		<meta name="darkreader-lock">
 		<link rel="stylesheet" href="{{ media }}/cascade.css">
 		<link rel="stylesheet" media="only screen and (max-device-width: 854px)" href="{{ media }}/mobile.css" />
 		<link rel="icon" href="{{ media }}/logo_48.png" sizes="48x48">


### PR DESCRIPTION
I propose to disable [Dark Deader](https://darkreader.org/) browser extension in the bootstap theme since the theme has built-in dark and light modes, as well as a mode which auto-detects the user's preference. Dark Reader also doesn't work well with the bootstrap theme, as seen below when using Dark Reader:

Before the change in this PR:
<img width="413" height="459" alt="before" src="https://github.com/user-attachments/assets/a0796be3-49bd-460a-a8a2-78c8e1252654" />

After the change in this PR:
<img width="413" height="459" alt="after" src="https://github.com/user-attachments/assets/97b50e95-a9ec-4109-826c-28b25ba03a51" />
