### PR TITLE
luci-app-attendedsysupgrade: fix syntax error

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/status/include/11_upgrades.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/status/include/11_upgrades.js
@@ -2,7 +2,7 @@
 'require baseclass';
 'require fs';
 'require rpc';
-'require uci'
+'require uci';
 'require ui';
 
 


### PR DESCRIPTION
Add the missing semicolon at the end of line 5.
Fix the syntax error popup on the LuCI homepage related to 11_upgrades.js.