### PR TITLE
luci-mod-status: resolve service names for ports

### DIFF
--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -2,6 +2,9 @@
 	"luci-mod-status-realtime": {
 		"description": "Grant access to realtime statistics",
 		"read": {
+			"file": {
+				"/etc/services": [ "read" ]
+			},
 			"ubus": {
 				"luci": [ "getConntrackList", "getRealtimeStats" ],
 				"network.rrdns": [ "lookup" ]


### PR DESCRIPTION
- Parse and map ports to corresponding service names.
- Display service names when DNS lookups are enabled.

Rationale:

Enhance endpoint readability by showing service names where available, improving clarity of source/destination information.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture: ARMv7, OpenWrt 25.12.0-rc2, browser: Chrome) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)
