### PR TITLE
luci: remove luci depend attendedsysupgrade

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -15,7 +15,6 @@ LUCI_DEPENDS:= \
 	+IPV6:luci-proto-ipv6 \
 	+luci-app-firewall \
 	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade \
 	+luci-mod-admin-full \
 	+luci-proto-ppp \
 	+luci-theme-bootstrap \

--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -17,8 +17,7 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
 LUCI_DEPENDS:=+luci-light \
 	+libustream-openssl \
 	+openssl-util \
-	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -13,8 +13,7 @@ LUCI_TITLE:=LuCI with HTTPS support (mbedtls as SSL backend)
 LUCI_DEPENDS:=+luci-light \
 	+libustream-mbedtls \
 	+px5g-mbedtls \
-	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -13,8 +13,7 @@ LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
 LUCI_DESCRIPTION:=Standard OpenWrt set including package management and attended sysupgrades support
 LUCI_DEPENDS:= \
 	+luci-light \
-	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
luci: remove luci depend attendedsysupgrade

Network upgrades are inherently uncontrollable, and the newly introduced network configurations will expose the system to hacker attacks. For this reason, luci-app-attendedsysupgrade should not be pre-installed by default.

 This PR is not from my main or master branch 💩, but a separate branch ✅
 Each commit has a valid ✒️ Signed-off-by: xiao bo <peterwillcn@gmail.com> row (via git commit --signoff)
 Each commit and PR title has a valid 📝 <luci>:(luci: remove luci depend attendedsysupgrade)
 Tested on: armsr/armv8, OpenWrt 25.12-SNAPSHOT, r32359-2da39423ed, Chrome ✅
 ( Preferred ) Mention: @jow- @systemcrash 
 ( Preferred ) Screenshot or mp4 of changes:
 Description: (describe the changes proposed in this PR)
We should avoid abusing "killall" because it can affect processes within the container.

