### PR TITLE
luci-mod-network: add autoneg and duplex options

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
@@ -1141,6 +1141,22 @@ return baseclass.extend({
 		o.placeholder = dev ? dev._devstate('qlen') : '';
 		o.datatype = 'uinteger';
 
+
+		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'autoneg', _('Auto negotiation'));
+    		o.value('',_(''));
+		o.value('1', _('Enable'));
+    		o.value('0', _('Disable'));
+    		o.default = '';
+    		o.rmempty = true;
+
+
+    		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'duplex', _('Duplex'));
+    		o.value('',_(''));
+    		o.value('1', _('Full duplex'));
+    		o.value('0', _('Half duplex'));
+    		o.default = '';
+    		o.rmempty = true;
+
 		/* PSE / PoE options */
 		if (hasPSE) {
 			o = this.replaceOption(s, 'devpse', form.ListValue, 'pse', _('PoE (C33)'),


### PR DESCRIPTION

- [x] This PR is not from my *main* or *master* branch, but a *separate* branch
- [x] Each commit has a valid `Signed-off-by: sion-111 <s.piotrowski91@gmail.com>`
- [x] Each commit and PR title has a valid `<package name>: title` first line subject
- [ ] Incremented any `PKG_VERSION` in the Makefile (not applicable)
- [x] Tested on: Banana Pi BPI-R4, OpenWrt 23.05.x, LuCI (browser: Chromium)
- [ ] Mention the original code author for feedback
- [ ] Screenshot or mp4 of changes
- [ ] Closes:
- [ ] Depends on:

### Description

This change adds Auto negotiation and Duplex options to device settings
in LuCI network configuration.

Leaving the value empty keeps the default kernel behavior.

Tested on Banana Pi BPI-R4.