### PR TITLE
luci-app-acme: fixed the issue where certificates were not displaying

### DIFF
--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme/acme.js
@@ -12,7 +12,7 @@ return view.extend({
 			L.resolveDefault(fs.list('/etc/ssl/acme/'), []).then(files => {
 				let certs = [];
 				for (let f of files) {
-					if (f.type == 'file' && f.name.match(/\.fullchain\.crt$/)) {
+					if ((f.type === 'file' || f.type === 'symlink' || f.type === 'link') && f.name.match(/\.fullchain\.crt$/)) {
 						certs.push(f);
 					}
 				}


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [ ] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (X86, openwrt 25.12, chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

This PR fixes an issue where ACME certificates were not displaying in the web interface. The fix expands the file type filter to include symlinks and files with undefined type properties, in addition to regular files, when listing certificate files in the /etc/ssl/acme/ directory.

Modified the file type check in the certificate listing logic to accept 'file', 'symlink', 'link', and entries with undefined type properties
Changed from loose equality (==) to strict equality (===) for type comparisons
Addresses scenarios where certificates may be stored as symlinks or have non-standard type properties

If after merging, hope to synchronize to openwrt-25.12 and other branches
