### PR TITLE
luci-app-radicale3: use ip6 bracket notation

### DIFF
--- a/applications/luci-app-radicale3/htdocs/luci-static/resources/view/radicale3.js
+++ b/applications/luci-app-radicale3/htdocs/luci-static/resources/view/radicale3.js
@@ -53,11 +53,11 @@ return view.extend({
 
 		button = '';
 
-		if ((radicale_address == '127.0.0.1') || (radicale_address == '::1')) {
+		if ((radicale_address == '127.0.0.1') || (radicale_address == '[::1]') || radicale_host == 'localhost') {
 			ui.addNotification(_('Need a listen address'),
 				_('Radicale needs a non-loopback IP address for your browser to access the web interface'));
 		} else {
-			if (radicale_address == '0.0.0.0' || radicale_address == '::') {
+			if (radicale_address == '0.0.0.0' || radicale_address == '[::]') {
 				radicale_address = window.location.hostname;
 			}
 			radicale_port = radicale_host.substring(radicale_host.lastIndexOf(':') + 1) || '5232';
@@ -84,8 +84,8 @@ return view.extend({
 
 		o = s.taboption('main', form.DynamicList, 'host', _('Host:port'));
 		o.optional = true;
-		o.datatype = 'or(hostport(0),ipaddrport(0))';
-		o.default = ['127.0.0.1:5232', '::1:5232'];
+		o.datatype = 'or(hostport(0),ipaddrport(1))';
+		o.default = ['127.0.0.1:5232', '[::1]:5232'];
 
 		s.tab('advanced', _('Advanced'));
 


### PR DESCRIPTION
**Description**: Update iphostport validation to use bracket notation for ipv6 IP addresses. Radicale understands it, and it is the preferred notation when using an IP address and port, together.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- N/A Incremented :up: any `PKG_VERSION` in the Makefile
  _appears to be auto-generated, not a manual setting_
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
  bcm27xx/bcm2712, SNAPSHOT r32673-9d1f6ec49d, Firefox 140.7.0 ESR
- [x] \( Preferred ) Mention: @ the original code author for feedback
  @danielfdickinson @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)