### PR TITLE
luci-mod-network: show "dhcpv4" option for dnsmasq

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -738,15 +738,17 @@ return view.extend({
 								_('As DHCP-Options; send unsolicited (dnsmasq only).'));
 						}
 
-						if (L.hasSystemFeature('odhcpd', 'dhcpv4')) {
+						if (L.hasSystemFeature('odhcpd', 'dhcpv4') || L.hasSystemFeature('dnsmasq')) {
 							so = ss.taboption('ipv4', form.RichListValue, 'dhcpv4', _('DHCPv4 Service'),
-									  _('Enable or disable DHCPv4 services on this interface (odhcpd only).'));
+									  _('Enable or disable DHCPv4 services on this interface.'));
 							so.optional = true;
-							so.value('', _('disabled'),
+							so.value('disabled', _('disabled'),
 								 _('Do not provide DHCPv4 services on this interface.'));
 							so.value('server', _('enabled'),
 								 _('Provide DHCPv4 services on this interface.'));
+						}
 
+						if (L.hasSystemFeature('odhcpd', 'dhcpv4')) {
 							so = ss.taboption('ipv4', form.Value, 'ipv6_only_preferred', _('IPv6-Only Preferred'),
 								_('Specifies how often (in seconds) clients should check whether IPv6-only mode is still preferred (see %s, odhcpd only).')
 								.format('<a href="%s" target="_blank">RFC8925</a>').format('https://www.rfc-editor.org/rfc/rfc8925'));


### PR DESCRIPTION
For odhcpd, an empty "dhcpv4" is equivalent to "disabled", but for dnsmasq, an empty "dhcpv4" is equivalent to "enabled", so an empty "dhcpv4" is ambiguous.

Fixes https://github.com/openwrt/openwrt/issues/21220

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: armsr/armv8, OpenWrt 25.12.0-rc1 r32353-9e9b05130c, Chrome :white_check_mark:
- [x] \( Preferred ) Mention: @systemcrash 
- [x] \( Optional ) Closes: https://github.com/openwrt/openwrt/issues/21220
- [x] Description: (describe the changes proposed in this PR)
dnsmasq cares about "dhcpv4" option in https://github.com/openwrt/openwrt/blob/74b5a63cf954219289e35a00d70eb09355b5d5ec/package/network/services/dnsmasq/files/dnsmasq.init#L602