### PR TITLE
[24.10] luci-app-https-dns-proxy: bugfix: rename options in luci app

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=2025.10.07
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-https-dns-proxy/

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -424,7 +424,7 @@ return view.extend({
 		o.modalonly = true;
 		o.optional = true;
 
-		o = s.option(form.ListValue, "use_http1", _("Use HTTP/1"));
+		o = s.option(form.ListValue, "force_http1", _("Use HTTP/1"));
 		o.modalonly = true;
 		o.optional = true;
 		o.rmempty = true;
@@ -434,7 +434,7 @@ return view.extend({
 
 		o = s.option(
 			form.ListValue,
-			"use_ipv6_resolvers_only",
+			"force_ipv6_resolvers",
 			_("Use IPv6 resolvers")
 		);
 		o.modalonly = true;


### PR DESCRIPTION
(cherry picked from commit cebf4cccce5a3b0daeda49d4e4ef784d698f6e74)
