### PR TITLE
luci-app-radicale3: fix bcrypt/libpass detection

### DIFF
--- a/applications/luci-app-radicale3/htdocs/luci-static/resources/view/radicale3.js
+++ b/applications/luci-app-radicale3/htdocs/luci-static/resources/view/radicale3.js
@@ -31,7 +31,7 @@ const callEncrypt = rpc.declare({
 const callPackageList = rpc.declare({
 	object: 'rpc-sys',
 	method: 'packagelist',
-	params: [],
+	params: ['all'],
 	expect: {},
 });
 
@@ -39,7 +39,7 @@ return view.extend({
 	load() {
 		return Promise.all([
 			L.resolveDefault(callServiceList('radicale3')),
-			L.resolveDefault(callPackageList()),
+			L.resolveDefault(callPackageList(true)),
 			uci.load('radicale3'),
 		]);
 	},


### PR DESCRIPTION
**Description:** Update call to `rpc-sys packagelist` to list all packages, not just top-level packages, so that we can actually check if python3-libpass and python3-bcrypt are installed.

Without this bcrypt authentication will not be made available to the user.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
  bcm27xx/bcm2712 rpi-5, SNAPSHOT r32673-9d1f6ec49d, Firefix 140.7.0 ESR
- [x] \( Preferred ) Mention: @ the original code author for feedback
  @danielfdickinson 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

@BKPepe FYI