### PR TITLE
luci-app-attendedsysupgrade: rework check-for-new-firmware

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/configuration.js
@@ -26,9 +26,8 @@ return view.extend({
 			form.DynamicList,
 			'rebuilder',
 			_('Rebuilders'),
-			_(
-				'Other ASU server instances that rebuild a requested image. ' +
-					'Allows to compare checksums and verify that the results are the same.'
+			_('Other ASU server instances that rebuild a requested image. ' +
+			  'Allows to compare checksums and verify that the results are the same.'
 			)
 		);
 
@@ -37,9 +36,18 @@ return view.extend({
 
 		o = s.option(
 			form.Flag,
+			'login_check_for_upgrades',
+			_('Check for upgrades'),
+			_('Check for upgrades whenever the System -> Overview page is loaded.')
+		);
+		o.default = '0';
+		o.rmempty = false;
+
+		o = s.option(
+			form.Flag,
 			'auto_search',
 			_('Search on opening'),
-			_('Search for new sysupgrades on opening the tab')
+			_('Search for upgrades when opening the Attended Sysupgrade tab')
 		);
 		o.default = '1';
 		o.rmempty = false;

--- a/applications/luci-app-attendedsysupgrade/root/etc/uci-defaults/95-luci-app-attendedsysupgrade-housekeeping
+++ b/applications/luci-app-attendedsysupgrade/root/etc/uci-defaults/95-luci-app-attendedsysupgrade-housekeeping
@@ -1,0 +1,9 @@
+#!/bin/sh
+check="$(uci -q get luci.main.check_for_newer_firmwares)"
+if [ -n "$check" ]; then
+        if ! uci -q get attendedsysupgrade.client.login_check_for_upgrades >/dev/null; then
+                uci set attendedsysupgrade.client.login_check_for_upgrades="$check"
+        fi
+        uci -q delete luci.main.check_for_newer_firmwares
+fi
+exit 0


### PR DESCRIPTION
Do a complete overhaul of the firmware check:

When the Status -> Overview page is loaded, we check if the configuration is set.  If not, we ask the user to choose between enabled or disabled.  Once this is done, it never appears again (much like the "set password" logic in the shell).

As a result, there is no longer a persistent section on the Overview page with a simple toggle eating real estate and playing havoc with the Hide/Show button scheme.

When the setting is enabled, then every time Status -> Overview is loaded, we do the firmware check and display an alert notice as before.  But, the alert notice now contains a button to disable the alerts, so navigation is still simple, you don't have to dig around to figure out how to turn it off.

The logic for version comparisons was cleaned up and simplified.

Fixes: #7925
Fixes: #8226

---
Initial screen, only shown once if you do enable/disable:
<img width="1260" height="360" alt="image" src="https://github.com/user-attachments/assets/bb5d4a83-6b0f-49bd-ad34-3ff446d1b0e4" />

Firmware check alert:
<img width="1146" height="476" alt="image" src="https://github.com/user-attachments/assets/43e52830-49f2-48c7-be79-54d6610f7649" />
