### PR TITLE
Revert "luci-app-mwan3: delete additional mwan3 load call"

### DIFF
--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/member.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/member.js
@@ -5,6 +5,11 @@
 'require ui';
 
 return view.extend({
+	load: function() {
+		return Promise.all([
+			uci.load('mwan3')
+		]);
+	},
 
 	render: function () {
 		let m, s, o;

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/policy.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/policy.js
@@ -5,6 +5,11 @@
 'require ui';
 
 return view.extend({
+	load: function() {
+		return Promise.all([
+			uci.load('mwan3')
+		]);
+	},
 
 	render: function () {
 		let m, s, o;

--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/rule.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/rule.js
@@ -8,7 +8,8 @@
 return view.extend({
 	load: function() {
 		return Promise.all([
-			fs.exec_direct('/usr/libexec/luci-mwan3', ['ipset', 'dump'])
+			fs.exec_direct('/usr/libexec/luci-mwan3', ['ipset', 'dump']),
+			uci.load('mwan3')
 		]);
 	},
 


### PR DESCRIPTION
This commit introduces a regression, so that in the policy, rule and member pages, the dropdowns are not filled with the required configuration options from the mwan3 configuration. Reverting the commit resolves the issue and the dropdowns are filled with values again.

Fixes: #8232

This reverts commit 1243d8023aaaf29a7cb750e104b5e96ec3689544.
