### PR TITLE
[24.10] luci-app-https-dns-proxy: update to 2025.12.29-3

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=2025.12.29
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/stangri/luci-app-https-dns-proxy/

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
@@ -14,7 +14,7 @@ return baseclass.extend({
 		return Promise.all([
 			hdp.getInitStatus(pkg.Name),
 			hdp.getProviders(pkg.Name),
-			hdp.getRuntime(pkg.Name),
+			hdp.getServiceInfo(pkg.Name),
 		]);
 	},
 

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,11 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:284
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:283
 msgid "%s%s%s proxy at %s on port %s.%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:276
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:275
 msgid "%s%s%s proxy on port %s.%s"
 msgstr ""
 
@@ -205,11 +205,11 @@ msgstr ""
 msgid "Direct"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:408
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:407
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:402
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:401
 msgid "Disabling %s service"
 msgstr ""
 
@@ -225,11 +225,11 @@ msgstr ""
 msgid "DoH DNS (SB)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:389
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:388
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:383
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:382
 msgid "Enabling %s service"
 msgstr ""
 
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:197
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:196
 msgid "Force DNS ports:"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "HTTPS DNS Proxy - Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:187
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:186
 msgid "HTTPS DNS Proxy - Status"
 msgstr ""
 
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Norway"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:213
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:212
 msgid "Not installed or not found"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:295
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:294
 msgid "Please %sdonate%s to support development of this project."
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "Quad 9"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:351
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:350
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:345
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:344
 msgid "Restarting %s service"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Security Filter"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:229
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:228
 msgid "See the %sREADME%s for details."
 msgstr ""
 
@@ -601,11 +601,11 @@ msgstr ""
 msgid "Select the DNSMASQ Configs to update"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:434
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:433
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:227
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:226
 msgid "Service Instances"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Service Options"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:191
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:190
 msgid "Service Status"
 msgstr ""
 
@@ -647,11 +647,11 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:332
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:331
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:326
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:325
 msgid "Starting %s service"
 msgstr ""
 
@@ -660,11 +660,11 @@ msgstr ""
 msgid "Statistic Interval"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:370
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:369
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:364
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:363
 msgid "Stopping %s service"
 msgstr ""
 
@@ -783,15 +783,15 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:195
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:194
 msgid "Version %s - Running."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:207
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:206
 msgid "Version %s - Stopped (Disabled)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:205
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:204
 msgid "Version %s - Stopped."
 msgstr ""
 

--- a/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
+++ b/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
@@ -9,7 +9,6 @@
 # ubus -S call luci.https-dns-proxy getInitStatus '{"name": "https-dns-proxy" }'
 # ubus -S call luci.https-dns-proxy getPlatformSupport '{"name": "https-dns-proxy" }'
 # ubus -S call luci.https-dns-proxy getProviders '{"name": "https-dns-proxy" }'
-# ubus -S call luci.https-dns-proxy getRuntime '{"name": "https-dns-proxy" }'
 
 readonly packageName="https-dns-proxy"
 readonly providersDir="/usr/share/${packageName}/providers"
@@ -112,19 +111,18 @@ get_providers() {
 	echo ']}'
 }
 
-get_runtime() { ubus call service list "{ 'verbose': true, 'name': '$1' }"; }
-
 set_init_action() {
-	local name="$1" action="$2" cmd
-	case $action in
+	local action="$2" cmd
+	[ "$(basename "$1")" = "$packageName" ] || { print_json_bool 'result' '0'; return 1; }
+		case $action in
 		enable|disable|start|stop|restart)
-			cmd="/etc/init.d/${name} ${action}"
+			cmd="/etc/init.d/${packageName} ${action}"
 		;;
 	esac
 	if [ -n "$cmd" ] && eval "$cmd" >/dev/null 2>&1; then
-		print_json_bool "result" '1'
+		print_json_bool 'result' '1'
 	else
-		print_json_bool "result" '0'
+		print_json_bool 'result' '0'
 	fi
 }
 
@@ -141,9 +139,6 @@ case "$1" in
 			json_add_string 'name' 'name'
 		json_close_object
 		json_add_object "getProviders"
-			json_add_string 'name' "name"
-		json_close_object
-		json_add_object "getRuntime"
 			json_add_string 'name' "name"
 		json_close_object
 		json_add_object "setInitAction"
@@ -182,13 +177,6 @@ case "$1" in
 				json_get_var name "name"
 				json_cleanup
 				get_providers "$name"
-				;;
-			getRuntime)
-				read -r input
-				json_load "$input"
-				json_get_var name "name"
-				json_cleanup
-				get_runtime "$name"
 				;;
 			setInitAction)
 				read -r input

--- a/applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json
@@ -7,23 +7,16 @@
 					"getInitList",
 					"getInitStatus",
 					"getPlatformSupport",
-					"getProviders",
-					"getRuntime"
-				]
+					"getProviders"
+				],
+				"service": ["list"]
 			},
-			"uci": [
-				"dhcp",
-				"https-dns-proxy"
-			]
+			"uci": ["dhcp", "https-dns-proxy"]
 		},
 		"write": {
-			"uci": [
-				"https-dns-proxy"
-			],
+			"uci": ["https-dns-proxy"],
 			"ubus": {
-				"luci.https-dns-proxy": [
-					"setInitAction"
-				]
+				"luci.https-dns-proxy": ["setInitAction"]
 			}
 		}
 	}


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.4
Run tested: x86_64, Dell EMC Edge 620, OpenWrt 24.10.4

Description:
status.js:
* update the donate anchor
* replace RPCD call with direct ubus pull of service info for faster operation

Overview page include javascript file:
* replace RPCD call with ubus pull

RPCD script:
* remove obsolete getRuntime method
* bugfix: prevent execution of arbitrary code (thanks @iwallplace)

ACL file:
* remove obsolete getRuntime access and add access to service list


(cherry picked from commit 721ec9414546d1968dcaed39e1986b415759d2c5)
