### PR TITLE
luci-ssl: remove luci depend attendedsysupgrade

### DIFF
--- a/collections/luci-nginx/Makefile
+++ b/collections/luci-nginx/Makefile
@@ -15,7 +15,6 @@ LUCI_DEPENDS:= \
 	+IPV6:luci-proto-ipv6 \
 	+luci-app-firewall \
 	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade \
 	+luci-mod-admin-full \
 	+luci-proto-ppp \
 	+luci-theme-bootstrap \

--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -17,8 +17,7 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
 LUCI_DEPENDS:=+luci-light \
 	+libustream-openssl \
 	+openssl-util \
-	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -13,8 +13,7 @@ LUCI_TITLE:=LuCI with HTTPS support (mbedtls as SSL backend)
 LUCI_DEPENDS:=+luci-light \
 	+libustream-mbedtls \
 	+px5g-mbedtls \
-	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -13,8 +13,7 @@ LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
 LUCI_DESCRIPTION:=Standard OpenWrt set including package management and attended sysupgrades support
 LUCI_DEPENDS:= \
 	+luci-light \
-	+luci-app-package-manager \
-	+luci-app-attendedsysupgrade
+	+luci-app-package-manager
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Not everyone needs attendedsysupgrade; let those who need it select it automatically, instead of adding it by default.


1.  **Priority to Space Compatibility**
    OpenWrt supports a vast array of hardware devices, including entry-level models equipped with only 4MB or 8MB of flash memory. Adding these tools—with a total footprint of over 200KB—as default packages would eat into the storage space reserved for the core system and other essential functions, rendering them incompatible with low-flash devices. **Providing them as optional packages** allows users to make independent choices based on their device's flash capacity, striking a balance between compatibility and flexibility.

2.  **On-Demand Function Loading**
    Attended sysupgrade is not a necessity for all users: some prefer compiling firmware manually, while certain embedded scenarios demand an ultra-minimalist system. Designating these tools as **optional components** aligns with OpenWrt’s modular, lightweight design philosophy, and prevents non-target users from being burdened with unnecessary dependencies.

3.  **Greater Flexibility for Iteration**
    The UI/UX of `luci-app-attendedsysupgrade` still requires optimization, and `owut` is undergoing component refactoring for architectural improvements. If these tools were included as default packages, any code changes would have to go through the rigorous iteration process for major releases. In contrast, distributing them as optional packages enables rapid updates via package feeds, accelerating feature development and bug fixes.

4.  **Recommended Implementation Plan**
    - Retain `luci-app-attendedsysupgrade` and `owut` in the **package feed repository** instead of migrating them to the main repository.
    - Avoid adding these tools as dependencies in `DEFAULT_PACKAGES`; instead, clearly document their functions in the LuCI package list and official documentation to guide users to install them on demand.
    - For high-flash-capacity devices, include these two tools in the officially recommended "full-featured firmware" configurations as a **differentiated supplement** to the default packages.


-  This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
-  Each commit has a valid :black_nib: `xiao bo peterwillcn@gmail.com` row (via `git commit --signoff`)
-  Each commit and PR title has a valid :memo: `luci-ssl: remove luci depend attendedsysupgrade` first line subject for packages
-  Tested on: armsr/armv8, OpenWrt 25.12-SNAPSHOT, r32359-2da39423ed, Chrome  :white_check_mark:
-  \( Preferred ) Mention: @hauke @jow- and also @aparcar
-  \( Preferred ) Screenshot or mp4 of changes:
-  \( Optional ) Closes: e.g. openwrt/luci#issue-number
-  \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
-  Description: (describe the changes proposed in this PR)
