### PR TITLE
[24.10] luci-app-adblock-fast: update to 1.2.0-26

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=20
+PKG_RELEASE:=26
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-adblock-fast/

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -55,7 +55,7 @@ msgstr ""
 msgid "AdBlock-Fast - Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:279
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:325
 msgid "AdBlock-Fast - Status"
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:292
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:338
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Cache file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:327
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:373
 msgid "Cache file found."
 msgstr ""
 
@@ -127,11 +127,11 @@ msgstr ""
 msgid "Compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:297
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:343
 msgid "Compressed cache file created."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:329
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:375
 msgid "Compressed cache file found."
 msgstr ""
 
@@ -169,7 +169,7 @@ msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:526
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:572
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:348
 msgid "Disable"
 msgstr ""
@@ -178,11 +178,11 @@ msgstr ""
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:323
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:369
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:520
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:566
 msgid "Disabling %s service"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:507
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:553
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:349
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:503
 msgid "Enable"
@@ -225,11 +225,11 @@ msgstr ""
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:501
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:547
 msgid "Enabling %s service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:400
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:446
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
@@ -329,7 +329,7 @@ msgstr ""
 msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:300
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:346
 msgid "Force DNS ports:"
 msgstr ""
 
@@ -345,7 +345,7 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:448
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:494
 msgid "Force redownloading %s block lists"
 msgstr ""
 
@@ -442,7 +442,7 @@ msgstr ""
 msgid "No blocked list URLs nor blocked-domains enabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:343
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:389
 msgid "Not installed or not found"
 msgstr ""
 
@@ -450,11 +450,11 @@ msgstr ""
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:469
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:515
 msgid "Pause"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:464
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:510
 msgid "Pausing %s"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Pick the dnsmasq instance(s) for ad-blocking"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:310
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:356
 msgid "Please %sdonate%s to support development of this project."
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Processing lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:454
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:500
 msgid "Redownload"
 msgstr ""
 
@@ -511,19 +511,19 @@ msgstr ""
 msgid "Sanity check discovered leading dots in %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:567
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:613
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:387
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:433
 msgid "Service Errors"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:283
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:329
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:357
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:403
 msgid "Service Warnings"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Some output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:435
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:481
 msgid "Start"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Starting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:429
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:475
 msgid "Starting %s service"
 msgstr ""
 
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:488
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:534
 msgid "Stop"
 msgstr ""
 
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:482
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:528
 msgid "Stopping %s service"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:397
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:443
 msgid "Unknown error"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Unknown message"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:367
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:413
 msgid "Unknown warning"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:286
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:332
 msgid "Version %s"
 msgstr ""
 

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -15,7 +15,7 @@
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "pause" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "stop" }'
 
-readonly rpcdCompat='8'
+readonly rpcdCompat='9'
 readonly adbFunctionsFile="${IPKG_INSTROOT}/etc/init.d/adblock-fast"
 if [ -s "$adbFunctionsFile" ]; then
 # shellcheck source=../../../../../adblock-fast/files/etc/init.d/adblock-fast


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.4
Run tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.4

Description:
* sync Compat with principal package
* better modal popup UE on long operations (thanks @Aethersailor)


(cherry picked from commit 63113daa5abfb44ce7ea58f106083d00443f14df)
