### PR TITLE
luci-app-nut: nut-server: show/hide genericups config

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -191,9 +191,11 @@ return view.extend({
 		o.placeholder = 45;
 
 		o = s.option(form.Value, 'mfr', _('Manufacturer (Display)'));
+		o.depends("driver", "genericups")
 		o.optional = true;
 
 		o = s.option(form.Value, 'model', _('Model (Display)'));
+		o.depends("driver", "genericups")
 		o.optional = true;
 
 		o = s.option(form.Flag, 'nolock', _('No Lock'), _('Do not lock port when starting driver'));
@@ -242,9 +244,11 @@ return view.extend({
 		o.datatype = 'uinteger';
 
 		o = s.option(form.Value, 'sdtime', _('Additional Shutdown Time(s)'));
+		o.depends("driver", "genericups")
 		o.optional = true;
 
 		o = s.option(form.Value, 'serial', _('Serial Number'));
+		o.depends("driver", "genericups")
 		o.optional = true;
 
 		o = s.option(form.Value, 'snmp_retries', _('SNMP retries'));


### PR DESCRIPTION
**Description:** Hide configuration applicable only to genericups when not configuring a genericups. This avoids user confusion in thinking settings such as mfr (shown as 'Manufacturer (Display)') are LuCI display only rather than passed to the driver as config (the settings are used as driver configuration items and end up on the ups.conf file; this can cause a driver other then genericups to fail to start).

Closes #8200
luci-app-nut: mfr, model fields not valid on usbhid-ups driver

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
  bcm27xx/bcm27xx, SNAPSHOT, Firefox 140.7.0 ESR
- [x] \( Preferred ) Mention: @ the original code author for feedback
  @danielfdickinson @systemcrash 
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#issue-number
  #8200 
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
