### PR TITLE
luci-theme-openwrt-2020: add missing selector

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -1640,6 +1640,12 @@ button.spinning::before, .btn.spinning::before {
 	background: var(--success-color);
 }
 
+.label.notice {
+	background:var(--secondary-bright-color);
+	color:var(--main-bright-color);
+	border: 1px solid var(--main-bright-color);
+}
+
 ul.deps {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
The `.label.notice` selector is defined in the bootstrap theme, and used in luci-base, but is not present in the openwrt2020 theme.

---
Before:
<img width="579" height="127" alt="image" src="https://github.com/user-attachments/assets/7ef0ed21-4b5a-42d8-8175-c85de9aa36df" />

After:
<img width="582" height="128" alt="image" src="https://github.com/user-attachments/assets/0967aebd-decd-4fc4-9c02-c33889c206ca" />
