### PR TITLE
luci-mod-network: show leases first in DHCP tab

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -211,13 +211,13 @@ return view.extend({
 		m = new form.Map('dhcp', _('DHCP'));
 		m.tabbed = true;
 
+		this.add_leases_cfg(m, hosts, duids, pools, macdata);
+
 		if (L.hasSystemFeature('dnsmasq'))
 			this.add_dnsmasq_cfg(m, networks);
 
 		if (L.hasSystemFeature('odhcpd'))
 			this.add_odhcpd_cfg(m);
-
-		this.add_leases_cfg(m, hosts, duids, pools, macdata);
 
 		return m.render().then(function(mapEl) {
 			poll.add(function() {


### PR DESCRIPTION
Fiddling with the dnsmasq/odhcpd specific settings is (at least in my experience) a much less common operation than wanting to see/change leases and their configuration, so reorder the tabs to show leases first and dnsmasq/odhcpd tabs second/third.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (NanoPi R6S, master, Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
