### PR TITLE
fix: luci_theme_material

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -501,36 +501,36 @@ header > .fill > .container > .status > * {
 
 .alert-message.notice,
 .label.notice {
-	background-color: var(--notice-color);
-	color: var(--on-notice-color);
+	background-color: var(--notice-color) !important;
+	color: var(--on-notice-color) !important;
 }
 
 .alert-message.danger,
 .btn.danger,
 .label.danger {
-	background-color: var(--danger-color);
-	color: var(--on-danger-color);
+	background-color: var(--danger-color) !important;
+	color: var(--on-danger-color) !important;
 }
 
 .alert-message.warning,
 .btn.warning,
 .label.warning {
-	background-color: var(--warning-color);
-	color: var(--on-warning-color);
+	background-color: var(--warning-color) !important;
+	color: var(--on-warning-color) !important;
 }
 
 .alert-message.success,
 .btn.success,
 .label.success {
-	background-color: var(--success-color);
-	color: var(--on-success-color);
+	background-color: var(--success-color) !important;
+	color: var(--on-success-color) !important;
 }
 
 .alert-message.error,
 .btn.error,
 .label.error {
-	background-color: var(--on-error-color);
-	color: var(--error-color);
+	background-color: var(--error-color) !important;
+	color: var(--on-error-color) !important;
 }
 
 [data-indicator]:not([data-style="inactive"]) {
@@ -540,6 +540,17 @@ header > .fill > .container > .status > * {
 .container .alert,
 .container .alert-message {
 	margin-top: 1rem;
+}
+
+/* Fix for table text in notifications - ensures table content inherits notification colors */
+.alert-message.notice table,
+.alert-message.notice .table,
+.alert-message.notice td,
+.alert-message.notice th,
+.alert-message.notice .td,
+.alert-message.notice .th {
+	color: var(--on-notice-color) !important;
+	background: transparent !important;
 }
 
 .main > .main-left > .nav {

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -877,19 +877,28 @@ p > a {
 }
 
 .alert-message.info {
+	color: var(--secondary-bright-color);
 	background: var(--main-bright-color);
 }
 
 .alert-message.warning {
+	color: var(--secondary-bright-color);
 	background: var(--warning-color);
 }
 
 .alert-message.danger {
+	color: var(--secondary-bright-color);
 	background: var(--danger-color);
 }
 
 .alert-message.success {
+	color: var(--secondary-bright-color);
 	background: var(--success-color);
+}
+
+.alert-message.notice {
+	color: var(--main-bright-color);
+	background: var(--secondary-bright-color);
 }
 
 .alert-message .btn {
@@ -898,6 +907,17 @@ p > a {
 
 .alert-message .btn:hover {
 	box-shadow: 0 0 4px 1px var(--secondary-bright-color);
+}
+
+/* Fix for table text in notifications */
+.alert-message.notice table,
+.alert-message.notice .table,
+.alert-message.notice td,
+.alert-message.notice th,
+.alert-message.notice .td,
+.alert-message.notice .th {
+	color: var(--main-bright-color) !important;
+	background: transparent !important;
 }
 
 @keyframes fade-in {


### PR DESCRIPTION
Closes: #8247

Fix ASU notification text readability in Material and OpenWrt 2020 themes.
Fix low-contrast text in LuCI themes that made some labels and values unreadable.
