### PR TITLE
 luci-app-tailscale-community: clarify subnet routing setup and refine UI strings

### DIFF
--- a/applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -406,7 +406,9 @@ return view.extend({
 		o.rmempty = true;
 
 		const fwBtn = s.taboption('general', form.Button, '_setup_firewall', _('Auto Configure Firewall'));
-		fwBtn.description = _('Experimental: applies minimal firewall and interface setup for Tailscale. It will create/patch network.tailscale (proto none, device tailscale0), add a firewall zone "tailscale" with ACCEPT/ACCEPT/ACCEPT, masq, mtu_fix, and ensure forwarding tailscale<->lan. It reloads network/firewall only if changes are made.');
+		fwBtn.description = _('Essential configuration for Subnet Routing (Site-to-Site) and Exit Node features.')
+		+'<br>'+_('It automatically creates the tailscale interface, sets up firewall zones for LAN <-> Tailscale forwarding,')
+		+'<br>'+_('and enables Masquerading and MSS Clamping (MTU fix) to ensure stable connections.');
 		fwBtn.inputstyle = 'action';
 		fwBtn.onclick = function() {
 			const btn = this;
@@ -419,6 +421,20 @@ return view.extend({
 			}).finally(function() {
 				btn.disabled = false;
 			});
+		};
+
+		const helpTitle = s.taboption('general', form.DummyValue, '_help_title');
+		helpTitle.title = _('How to enable Site-to-Site?');
+		helpTitle.render = function() {
+			return E('div', { 'class': 'cbi-value', 'style': 'margin-top: 1em; border-top: 1px font-weight: bold;' }, [
+				E('label', { 'class': 'cbi-value-title' }, this.title),
+				E('div', { 'class': 'cbi-value-field', 'style': 'line-height: 1.6em; font-size: 95%; color: #555;' }, [
+					_('1. Select "Accept Routes" (to access remote devices).'), E('br'),
+					_('2. In "Advertise Routes", select your local subnet (to allow remote devices to access this LAN).'), E('br'),
+					_('3. Click "Auto Configure Firewall" (to allow traffic forwarding).'), E('br'),
+					E('strong', { 'style': 'color: #d9534f;' }, _('[Important] Log in to the Tailscale admin console and manually enable "Subnet Routes" for this device.'))
+				])
+			]);
 		};
 
 		// Create the account settings

--- a/applications/luci-app-tailscale-community/po/templates/community.pot
+++ b/applications/luci-app-tailscale-community/po/templates/community.pot
@@ -5,11 +5,25 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "(Experimental) Reduce Memory Usage"
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+msgid "1. Select \"Accept Routes\" (to access remote devices)."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:433
+msgid ""
+"2. In \"Advertise Routes\", select your local subnet (to allow remote "
+"devices to access this LAN)."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
+msgstr ""
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
 msgid "Accept Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:425
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:441
 msgid "Account Settings"
 msgstr ""
 
@@ -43,11 +57,11 @@ msgstr ""
 msgid "Allow user access to tailscale"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:563
 msgid "Applying changes..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:499
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
 msgid "Are you sure you want to log out?"
 msgstr ""
 
@@ -55,15 +69,15 @@ msgstr ""
 msgid "Auto Configure Firewall"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:522
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:450
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
 msgid "Click to Log out account on this device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
 msgid "Click to get a login URL for this device."
 msgstr ""
 
@@ -72,7 +86,7 @@ msgstr ""
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:541
 msgid "Confirm Logout"
 msgstr ""
 
@@ -80,17 +94,17 @@ msgstr ""
 msgid "Connection Info"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:450
 msgid "Custom Login Server"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:442
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
 msgid "Custom Login Server Auth Key"
 msgstr ""
 
@@ -116,7 +130,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:451
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:467
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr ""
 
@@ -138,11 +152,11 @@ msgid ""
 "performance (set GOGC=10)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:503
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:562
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:578
 msgid "Error applying settings: %s"
 msgstr ""
 
@@ -158,8 +172,14 @@ msgstr ""
 msgid "Error reading cached DERP region map: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:574
 msgid "Error saving settings: %s"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:409
+msgid ""
+"Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
+"features."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:278
@@ -167,37 +187,28 @@ msgstr ""
 msgid "Exit Node"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:409
-msgid ""
-"Experimental: applies minimal firewall and interface setup for Tailscale. It "
-"will create/patch network.tailscale (proto none, device tailscale0), add a "
-"firewall zone \"tailscale\" with ACCEPT/ACCEPT/ACCEPT, masq, mtu_fix, and "
-"ensure forwarding tailscale<->lan. It reloads network/firewall only if "
-"changes are made."
-msgstr ""
-
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:23
 msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:418
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid "Failed to configure firewall: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
 msgid "Failed to get login URL. You may close this tab."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:493
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:509
 msgid "Failed to get login URL: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:489
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Failed to get login URL: Invalid response from server."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:568
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:584
 msgid "Failed to save settings: %s"
 msgstr ""
 
@@ -205,7 +216,7 @@ msgstr ""
 msgid "Firewall Mode"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:415
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:417
 msgid "Firewall configuration applied."
 msgstr ""
 
@@ -217,12 +228,16 @@ msgstr ""
 msgid "Hostname"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:430
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:427
+msgid "How to enable Site-to-Site?"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:460
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -230,6 +245,12 @@ msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:90
 msgid "Invalid Date"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:410
+msgid ""
+"It automatically creates the tailscale interface, sets up firewall zones for "
+"LAN <-> Tailscale forwarding,"
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:93
@@ -244,24 +265,24 @@ msgstr ""
 msgid "Last Seen"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:436
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "Leave blank for default Tailscale control plane."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:512
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
 msgid "Logging out..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
 msgid "Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:449
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:522
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:538
 msgid "Logout"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:519
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
 msgid "Logout failed: %s"
 msgstr ""
 
@@ -301,13 +322,13 @@ msgstr ""
 msgid "Online"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:451
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "https://example.com)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:443
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:459
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
@@ -317,10 +338,10 @@ msgstr ""
 msgid "Please use the login button in the settings below to authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:512
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:494
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:563
 msgid "Please wait."
 msgstr ""
 
@@ -332,12 +353,12 @@ msgstr ""
 msgid "RX"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:494
 msgid "Requesting Login URL..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:469
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr ""
 
@@ -372,7 +393,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:532
 msgid "Successfully logged out."
 msgstr ""
 
@@ -413,7 +434,7 @@ msgstr ""
 msgid "Tailscale IPv6"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:468
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:484
 msgid "Tailscale Login"
 msgstr ""
 
@@ -424,15 +445,15 @@ msgid ""
 "your OpenWrt device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:553
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:569
 msgid "Tailscale settings applied successfully."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
 msgid "This can take up to 30 seconds."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
@@ -441,10 +462,10 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:493
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:519
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:562
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:509
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:574
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:578
 msgid "Unknown error"
 msgstr ""
 
@@ -465,6 +486,18 @@ msgstr ""
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+msgid ""
+"[Important] Log in to the Tailscale admin console and manually enable "
+"\"Subnet Routes\" for this device."
+msgstr ""
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:96
 msgid "ago"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
+msgid ""
+"and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
+"connections."
 msgstr ""

--- a/applications/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/applications/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -5,11 +5,25 @@ msgstr "Content-Type: text/plain; charset=UTF-8\n"
 msgid "(Experimental) Reduce Memory Usage"
 msgstr "(实验性) 减少内存使用"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+msgid "1. Select \"Accept Routes\" (to access remote devices)."
+msgstr "1. 勾选 接受路由 (接受远程设备访问)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:433
+msgid ""
+"2. In \"Advertise Routes\", select your local subnet (to allow remote "
+"devices to access this LAN)."
+msgstr "2. 在 通告路由 选择本设备的局域网段 (让远程设备能访问你)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
+msgstr "3. 点击 自动配置防火墙 (打通防火墙转发)。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
 msgid "Accept Routes"
 msgstr "接受路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:425
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:441
 msgid "Account Settings"
 msgstr "账户设置"
 
@@ -44,11 +58,11 @@ msgstr "允许通过 Tailscale 的 SSH 功能连接到此设备。"
 msgid "Allow user access to tailscale"
 msgstr "允许用户访问 Tailscale"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:563
 msgid "Applying changes..."
 msgstr "正在应用更改..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:499
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
 msgid "Are you sure you want to log out?"
 msgstr "您确定要登出吗？"
 
@@ -56,15 +70,15 @@ msgstr "您确定要登出吗？"
 msgid "Auto Configure Firewall"
 msgstr "自动配置防火墙"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:522
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:450
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
 msgid "Click to Log out account on this device."
 msgstr "点击以登出此设备上的账户。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
 msgid "Click to get a login URL for this device."
 msgstr "点击获取此设备的登录 URL。"
 
@@ -73,7 +87,7 @@ msgstr "点击获取此设备的登录 URL。"
 msgid "Collecting data ..."
 msgstr "正在收集数据..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:541
 msgid "Confirm Logout"
 msgstr "确认登出"
 
@@ -81,17 +95,17 @@ msgstr "确认登出"
 msgid "Connection Info"
 msgstr "连接信息"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr "无法打开新标签页。请检查您的浏览器或扩展程序是否阻止了弹出窗口。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:450
 msgid "Custom Login Server"
 msgstr "自定义登录服务器"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:442
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
 msgid "Custom Login Server Auth Key"
 msgstr "自定义登录服务器认证密钥"
 
@@ -117,7 +131,7 @@ msgstr "为通告路由的流量禁用源地址转换 (SNAT)。大多数用户�
 msgid "Disabled"
 msgstr "已禁用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:451
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:467
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr "从 Tailscale 断开连接并使当前节点密钥过期。"
 
@@ -139,11 +153,11 @@ msgid ""
 "performance (set GOGC=10)."
 msgstr "启用此选项可以减少内存使用，但可能会牺牲一些性能 (设置 GOGC=10)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:503
 msgid "Error"
 msgstr "错误"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:562
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:578
 msgid "Error applying settings: %s"
 msgstr "应用设置时出错: %s"
 
@@ -159,50 +173,43 @@ msgstr "获取 DERP 区域地图时出错: %s"
 msgid "Error reading cached DERP region map: %s"
 msgstr "读取缓存的 DERP 区域地图时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:574
 msgid "Error saving settings: %s"
 msgstr "保存设置时出错: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:409
+msgid ""
+"Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
+"features."
+msgstr "子网路由和出口节点的基本配置。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:278
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
 msgid "Exit Node"
 msgstr "出口节点"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:409
-msgid ""
-"Experimental: applies minimal firewall and interface setup for Tailscale. It "
-"will create/patch network.tailscale (proto none, device tailscale0), add a "
-"firewall zone \"tailscale\" with ACCEPT/ACCEPT/ACCEPT, masq, mtu_fix, and "
-"ensure forwarding tailscale<->lan. It reloads network/firewall only if "
-"changes are made."
-msgstr ""
-"实验性功能:为Tailscale应用所必须最小的防火墙设置。它将创建/修补network."
-"tailscale (proto none，device tailscale0)，添加ACCEPT/ACCEPT/ACCEPT、masq、"
-"mtu_fix的防火墙区域“tailscale”，并转发tailscale<->lan。反正总之如果你不知道这"
-"个是干什么的，而且你tailscale网络又有问题，说明你需要点这个。"
-
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:23
 msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr "在端口 5252 上暴露一个 Web 界面，用于通过 Tailscale 管理此节点。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:418
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid "Failed to configure firewall: %s"
 msgstr "获取防火墙设置失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
 msgid "Failed to get login URL. You may close this tab."
 msgstr "获取登录 URL 失败。您可以关闭此标签页。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:493
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:509
 msgid "Failed to get login URL: %s"
 msgstr "获取登录 URL 失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:489
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Failed to get login URL: Invalid response from server."
 msgstr "获取登录 URL 失败: 服务器响应无效。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:568
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:584
 msgid "Failed to save settings: %s"
 msgstr "保存设置失败: %s"
 
@@ -210,7 +217,7 @@ msgstr "保存设置失败: %s"
 msgid "Firewall Mode"
 msgstr "防火墙模式"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:415
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:417
 msgid "Firewall configuration applied."
 msgstr "已应用防火墙配置"
 
@@ -222,12 +229,16 @@ msgstr "常规设置"
 msgid "Hostname"
 msgstr "主机名"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:430
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:427
+msgid "How to enable Site-to-Site?"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr "如果显示超时，您可以刷新页面并再次点击登录。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:460
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -238,6 +249,12 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:90
 msgid "Invalid Date"
 msgstr "无效日期"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:410
+msgid ""
+"It automatically creates the tailscale interface, sets up firewall zones for "
+"LAN <-> Tailscale forwarding,"
+msgstr "子网路由和出口节点的基本配置。会自动tailscale接口，设置防火墙区域LAN <-> Tailscale转发"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:93
 msgid "Just now"
@@ -251,24 +268,24 @@ msgstr "已登出"
 msgid "Last Seen"
 msgstr "上次在线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:436
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "Leave blank for default Tailscale control plane."
 msgstr "留空以使用默认的 Tailscale 控制平面。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:512
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
 msgid "Logging out..."
 msgstr "正在登出..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
 msgid "Login"
 msgstr "登录"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:449
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:522
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:538
 msgid "Logout"
 msgstr "登出"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:519
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
 msgid "Logout failed: %s"
 msgstr "登出失败: %s"
 
@@ -308,7 +325,7 @@ msgstr "离线"
 msgid "Online"
 msgstr "在线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:451
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "https://example.com)."
@@ -316,7 +333,7 @@ msgstr ""
 "可选：指定一个自定义控制服务器 URL (例如，一个 Headscale 实例，https://"
 "example.com)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:443
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:459
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
@@ -326,10 +343,10 @@ msgstr "可选：为自定义控制服务器指定一个认证密钥。如果不
 msgid "Please use the login button in the settings below to authenticate."
 msgstr "请使用下方设置中的登录按钮进行认证。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:512
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:494
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:563
 msgid "Please wait."
 msgstr "请稍候。"
 
@@ -341,12 +358,12 @@ msgstr "正在运行"
 msgid "RX"
 msgstr "接收"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:494
 msgid "Requesting Login URL..."
 msgstr "正在请求登录 URL..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:469
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr "正在请求 Tailscale 登录 URL... 请稍候。"
 
@@ -381,7 +398,7 @@ msgstr "开启防护 (Shields Up)"
 msgid "Status"
 msgstr "状态"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:532
 msgid "Successfully logged out."
 msgstr "登出成功。"
 
@@ -422,7 +439,7 @@ msgstr "Tailscale IPv4"
 msgid "Tailscale IPv6"
 msgstr "Tailscale IPv6"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:468
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:484
 msgid "Tailscale Login"
 msgstr "Tailscale 登录"
 
@@ -435,15 +452,15 @@ msgstr ""
 "Tailscale 是一个网状 VPN 解决方案，可以轻松地安全连接您的设备。此配置页面允许"
 "您在 OpenWrt 设备上管理 Tailscale 设置。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:553
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:569
 msgid "Tailscale settings applied successfully."
 msgstr "Tailscale 设置已成功应用。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
 msgid "This can take up to 30 seconds."
 msgstr "此过程最多可能需要 30 秒。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
@@ -452,16 +469,16 @@ msgstr "这将使此设备从您的 Tailnet 断开连接，并需要您重新进
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:493
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:519
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:562
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:509
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:574
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:578
 msgid "Unknown error"
 msgstr "未知错误"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
 msgid "Use system DNS instead of MagicDNS."
-msgstr ""
+msgstr "使用系统 DNS 而不是 MagicDNS。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
 msgid "Version"
@@ -476,9 +493,18 @@ msgstr "启用后，将阻止来自 Tailscale 网络的所有入站连接。"
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr "使用出口节点时，允许访问本地局域网。"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+msgid ""
+"[Important] Log in to the Tailscale admin console and manually enable "
+"\"Subnet Routes\" for this device."
+msgstr "【重要】 登录 Tailscale 控制平面，在设备设置中手动授权子网路由。"
+
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:96
 msgid "ago"
 msgstr "前"
 
-#~ msgid "Specify an exit node. Leave it blank and it will not be used."
-#~ msgstr "指定一个出口节点。留空则不使用。"
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
+msgid ""
+"and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
+"connections."
+msgstr "并启用地址伪装和 MSS钳制确保连接稳定。"


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: Tokisaki Galaxy <moebest@outlook.jp>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `luci-app-tailscale-community: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86_64/aarch_a53, ImmortalWrt 24.10.4, Chrome/Edge) :white_check_mark:

First of all, I sincerely apologize for submitting this follow-up PR so soon (less than 12 hours) after the initial merge of this package. 

After immediate community feedback and further testing, it became clear that the "Auto Configure Firewall" button—while technically a helper—is a hard requirement for the "Site-to-Site" and "Exit Node" features. The previous wording labeled it as "Experimental," which discouraged users from clicking it, leading to common forwarding issues.

To ensure the best out-of-the-box **experience for users** installing via opkg, this PR refines the UI strings to be more goal-oriented.

**Changes:**
- **Refine Firewall Button:** Renamed/re-described the button to emphasize its role in enabling LAN <-> Tailscale forwarding.
- **Terminology Clarification:** Plain-language explanations for Masquerading and MSS Clamping (MTU fix) to help users understand why they are needed.
- **Remove "Experimental" tag:** The firewall logic has proven stable and is essential for standard OpenWrt VPN deployments.
- **Improve UX Flow:** Added guidance text for the "Advertise Routes" option to point users toward the firewall initialization step.

My goal is to minimize common support requests regarding "pings working but no data transfer" by providing clearer guidance directly within the LuCI interface.
