### PR TITLE
luci-app-nut: improve confusing driver option text

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -154,7 +154,7 @@ return view.extend({
 		o.optional = true;
 		o.placeholder = 'private';
 
-		o = s.option(form.Value, 'desc', _('Description (Display)'));
+		o = s.option(form.Value, 'desc', _('Description (Display)'), _('This is passed through to the driver, so make sure your driver supports this option'));
 		o.optional = true;
 
 		o = s.option(form.ListValue, 'driver', _('Driver'),
@@ -190,10 +190,10 @@ return view.extend({
 		o.datatype = 'uinteger';
 		o.placeholder = 45;
 
-		o = s.option(form.Value, 'mfr', _('Manufacturer (Display)'));
+		o = s.option(form.Value, 'mfr', _('Manufacturer (Display)'), _('This is passed through to the driver, so make sure your driver supports this option'));
 		o.optional = true;
 
-		o = s.option(form.Value, 'model', _('Model (Display)'));
+		o = s.option(form.Value, 'model', _('Model (Display)'), _('This is passed through to the driver, so make sure your driver supports this option'));
 		o.optional = true;
 
 		o = s.option(form.Flag, 'nolock', _('No Lock'), _('Do not lock port when starting driver'));
@@ -244,7 +244,7 @@ return view.extend({
 		o = s.option(form.Value, 'sdtime', _('Additional Shutdown Time(s)'));
 		o.optional = true;
 
-		o = s.option(form.Value, 'serial', _('Serial Number'));
+		o = s.option(form.Value, 'serial', _('Serial Number'),  _('This is passed through to the driver, so make sure your driver supports this option'));
 		o.optional = true;
 
 		o = s.option(form.Value, 'snmp_retries', _('SNMP retries'));

--- a/applications/luci-app-nut/po/ar/nut.po
+++ b/applications/luci-app-nut/po/ar/nut.po
@@ -507,6 +507,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/bg/nut.po
+++ b/applications/luci-app-nut/po/bg/nut.po
@@ -510,6 +510,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/bn_BD/nut.po
+++ b/applications/luci-app-nut/po/bn_BD/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/ca/nut.po
+++ b/applications/luci-app-nut/po/ca/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/cs/nut.po
+++ b/applications/luci-app-nut/po/cs/nut.po
@@ -513,6 +513,15 @@ msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 "Název této sekce bude na ostatních místech používán jako název UPS zdroje"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Prodleva (v sekundách) mezi opětovnými pokusy o spuštění ovladače."

--- a/applications/luci-app-nut/po/da/nut.po
+++ b/applications/luci-app-nut/po/da/nut.po
@@ -510,6 +510,15 @@ msgstr "Synkron kommunikation"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Navnet på denne sektion vil blive brugt som UPS-navn andre steder"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tid i sekunder mellem forsøg på at genstarte driveren igen."

--- a/applications/luci-app-nut/po/de/nut.po
+++ b/applications/luci-app-nut/po/de/nut.po
@@ -515,6 +515,15 @@ msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 "Der Name dieses Abschnitts wird an anderer Stelle als UPS-Name verwendet"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/el/nut.po
+++ b/applications/luci-app-nut/po/el/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/es/nut.po
+++ b/applications/luci-app-nut/po/es/nut.po
@@ -517,6 +517,15 @@ msgstr "Comunicación sincrónica"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "El nombre de esta sección se usará como nombre de UPS en otra parte"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/et/nut.po
+++ b/applications/luci-app-nut/po/et/nut.po
@@ -501,6 +501,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/fi/nut.po
+++ b/applications/luci-app-nut/po/fi/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/fr/nut.po
+++ b/applications/luci-app-nut/po/fr/nut.po
@@ -514,6 +514,15 @@ msgstr "Communication synchrone"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Le nom de cette section sera utilisé ailleurs en tant que nom ISA"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Temps en secondes entre les réessais de démarrage du pilote."

--- a/applications/luci-app-nut/po/ga/nut.po
+++ b/applications/luci-app-nut/po/ga/nut.po
@@ -510,6 +510,15 @@ msgstr "Cumarsáid Sioncrónach"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Úsáidfear ainm an chuid seo mar ainm UPS in áiteanna eile"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Am i soicindí idir iarrachtaí arís a thosú le tiománaí."

--- a/applications/luci-app-nut/po/he/nut.po
+++ b/applications/luci-app-nut/po/he/nut.po
@@ -507,6 +507,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/hi/nut.po
+++ b/applications/luci-app-nut/po/hi/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/hu/nut.po
+++ b/applications/luci-app-nut/po/hu/nut.po
@@ -517,6 +517,15 @@ msgstr "Egyidejű kommunikáció"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "A munkamenet neve lesz használva UPS névként máshol"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/it/nut.po
+++ b/applications/luci-app-nut/po/it/nut.po
@@ -508,6 +508,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/ja/nut.po
+++ b/applications/luci-app-nut/po/ja/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/ko/nut.po
+++ b/applications/luci-app-nut/po/ko/nut.po
@@ -508,6 +508,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/lt/nut.po
+++ b/applications/luci-app-nut/po/lt/nut.po
@@ -533,6 +533,15 @@ msgstr ""
 "Šio skyriaus pavadinimas bus naudojamas kaip nenutrūkstamo maitinimo "
 "šaltinio pavadinimas kitur"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/mr/nut.po
+++ b/applications/luci-app-nut/po/mr/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/ms/nut.po
+++ b/applications/luci-app-nut/po/ms/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/nb_NO/nut.po
+++ b/applications/luci-app-nut/po/nb_NO/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/nl/nut.po
+++ b/applications/luci-app-nut/po/nl/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/pl/nut.po
+++ b/applications/luci-app-nut/po/pl/nut.po
@@ -516,6 +516,15 @@ msgstr "Komunikacja synchroniczna"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Nazwa tej sekcji będzie używana jako nazwa UPS w innych miejscach"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Czas w sekundach między ponownymi próbami uruchomienia sterownika."

--- a/applications/luci-app-nut/po/pt/nut.po
+++ b/applications/luci-app-nut/po/pt/nut.po
@@ -516,6 +516,15 @@ msgstr "Comunicação Síncrona"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "O nome desta secção será usado como o nome do UPS em outros lugares"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tempo em segundos entre as tentativas de reinício do driver."

--- a/applications/luci-app-nut/po/pt_BR/nut.po
+++ b/applications/luci-app-nut/po/pt_BR/nut.po
@@ -516,6 +516,15 @@ msgstr "Comunicação Síncrona"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "O nome desta seção será usado como o nome do Nobreak em outros lugares"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tempo em segundos entre as tentativas de reinício do driver."

--- a/applications/luci-app-nut/po/ro/nut.po
+++ b/applications/luci-app-nut/po/ro/nut.po
@@ -516,6 +516,15 @@ msgstr "Comunicare sincronă"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Numele acestei secțiuni va fi folosit ca nume UPS în altă parte"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/ru/nut.po
+++ b/applications/luci-app-nut/po/ru/nut.po
@@ -514,6 +514,15 @@ msgstr ""
 "Название этого раздела будет использоваться в качестве названия ИБП в других "
 "местах"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Время в секундах между повторными попытками запуска драйвера."

--- a/applications/luci-app-nut/po/sgs/nut.po
+++ b/applications/luci-app-nut/po/sgs/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/sk/nut.po
+++ b/applications/luci-app-nut/po/sk/nut.po
@@ -506,6 +506,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/sr/nut.po
+++ b/applications/luci-app-nut/po/sr/nut.po
@@ -507,6 +507,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/sv/nut.po
+++ b/applications/luci-app-nut/po/sv/nut.po
@@ -508,6 +508,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/ta/nut.po
+++ b/applications/luci-app-nut/po/ta/nut.po
@@ -507,6 +507,15 @@ msgstr "ஒத்திசைவான தொடர்பு"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "இந்த பிரிவின் பெயர் வேறு இடங்களில் யுபிஎச் பெயராகப் பயன்படுத்தப்படும்"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "ஓட்டுநருக்கு இடையிலான விநாடிகளில் நேரம் மீண்டும் முயற்சிகளைத் தொடங்குகிறது."

--- a/applications/luci-app-nut/po/templates/nut.pot
+++ b/applications/luci-app-nut/po/templates/nut.pot
@@ -495,6 +495,15 @@ msgstr ""
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/tr/nut.po
+++ b/applications/luci-app-nut/po/tr/nut.po
@@ -512,6 +512,15 @@ msgstr "Senkronize İletişim"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Bu bölümün adı, başka bir yerde UPS adı olarak kullanılacaktır"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/uk/nut.po
+++ b/applications/luci-app-nut/po/uk/nut.po
@@ -510,6 +510,15 @@ msgstr "Синхронна комунікація"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Назва цього розділу використовуватиметься як назва UPS в інших місцях"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Час у секундах між спробами повторного запуску драйвера."

--- a/applications/luci-app-nut/po/vi/nut.po
+++ b/applications/luci-app-nut/po/vi/nut.po
@@ -509,6 +509,15 @@ msgstr "Giao tiếp đồng bộ"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Tên phần này sẽ được sử dụng làm tên UPS ở nơi khác"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""

--- a/applications/luci-app-nut/po/zh_Hans/nut.po
+++ b/applications/luci-app-nut/po/zh_Hans/nut.po
@@ -511,6 +511,15 @@ msgstr "同步通信"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "此部分的名称将在其他地方用作 UPS 名称"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "驱动程序重试之间的间隔（秒）。"

--- a/applications/luci-app-nut/po/zh_Hant/nut.po
+++ b/applications/luci-app-nut/po/zh_Hant/nut.po
@@ -511,6 +511,15 @@ msgstr "同步通訊"
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "此部分的名稱將在其他地方用作 UPS 名稱"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:193
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+msgid ""
+"This is passed through to the driver, so make sure your driver supports this "
+"option"
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:125
 msgid "Time in seconds between driver start retry attempts."
 msgstr "驅動程式重試之間的間隔（秒）。"


### PR DESCRIPTION
**Description:** Some driver options were noted as '(Display)' even though they are added to the `ups.conf` configuration file (this is because the drivers use them in the messages they emit). Since not all drivers support these options and it is quite a large job to manage the which options apply to which of the many drivers for nut, for now we add informational text to inform the user of the situation.

Discussed in #8200 mfr, model fields not valid on usbhid-ups driver and #8241.

As noted in the latter's comments, more than one driver uses the problematic options, so the solution is not as simple as hiding the options for any driver except that one.

**Screenshot:**

<img width="1324" height="1005" alt="image" src="https://github.com/user-attachments/assets/5723c91c-b88b-42b4-acbe-0d8322efe370" />

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
  bcm27xx/bcm712 (rpi-5), SNAPSHOT r32783-cf84e8ee86, Firefox 140.7.0 ESR
- [x] \( Preferred ) Mention: @ the original code author for feedback
  @danielfdickinson @systemcrash
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
  Partial: #8200 
- [x] Description: (describe the changes proposed in this PR)
