### PR TITLE
luci-mod-status: improve hide/show button placement and size

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
@@ -129,10 +129,11 @@ return view.extend({
 
 			rv.appendChild(E('div', { 'class': 'cbi-section', 'style': 'display: none' }, [
 				E('div', { 'class': 'cbi-title' },[
-					title != '' ? E('h3', title) : '',
-					E('div', [
+					E('h3', { 'style': 'display: flex; justify-content: space-between' }, [
+						title || '-',
 						E('span', {
 							'class': includes[i].hide ? 'label notice' : 'label',
+							'style': 'display: flex; align-items: center; justify-content: center; min-width: 4em',
 							'data-style': includes[i].hide ? 'active' : 'inactive',
 							'data-indicator': 'poll-status',
 							'data-clickable': 'true',


### PR DESCRIPTION
Align the hide/show buttons with the header of the section that they control.  Make the buttons as tall as the header line, very much improving accessibility on mobile.

---
In 2020 theme on desktop:
<img width="1513" height="633" alt="image" src="https://github.com/user-attachments/assets/29b0d578-bf2a-441a-978e-dd05000e7c19" />

Bootstrap theme on mobile:
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/0ee3c7c1-7135-4861-b72a-888868e74478" />

2020 theme on mobile:
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/769df406-a36d-42f4-90b8-7f59f44ba0f3" />
