### PR TITLE
luci-app-watchcat: revert multiple pinghosts support

### DIFF
--- a/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
+++ b/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
@@ -49,9 +49,9 @@ return view.extend({
 				1 hour would be: <b>1h</b></li><li>1 week would be: <b>7d</b></li><ul>"));
 		o.default = '6h';
 
-		o = s.taboption('general', form.DynamicList, 'pinghosts', _('Hosts To Check'), _(`IP addresses or hostnames to ping.`));
+		o = s.taboption('general', form.Value, 'pinghosts', _('Host To Check'), _(`IP address or hostname to ping.`));
 		o.datatype = 'host';
-		o.default = ['8.8.8.8', '1.1.1.1'];
+		o.default = '8.8.8.8';
 		o.depends({ mode: "ping_reboot" });
 		o.depends({ mode: "restart_iface" });
 		o.depends({ mode: "run_script" });


### PR DESCRIPTION
This change introduced support for multiple ping hosts, but due to inconsistent argument handling with the backend, it results in broken behavior.

As part of this revert, the pinghosts option is disabled in LUCI to restore the previous, known-working behavior. This aligns LUCI with the current backend until a proper fix is implemented.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86_64, openwrt SNAPSHOT, Firefox 146.0.1) :white_check_mark:
- [x] Mention: <nicholas@nbembedded.com> the original code author for feedback
- [x] Screenshot of changes below
- [x]  Closes: e.g. https://github.com/openwrt/packages/issues/28100
- [x]  Depends on: https://github.com/openwrt/packages/pull/28154 in sister repo
- [x] Description above

<img width="915" height="361" alt="imagen" src="https://github.com/user-attachments/assets/ae5e61f6-b67f-4d9e-a025-fcf3e1c4289d" />
Drop multiple ping host support

