### PR TITLE
luci-mod-status: show DHCPv6 stats as tooltip

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
@@ -3,6 +3,7 @@
 'require fs';
 'require network';
 'require rpc';
+'require ui';
 
 
 /* returns per odhcp6c active interface JSON like:
@@ -43,7 +44,10 @@ function renderbox(ifc, ipv6, dhcpv6_stats) {
 			const arr = [];
 			for (const [pkt_type, count] of Object.entries(dhcpv6_stats[dev.device]))
 				arr.push(pkt_type.replace('dhcp_', _('DHCPv6') + ' '), `${count} ${_('pkts', 'packets, abbreviated')}`);
-			return arr;
+			return [_('DHCPv6 Statistics'), E('span', { 'class': 'cbi-tooltip-container'}, [
+				'📊',
+				E('span', { 'class': 'cbi-tooltip' }, ui.itemlist(E('span'), arr))
+			])];
 		}
 		return ['', null];
 	}


### PR DESCRIPTION
In the previous view, the DHCPv6 statistics displayed in the IPv6 Upstream interface boxes contained many fields, which made the boxes very tall. This stretched the adjacent IPv4 Upstream boxes and left empty space in the middle.

*Previous view: all DHCPv6 stats visible, boxes height increased.*
<img width="1466" height="606" alt="image" src="https://github.com/user-attachments/assets/d57b1ddb-ef06-4fa4-9690-d99878e6586f" />

---

I suggest keeping the DHCPv6 statistics in tooltips. This way, the box content remains compact, while users can still view the details on hover.

*Current view: DHCPv6 stats shown as tooltips, box body stays concise.*
<img width="1723" height="576" alt="image" src="https://github.com/user-attachments/assets/f8209e19-f368-46c7-ba91-7d79c44db5ee" />
