### PR TITLE
luci-app-ksmbd: add option to set guest on IPC$ share

### DIFF
--- a/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
+++ b/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
@@ -54,6 +54,9 @@ return view.extend({
 		o = s.taboption('general', form.Value, 'description', _('Description'));
 		o.placeholder = 'Ksmbd on OpenWrt';
 		
+		o = s.taboption('general', form.Flag, 'allow_guest_ipc', _('Allow guest on IPC$.'),
+			_('Add optional guest access to IPC$ share, disabled by default'));
+
 		o = s.taboption('general', form.Flag, 'allow_legacy_protocols', _('Allow legacy (insecure) protocols/authentication.'),
 			_('Allow legacy smb(v1)/Lanman connections, needed for older devices without smb(v2.1/3) support.'));
 


### PR DESCRIPTION
From ksmbd-3.5.6 IPC$ guest is disabled by default.
This commit can restore guest access to IPC$ by check the option "Allow guest on IPC$"

Depends on: https://github.com/openwrt/packages/pull/28018
