### PR TITLE
[25.12] luci-app-pbr: upgrade to 1.2.1-45

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.2.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.2.1
+PKG_RELEASE:=45
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-pbr/

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
@@ -228,6 +228,21 @@ return view.extend({
 		o.datatype = "hexstring";
 
 		o = s.taboption(
+			"tab_advanced",
+			form.Value,
+			"uplink_ip_rules_priority",
+			_("Uplink IP Rules Priority"),
+			_(
+				"Starting (Uplink/WAN) ip rules priority used by the pbr service. High starting priority is " +
+					"used to avoid conflict with other services, this can be changed by user."
+			)
+		);
+		o.rmempty = true;
+		o.placeholder = "30000";
+		o.datatype = "uinteger";
+		o.default = "30000";
+
+		o = s.taboption(
 			"tab_webui",
 			form.ListValue,
 			"webui_show_ignore_target",
@@ -321,9 +336,7 @@ return view.extend({
 		o = s.option(form.ListValue, "chain", _("Chain"));
 		o.value("", "prerouting");
 		o.value("forward", "forward");
-		o.value("input", "input");
 		o.value("output", "output");
-		o.value("postrouting", "postrouting");
 		o.default = "";
 		o.rmempty = true;
 

--- a/applications/luci-app-pbr/po/templates/pbr.pot
+++ b/applications/luci-app-pbr/po/templates/pbr.pot
@@ -1,12 +1,12 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:277
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:398
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:308
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:432
 msgid "%s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:356
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:390
 msgid "%s binary cannot be found"
 msgstr ""
 
@@ -29,11 +29,11 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:234
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:249
 msgid "Add Ignore Target"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:236
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:251
 msgid ""
 "Adds 'ignore' to the list of interfaces for policies. See the %sREADME%s for "
 "details."
@@ -63,11 +63,11 @@ msgstr ""
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:321
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:336
 msgid "Chain"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:446
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:480
 msgid "Command failed: '%s'"
 msgstr ""
 
@@ -75,7 +75,7 @@ msgstr ""
 msgid "Condensed output"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:353
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:387
 msgid "Config (%s) validation failure"
 msgstr ""
 
@@ -83,23 +83,23 @@ msgstr ""
 msgid "Controls both system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:408
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:421
 msgid "Custom User File Includes"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:401
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:435
 msgid "Custom user file '%s' not found or empty"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:340
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:353
 msgid "DNS Policies"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:399
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:412
 msgid "DSCP Tag"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:386
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:399
 msgid "DSCP Tagging"
 msgstr ""
 
@@ -107,33 +107,33 @@ msgstr ""
 msgid "Default ICMP Interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:451
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:485
 msgid "Default fw4 chain '%s' is missing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:450
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:484
 msgid "Default fw4 table '%s' is missing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:585
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:634
 msgid "Disable"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:114
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:134
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:242
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:257
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:579
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:628
 msgid "Disabling %s service"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:252
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:267
 msgid "Display these protocols in protocol column in Web UI."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:303
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:334
 msgid ""
 "Dnsmasq instance (%s) targeted in settings, but it doesn't have its own "
 "confdir"
@@ -151,35 +151,35 @@ msgstr ""
 msgid "Do not enforce policies when their gateway is down"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:632
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:681
 msgid "Donate to the Project"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:566
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:615
 msgid "Enable"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:135
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:243
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:274
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:354
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:421
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:258
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:289
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:367
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:434
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:560
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:609
 msgid "Enabling %s service"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:403
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:437
 msgid "Error running custom user file '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:459
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:493
 msgid "Errors encountered, please check %s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:474
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:523
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
@@ -189,35 +189,35 @@ msgid ""
 "QoS. Change with caution together with"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:457
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:491
 msgid "Failed to create temporary file with mktemp mask: '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:442
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:476
 msgid "Failed to download '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:440
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:474
 msgid "Failed to download '%s', HTTPS is not supported"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:435
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:469
 msgid "Failed to install fw4 nft file '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:400
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:434
 msgid "Failed to reload '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:431
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:465
 msgid "Failed to resolve '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:399
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:433
 msgid "Failed to set up '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:407
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:441
 msgid "Failed to set up any gateway"
 msgstr ""
 
@@ -245,15 +245,15 @@ msgstr ""
 msgid "Inactive (Disabled)"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:318
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:349
 msgid "Incompatible DHCP Option 6 for interface %s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:448
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:482
 msgid "Incompatible custom user file detected '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:300
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:331
 msgid ""
 "Incompatible nft calls detected in user include file, disabling fw4 nft file "
 "support"
@@ -263,51 +263,51 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:425
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:459
 msgid "Insertion failed for IPv4 for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:422
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:456
 msgid "Insertion failed for both IPv4 and IPv6 for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:275
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:306
 msgid "Installed AdGuardHome (%s) doesn't support 'ipset_file' option."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:330
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:343
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:393
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:427
 msgid "Interface '%s' has no assigned DNS"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:269
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:300
 msgid ""
 "Internal version mismatch (package: %s, luci app: %s, luci rpcd: %s), you "
 "may need to update packages or reboot the device, please check the "
 "%sREADME%s."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:291
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:322
 msgid "Invalid OpenVPN config for %s interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:433
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:467
 msgid "Invalid OpenVPN config for '%s' interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:280
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:361
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:295
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:374
 msgid "Local addresses / devices"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:286
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:301
 msgid "Local ports"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:416
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:450
 msgid "Mismatched IP family between in policy '%s'"
 msgstr ""
 
@@ -315,12 +315,12 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:278
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:358
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:293
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:371
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:261
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:276
 msgid ""
 "Name, interface and at least one other field are required. Multiple local "
 "and remote addresses/devices/domains and ports can be space separated. "
@@ -328,18 +328,42 @@ msgid ""
 "fields are left blank. For more information on options, check the %sREADME%s."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:342
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:355
 msgid ""
 "Name, local address and remote DNS fields are required. Multiple local "
 "addresses/devices can be space separated. For more information on options, "
 "check the %sREADME%s."
 msgstr ""
 
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:495
+msgid "Netifd setup: failed to install fw4 netifd nft file '%s'"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:498
+msgid "Netifd setup: failed to remove fw4 netifd nft file '%s'"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:504
+msgid "Netifd setup: invalid value of netifd_interface_default option '%s'"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:507
+msgid "Netifd setup: invalid value of netifd_interface_default6 option '%s'"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:352
+msgid "Netifd setup: option netifd_interface_local is missing, assuming '%s'"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:501
+msgid "Netifd setup: required option '%s' is missing"
+msgstr ""
+
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:188
 msgid "No Change"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:217
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:248
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:58
 msgid "Not installed or not found"
 msgstr ""
@@ -348,12 +372,12 @@ msgstr ""
 msgid "Output verbosity"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:426
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:439
 msgid "Path"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:244
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:640
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:275
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:689
 msgid "Please %sdonate%s to support development of this project."
 msgstr ""
 
@@ -361,48 +385,48 @@ msgstr ""
 msgid "Please check the %sREADME%s before changing this option."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:307
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:338
 msgid ""
 "Please set 'dhcp.%%s.force=1' to speed up service start-up %s(more info)%s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:285
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:316
 msgid "Please unset 'chain' or set 'chain' to 'PREROUTING' for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:288
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:319
 msgid "Please unset 'chain' or set 'chain' to 'prerouting' for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:282
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:313
 msgid "Please unset 'proto' or set 'proto' to 'all' for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:279
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:310
 msgid "Please unset 'src_addr', 'src_port' and 'dest_port' for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:259
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:274
 msgid "Policies"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:396
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:430
 msgid "Policy '%s' has an unknown interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:391
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:425
 msgid "Policy '%s' has no assigned DNS"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:390
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:424
 msgid "Policy '%s' has no assigned interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:388
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:422
 msgid "Policy '%s' has no source/destination parameters"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:437
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:471
 msgid ""
 "Policy '%s' refers to URL which can't be downloaded in 'secure_reload' mode"
 msgstr ""
@@ -415,7 +439,7 @@ msgstr ""
 msgid "Policy Based Routing - Configuration"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:190
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:221
 msgid "Policy Based Routing - Status"
 msgstr ""
 
@@ -423,65 +447,65 @@ msgstr ""
 msgid "Policy Routing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:304
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:319
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:429
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:463
 msgid "Received empty tid/mark or interface name when setting up routing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:376
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:410
 msgid "Refer to https://docs.openwrt.melmac.ca/pbr/#uplink_interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:368
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:381
 msgid "Remote DNS"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:376
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:389
 msgid "Remote DNS Port"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:292
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:307
 msgid "Remote addresses / domains"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:298
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:313
 msgid "Remote ports"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:452
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:486
 msgid "Required binary '%s' is missing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:408
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:442
 msgid "Resolver '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:364
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:398
 msgid "Resolver set (%s) is not supported on this system"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:272
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:303
 msgid "Resolver set (%s) is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:358
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:392
 msgid ""
 "Resolver set support (%s) requires ipset, but ipset binary cannot be found"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:361
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:395
 msgid ""
 "Resolver set support (%s) requires nftables, but nft binary cannot be found"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:528
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:577
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:522
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:571
 msgid "Restarting %s service"
 msgstr ""
 
@@ -489,13 +513,13 @@ msgstr ""
 msgid "Rule Create option"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:410
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:423
 msgid ""
 "Run the following user files after setting up but before restarting DNSMASQ. "
 "See the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:199
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:230
 msgid "Running"
 msgstr ""
 
@@ -507,11 +531,11 @@ msgstr ""
 msgid "Select Add for -A/add and Insert for -I/Insert."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:611
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:660
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:464
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:513
 msgid "Service Errors"
 msgstr ""
 
@@ -520,33 +544,33 @@ msgstr ""
 msgid "Service FW Mask"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:231
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:262
 msgid "Service Gateways"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:194
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:225
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:324
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:358
 msgid "Service Warnings"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:388
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:401
 msgid ""
 "Set DSCP tags (in range between 1 and 63) for specific interfaces. See the "
 "%sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:410
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:444
 msgid "Skipping IPv6 policy '%s' as IPv6 support is disabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:509
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:558
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:503
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:552
 msgid "Starting %s service"
 msgstr ""
 
@@ -557,23 +581,30 @@ msgid ""
 "together with"
 msgstr ""
 
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:236
+msgid ""
+"Starting (Uplink/WAN) ip rules priority used by the pbr service. High "
+"starting priority is used to avoid conflict with other services, this can be "
+"changed by user."
+msgstr ""
+
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:63
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:547
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:596
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:213
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:244
 msgid "Stopped (Disabled)."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:211
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:242
 msgid "Stopped."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:541
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:590
 msgid "Stopping %s service"
 msgstr ""
 
@@ -589,7 +620,7 @@ msgstr ""
 msgid "Supported Interfaces"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:251
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:266
 msgid "Supported Protocols"
 msgstr ""
 
@@ -597,29 +628,29 @@ msgstr ""
 msgid "Suppress/No output"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:402
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:436
 msgid "Syntax error in custom user file '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:235
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:266
 msgid "The %s indicates default gateway. See the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:373
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:407
 msgid ""
-"The %s interface not found, you need to set the "
-"'pbr.config.uplink_interface' option"
+"The %s interface not found, you need to set the 'pbr.config."
+"uplink_interface' option"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:96
 msgid "The %s is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:370
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:404
 msgid "The %s service failed to discover WAN gateway"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:367
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:401
 msgid "The %s service is currently disabled"
 msgstr ""
 
@@ -627,39 +658,39 @@ msgstr ""
 msgid "The %s support is unknown."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:294
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:325
 msgid "The WebUI application (luci-app-pbr) is outdated, please update it"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:444
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:478
 msgid "The file:// schema requires curl, but it's not detected on this system"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:379
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:413
 msgid "The ipset name '%s' is longer than allowed 31 characters"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:382
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:416
 msgid "The nft set name '%s' is longer than allowed 255 characters"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:297
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:328
 msgid "The principal package (pbr) is outdated, please update it"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:385
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:419
 msgid "Unexpected exit or service termination: '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:454
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:488
 msgid "Unknown IPv6 Link type for device '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:427
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:461
 msgid "Unknown entry in policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:471
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:520
 msgid "Unknown error"
 msgstr ""
 
@@ -667,23 +698,27 @@ msgstr ""
 msgid "Unknown message"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:413
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:447
 msgid "Unknown packet mark for interface '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:419
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:453
 msgid "Unknown protocol in policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:331
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:365
 msgid "Unknown warning"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:234
+msgid "Uplink IP Rules Priority"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:200
 msgid "Uplink Interface Table FW Mark"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:405
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:439
 msgid ""
 "Use of 'curl' is detected in custom user file '%s', but 'curl' isn't "
 "installed"
@@ -701,7 +736,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:197
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:228
 msgid "Version %s"
 msgstr ""
 
@@ -709,11 +744,11 @@ msgstr ""
 msgid "WAN Table FW Mark"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:316
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:347
 msgid "Warnings encountered, please check %s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:334
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:368
 msgid "Warnings encountered, please check the %sREADME%s"
 msgstr ""
 
@@ -721,21 +756,21 @@ msgstr ""
 msgid "Web UI Configuration"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:313
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:328
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:203
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:234
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:44
 msgid "fw4 nft file mode"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:201
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:232
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:42
 msgid "iptables mode"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:205
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:236
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:46
 msgid "nft mode"
 msgstr ""

--- a/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
+++ b/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
@@ -12,7 +12,7 @@
 # ubus -S call luci.pbr getGateways '{"name": "pbr" }'
 # ubus -S call luci.pbr getInterfaces '{"name": "pbr" }'
 
-readonly rpcdCompat='17'
+readonly rpcdCompat='20'
 readonly pbrFunctionsFile="${IPKG_INSTROOT}/etc/init.d/pbr"
 if [ -s "$pbrFunctionsFile" ]; then
 # shellcheck source=../../../../../pbr/files/etc/init.d/pbr
@@ -24,7 +24,7 @@ fi
 
 # compatibility with old luci app versions
 is_running_iptables() { iptables -t mangle -n -L | grep -q PBR_PREROUTING >/dev/null 2>&1; }
-is_running() { is_running_iptables || is_running_nft; }
+is_running() { exists_lockfile && { is_running_iptables || is_running_nft; }; }
 check_ipset() { { [ -n "$ipset" ] && "$ipset" help hash:net; } >/dev/null 2>&1; }
 check_agh_ipset() {
 	check_ipset || return 1
@@ -113,7 +113,6 @@ get_init_status() {
 		json_add_boolean 'running_nft_file' '0'
 	fi
 	json_add_string 'version' "$PKG_VERSION"
-	json_add_string 'gateways' "$gateways"
 	json_add_int		'packageCompat'	"${packageCompat:-0}"
 	json_add_int		'rpcdCompat'		"${rpcdCompat:-0}"
 	json_close_object


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.4
Run tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.4

Description:
Makefile:
* update version to match principal package

Javascript:
* update Compat variables to match principal package
* allow waiting for longer operations to complete
* update warnings/error messages arrays
* add uplink_ip_rules_priority option to WebUI
* remove obsolete input and postrouting chains from WebUI

RPCD script:
* remove gateways string from getInitStatus, as the gateways array is returned by its own call


(cherry picked from commit 1ce137b6ca7f5e8114ae7639f57617eadddbef9b)
