### PR TITLE
CI: post formality check comments to PRs

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -1,7 +1,7 @@
 name: Test Formalities
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read
@@ -13,8 +13,5 @@ jobs:
     uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
     with:
       exclude_weblate: true
-    #   # Post formality check summaries to the PR.
-    #   # Repo's permissions need to be updated for actions to modify PRs:
-    #   # https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
-    #   post_comment: true
-    #   warn_on_no_modify: true
+      post_comment: true
+      warn_on_no_modify: true


### PR DESCRIPTION
Enable posting formality check comments and warn if _Allow edits and access to secrets by maintainers_ is not checked.

Related:
- #8114 