### PR TITLE
luci-theme-material: ensure contrast on alternate table rows

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -491,6 +491,14 @@ header > .fill > .container > .status > * {
 	font-weight: bold;
 }
 
+.alert-message a:is(:link, :active, :visited) {
+	color: var(--gray-color-high);
+}
+
+.alert-message a:is(:hover, :focus) {
+	color: var(--gray-color);
+}
+
 .alert-message > * {
 	margin: .5rem 0;
 }
@@ -916,7 +924,8 @@ tr > th,
 
 div > table > tbody > tr:nth-of-type(2n),
 div > .table > .tr:nth-of-type(2n) {
-	background-color: var(--white-color-low);
+	color: var(--notice-color);
+	background-color: var(--on-notice-color);
 }
 
 /* fix multiple table */


### PR DESCRIPTION
Tables in the material theme use alternating colors to highlight the rows.  The light-background rows were inheriting a light color for the foreground, rendering the text unreadable.

Likewise "a" elements were rendered in the alert-message containers with non-contrasting colors.

We explicitly set these element's colors to ensure contrast.

Fixes: #8247

---
After shot, showing contrast of text in all table rows and visibility of links below table.

<img width="1522" height="377" alt="image" src="https://github.com/user-attachments/assets/99f0506a-e038-4741-9696-87f96078d21d" />
