### PR TITLE
luci-mod-network: bump reassociation_deadline default to 20000

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1885,7 +1885,7 @@ return view.extend({
 
 					o = ss.taboption('roaming', form.Value, 'reassociation_deadline', _('Reassociation Deadline'), _('time units (TUs / 1.024 ms) [1000-65535]'));
 					o.depends({ ieee80211r: '1' });
-					o.placeholder = '1000';
+					o.placeholder = '20000';
 					o.datatype = 'range(1000,65535)';
 					o.rmempty = true;
 


### PR DESCRIPTION
With OpenWRT commit [1], the default for reassociation_deadline is now 20000. Update LuCI to reflect that change.

[1]: https://github.com/openwrt/openwrt/commit/a7790ce41099549cf6c97765561ac716d102ae5e