### PR TITLE
luci-base: http.uc: add CSP headers to http response

### DIFF
--- a/applications/luci-app-uhttpd/htdocs/luci-static/resources/view/uhttpd/uhttpd.js
+++ b/applications/luci-app-uhttpd/htdocs/luci-static/resources/view/uhttpd/uhttpd.js
@@ -96,6 +96,28 @@ return view.extend({
 		o.default = o.enabled;
 		o.rmempty = false;
 
+		const csp_mode_option = s.taboption('general', form.RichListValue, "csp_mode", _('Content-Security-Policy'), _('Configure CSP headers to improve security.'));
+		csp_mode_option.value('none', _('None (default)'), _('Least secure. CSP disabled.'));
+		csp_mode_option.value('strict', _('Strict'), _('Most secure setting compatible with OpenWRT default installs.'));
+		csp_mode_option.value('permissive', _('Permissive'), _('Less secure than Strict, but better than None.<br>Use with integrations incompatible with Strict.'));
+		csp_mode_option.value('custom', _('Custom'), _('For experts only.'));
+		csp_mode_option.default = 'none';
+		csp_mode_option.rmempty = false;
+
+		const csp_policy_option = s.taboption('general', form.Value, 'csp_policy', _('Custom CSP Policy String'), _('The Content-Security-Policy header-value used in custom-mode.') + "<br />" + _(' WARNING: Wrong values for this setting can render the web-UI inaccessible and require recovery by SSH.'));
+		csp_policy_option.default = "default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'trusted-types-eval'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://sysupgrade.openwrt.org;";
+
+		csp_mode_option.onchange = function(ev, section_id, value) {
+			const policy_element = csp_policy_option.getUIElement(section_id);
+			const node = policy_element.node.querySelector('input');
+			const isCustom = value === 'custom';
+			if (isCustom) {
+				node.removeAttribute('readonly', 'readonly');
+			} else {
+				node.setAttribute('readonly', 'readonly');
+			}
+		};
+
 		o = s.taboption('general', form.Flag, 'rfc1918_filter', _('Ignore private IPs on public interface'), _('Prevent access from private (RFC1918) IPs on an interface if it has an public IP address'));
 		o.default = o.enabled;
 		o.rmempty = false;

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
@@ -14,6 +14,28 @@ return view.extend({
 		o = s.option(form.Flag, 'redirect_https', _('Redirect to HTTPS'), _('Enable automatic redirection of <abbr title="Hypertext Transfer Protocol">HTTP</abbr> requests to <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> port.'));
 		o.rmempty = false;
 
+		const csp_mode_option = s.option(form.RichListValue, "csp_mode", _('Content-Security-Policy'), _('Configure CSP headers to improve security.'));
+		csp_mode_option.value('none', _('None (default)'), _('Least secure. CSP disabled.'));
+		csp_mode_option.value('strict', _('Strict'), _('Most secure setting compatible with OpenWRT default installs.'));
+		csp_mode_option.value('permissive', _('Permissive'), _('Less secure than Strict, but better than None.<br>Use with integrations incompatible with Strict.'));
+		csp_mode_option.value('custom', _('Custom'), _('For experts only.'));
+		csp_mode_option.default = 'none';
+		csp_mode_option.rmempty = false;
+
+		const csp_policy_option = s.option(form.Value, 'csp_policy', _('Custom CSP Policy String'), _('The Content-Security-Policy header-value used in custom-mode.') + "<br />" + _(' WARNING: Wrong values for this setting can render the web-UI inaccessible and require recovery by SSH.'));
+		csp_policy_option.default = "default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'trusted-types-eval'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://sysupgrade.openwrt.org;";
+
+		csp_mode_option.onchange = function(ev, section_id, value) {
+			const policy_element = csp_policy_option.getUIElement(section_id);
+			const node = policy_element.node.querySelector('input');
+			const isCustom = value === 'custom';
+			if (isCustom) {
+				node.removeAttribute('readonly', 'readonly');
+			} else {
+				node.setAttribute('readonly', 'readonly');
+			}
+		};
+
 		return m.render();
 	}
 });


### PR DESCRIPTION
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (Atheros AR9132 rev 2, 25.12.0-RC1, Chromium) :white_check_mark:
- [X] \( Preferred ) Mention: @josteink
- [X] \( Preferred ) Screenshot or mp4 of changes: 
<img width="856" height="228" alt="image" src="https://github.com/user-attachments/assets/802d0f81-662b-4972-97b2-1fab7868dcd9" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5755d869-ce35-4e4f-9399-f93f6bcbf5cb" />

- [X] \( Optional ) Closes: e.g. openwrt/luci#8160
- [X] Description: (describe the changes proposed in this PR)

This PR adds support for Content Security Policy to Luci Web.

Content Security Policy is a very effective security hardening for browser-based applications:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP

CSP for OpenWRT/Luci is implemented in 4 different modes:

- None (Disabled - least secure) - default
- Permissive (More secure. Should permit extensive customization)
- Strict (Most secure. Only allow what is required by OpenWRT/Luci by default) - block everything else
- Custom - allow user to define own CSP policy

This option is stored in `/etc/config/uhttpd` and also manageable via the Luci Web UI under "System" -> "Administration" -> "uHTTPd" -> "HTTP(s) Acces" -> "General settings".