### PR TITLE
luci-app-dockerman: fix unhandled nil on containers page

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
@@ -77,7 +77,7 @@ function get_containers()
 
 		for ii,iv in ipairs(images) do
 			if iv.Id == v.ImageID then
-				data[index]["_image"] = iv.RepoTags and iv.RepoTags[1] or (iv.RepoDigests[1]:gsub("(.-)@.+", "%1") .. ":<none>")
+				data[index]["_image"] = iv.RepoTags and iv.RepoTags[1] or ((iv.RepoDigests[1] or ""):gsub("(.-)@.+", "%1") .. ":<none>")
 			end
 		end
 


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, 24.10.0, chrome) :white_check_mark:
- [x] Description: 
<img width="1173" height="602" alt="Снимок экрана от 2025-11-28 10-23-07" src="https://github.com/user-attachments/assets/f0b3e7b3-9993-4352-a388-6732607fbfb0" />
Bug with unhandled nil on docker containers page

