### PR TITLE
luci-base: fix ipaddrport brackets for ipv6 validation

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -422,7 +422,7 @@ const ValidatorFactory = baseclass.extend({
 
 		ipaddrport(bracket) {
 			const m4 = this.value.match(/^([^\[\]:]+):(\d+)$/);
-			const m6 = this.value.match((bracket == 1) ? /^\[(.+)\]:(\d+)$/ : /^([^\[\]]+):(\d+)$/);
+			const m6 = this.value.match((bracket == 1) ? /^(\[(.+)\]):(\d+)$/ : /^([^\[\]]+):(\d+)$/);
 
 			if (m4)
 				return this.assert(this.apply('ip4addr', m4[1], [true]) && this.apply('port', m4[2]),


### PR DESCRIPTION
**Description:** There was an error in the regex in the case (brackets == 1): The ip6addr part was not captured (no parentheses), so validation always failed for ipaddrport(1) when entering an ipv6-address:port pair.

This commit adds the parentheses and allows validation to succeed.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- ? Incremented :up: any `PKG_VERSION` in the Makefile
  _There is no PKG_VERSION in the `luci-base` Makefile_
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
  bcm27xx/bcm217, SNAPSHOT r32673-9d1f6ec49d, Firefox 140.7.0 ESR
- [x] \( Preferred ) Mention: @ the original code author for feedback
  @jow- @hnyman @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
