### PR TITLE
luci-theme-bootstrap: restyle wireless overview

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -317,7 +317,7 @@ a:hover {
 }
 
 .nowrap:not(span) {
-/*	Sometimes you need to wrap: badges on narrow screens look weird 
+/*	Sometimes you need to wrap: badges on narrow screens look weird
 	and nowrap defeats other width constraints, so exclude span */
 	white-space: nowrap;
 }
@@ -653,7 +653,7 @@ select,
 }
 
 /* indication line for drag-and-drop in UIDynamicList*/
-.cbi-dynlist > .item.drag-over { 
+.cbi-dynlist > .item.drag-over {
 	border-top: 1px solid var(--text-color-highest);
 }
 
@@ -2212,6 +2212,39 @@ th[data-sort-direction="desc"]::after { content: "\a0\25bc"; }
 	line-height: 1.2em;
 }
 
+@media screen and (min-device-width: 800px) {
+	body[data-page="admin-network-wireless"] .td[data-name="_badge"] {
+		width: 1%;
+	}
+
+	body[data-page="admin-network-wireless"] .ifacebadge {
+		align-items: center;
+		padding: 5px;
+		text-align: left;
+	}
+
+	body[data-page="admin-network-wireless"] .tr[data-sid^="radio"] .td[data-name="_badge"] .ifacebadge {
+		min-width: 170px;
+	}
+
+	body[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] div.center {
+		align-items: center;
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	body[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] div.center:before {
+		color: #999;
+		content: '\21B3';
+		font-size: 1.2em;
+		margin-right: 10px;
+	}
+
+	body[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] .ifacebadge {
+		min-width: 130px;
+	}
+}
+
 .ifacebadge img {
 	width: 32px;
 	height: 32px;
@@ -2320,7 +2353,7 @@ div.cbi-value var,
 }
 
 .cbi-value-first-field {
-	font-weight: bold;	
+	font-weight: bold;
 }
 
 div.cbi-value var[data-tooltip],

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
@@ -345,6 +345,27 @@ header h3 a, header .brand {
 	[data-page="admin-network-network"] .td[data-name="_ifacestat"] {
 		flex-basis: 60%;
 	}
+
+	[data-page="admin-network-wireless"] .tr[data-sid^="radio"] .td[data-name="_badge"] .ifacebadge {
+		min-width: 100%;
+	}
+
+	[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] div.center {
+		align-items: center;
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] div.center:before {
+		color: #999;
+		content: '\21B3';
+		font-size: 1.8em;
+		margin-right: 10px;
+	}
+
+	[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] .ifacebadge {
+		min-width: 80%;
+	}
 }
 
 @media screen and (max-device-width: 375px) {
@@ -425,5 +446,18 @@ header h3 a, header .brand {
 	.td .ifacebox .ifacebox-head > *,
 	.ifacebox .ifacebox-body > * {
 		margin: .125em;
+	}
+
+	[data-page="admin-network-wireless"] .td[data-name="_badge"] {
+		min-width: 100%;
+	}
+
+	[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] .ifacebadge {
+		min-width: 100%;
+	}
+
+	[data-page="admin-network-wireless"] .tr:not([data-sid^="radio"]) .td[data-name="_badge"] div.center:before {
+		content: none;
+		width: 0;
 	}
 }


### PR DESCRIPTION
Restyle wireless overview to make it clearer which SSIDs belong to which radios.

More of an RFC, as this is surely not the best way to do it. I wanted to do this purely through theming without breaking any other screens.

Before:

<img width="320" height="330" alt="Screenshot From 2026-01-27 21-50-33" src="https://github.com/user-attachments/assets/83661d96-3fb5-48a8-bad0-762f4068e389" />

After:

<img width="257" height="361" alt="Screenshot From 2026-01-27 21-50-53" src="https://github.com/user-attachments/assets/88ba13d6-9d6f-4615-847e-27fd2a64ed7f" /> <img width="257" height="361" alt="Screenshot From 2026-01-27 21-50-58" src="https://github.com/user-attachments/assets/14806ef7-3134-4237-9e8b-813ebaa18eb7" />

Mobile:

<img width="236" height="394" alt="image" src="https://github.com/user-attachments/assets/0d32a67d-79a0-4294-91c0-045028c414ce" />

Mobile (tiny screen):

<img width="378" height="274" alt="image" src="https://github.com/user-attachments/assets/66f6e236-4245-4917-8d5f-0734ecf1166f" />

Tested on 25.12-rc3 with desktop Firefox and Chromium, and mobile Firefox and Chrome on Android. Mobile rendering of `↳` seems to be device-dependent, so this bit might need some rethinking.

cc: @systemcrash