### PR TITLE
luci-base: fix JSDoc errors in form.Flag and form.Button

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -4298,13 +4298,13 @@ const CBIRangeSliderValue = CBIValue.extend(/** @lends LuCI.form.RangeSliderValu
 });
 
 /**
- * @class FlagValue
+ * @class Flag
  * @memberof LuCI.form
  * @augments LuCI.form.Value
  * @hideconstructor
  * @classdesc
  *
- * The `FlagValue` element builds upon the {@link LuCI.ui.Checkbox} widget to
+ * The `Flag` element builds upon the {@link LuCI.ui.Checkbox} widget to
  * implement a simple checkbox element.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
@@ -4328,7 +4328,7 @@ const CBIRangeSliderValue = CBIValue.extend(/** @lends LuCI.form.RangeSliderValu
  * @param {string} [description]
  * The description text of the option element.
  */
-const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */ {
+const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.Flag.prototype */ {
 	__name__: 'CBI.FlagValue',
 
 	__init__(...args) {
@@ -4342,7 +4342,7 @@ const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */
 	/**
 	 * Sets the input value to use for the checkbox checked state.
 	 *
-	 * @name LuCI.form.FlagValue.prototype#enabled
+	 * @name LuCI.form.Flag.prototype#enabled
 	 * @type string
 	 * @default 1
 	 */
@@ -4350,7 +4350,7 @@ const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */
 	/**
 	 * Sets the input value to use for the checkbox unchecked state.
 	 *
-	 * @name LuCI.form.FlagValue.prototype#disabled
+	 * @name LuCI.form.Flag.prototype#disabled
 	 * @type string
 	 * @default 0
 	 */
@@ -4364,7 +4364,7 @@ const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */
 	 * value will be shown as a tooltip. If the return value of the function
 	 * is `null` no tooltip will be set.
 	 *
-	 * @name LuCI.form.FlagValue.prototype#tooltip
+	 * @name LuCI.form.Flag.prototype#tooltip
 	 * @type string|function
 	 * @default null
 	 */
@@ -4375,7 +4375,7 @@ const CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */
 	 * If set, this icon will be shown for the default one.
 	 * This could also be a png icon from the resources directory.
 	 *
-	 * @name LuCI.form.FlagValue.prototype#tooltipicon
+	 * @name LuCI.form.Flag.prototype#tooltipicon
 	 * @type string
 	 * @default 'ℹ️';
 	 */
@@ -4733,13 +4733,13 @@ const CBIDummyValue = CBIValue.extend(/** @lends LuCI.form.DummyValue.prototype 
 });
 
 /**
- * @class ButtonValue
+ * @class Button
  * @memberof LuCI.form
  * @augments LuCI.form.Value
  * @hideconstructor
  * @classdesc
  *
- * The `ButtonValue` element wraps a {@link LuCI.ui.Hiddenfield} widget and
+ * The `Button` element wraps a {@link LuCI.ui.Hiddenfield} widget and
  * renders the underlying UCI option or default value as readonly text.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
@@ -4763,7 +4763,7 @@ const CBIDummyValue = CBIValue.extend(/** @lends LuCI.form.DummyValue.prototype 
  * @param {string} [description]
  * The description text of the option element.
  */
-const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototype */ {
+const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.Button.prototype */ {
 	__name__: 'CBI.ButtonValue',
 
 	/**
@@ -4779,7 +4779,7 @@ const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototyp
 	 *
 	 * The default of `null` means the option title is used as caption.
 	 *
-	 * @name LuCI.form.ButtonValue.prototype#inputtitle
+	 * @name LuCI.form.Button.prototype#inputtitle
 	 * @type string|function
 	 * @default null
 	 */
@@ -4795,7 +4795,7 @@ const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototyp
 	 *
 	 * The default of `null` means a neutral button styling is used.
 	 *
-	 * @name LuCI.form.ButtonValue.prototype#inputstyle
+	 * @name LuCI.form.Button.prototype#inputstyle
 	 * @type string
 	 * @default null
 	 */
@@ -4812,7 +4812,7 @@ const CBIButtonValue = CBIValue.extend(/** @lends LuCI.form.ButtonValue.prototyp
 	 * DOM click element as the first and the underlying configuration section ID
 	 * as the second argument.
 	 *
-	 * @name LuCI.form.ButtonValue.prototype#onclick
+	 * @name LuCI.form.Button.prototype#onclick
 	 * @type function
 	 * @default null
 	 */


### PR DESCRIPTION
Fix JSDoc `@lends`, `@name`, `@class`, and `@classdesc` annotations for `form.Flag` and `form.Button` classes.

The JSDoc documentation was referencing incorrect names:
- `form.FlagValue` → `form.Flag`
- `form.ButtonValue` → `form.Button`

This aligns the documentation with the actual definitions, preventing confusion for developers using the API.