### PR TITLE
[openwrt-25.12] luci-base: rpc: fix luci/getMountPoints crash on path containing '\xxx'

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -541,8 +541,8 @@ const methods = {
 
 				for (let line = fd.read('line'); length(line); line = fd.read('line')) {
 					const m = split(line, ' ');
-					const device = replace(m[0], /\\([0-9][0-9][0-9])/g, (m, n) => char(int(n, 8)));
-					const mount  = replace(m[1], /\\([0-9][0-9][0-9])/g, (m, n) => char(int(n, 8)));
+					const device = replace(m[0], /\\([0-9][0-9][0-9])/g, (m, n) => chr(int(n, 8)));
+					const mount  = replace(m[1], /\\([0-9][0-9][0-9])/g, (m, n) => chr(int(n, 8)));
 					const stat = statvfs(mount);
 
 					if (stat?.blocks > 0) {


### PR DESCRIPTION
getMountPoints crash on path containing '\xxx'.

`char` should be `chr`

Fixes https://github.com/openwrt/openwrt/issues/21459


(cherry picked from commit 5ad9c3609e1616836d6bc6125a6c983231a2de9c)

This is a backport of https://github.com/openwrt/luci/pull/8204
