### PR TITLE
luci-mod-network: fix placeholder for roaming identifiers

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -13330,6 +13330,14 @@ msgstr "تلقائي (معطل)"
 msgid "automatic (enabled)"
 msgstr "تلقائي (ممكّن)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT انتقال النطاق الأساسي بكابل ثنائي ملفوف"

--- a/modules/luci-base/po/ast/base.po
+++ b/modules/luci-base/po/ast/base.po
@@ -12828,6 +12828,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -12875,6 +12875,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/bn/base.po
+++ b/modules/luci-base/po/bn/base.po
@@ -12798,6 +12798,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -12809,6 +12809,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -12970,6 +12970,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -13676,6 +13676,14 @@ msgstr "automatické (vypnuto)"
 msgid "automatic (enabled)"
 msgstr "automaticky (zapnuto)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -13400,6 +13400,14 @@ msgstr "automatisk (deaktiveret)"
 msgid "automatic (enabled)"
 msgstr "automatisk (aktiveret)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -13776,6 +13776,14 @@ msgstr "automatisch (deaktiviert)"
 msgid "automatic (enabled)"
 msgstr "automatisch (aktiviert)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -12928,6 +12928,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -13820,6 +13820,14 @@ msgstr "automático (desactivado)"
 msgid "automatic (enabled)"
 msgstr "automático (activado)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/fa/base.po
+++ b/modules/luci-base/po/fa/base.po
@@ -12809,6 +12809,14 @@ msgstr "خودکار (از کار افتاده)"
 msgid "automatic (enabled)"
 msgstr "خودکار (به کار افتاده)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -13108,6 +13108,14 @@ msgstr "automaattinen (ei käytössä)"
 msgid "automatic (enabled)"
 msgstr "automaattinen (käytössä)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/fil/base.po
+++ b/modules/luci-base/po/fil/base.po
@@ -12872,6 +12872,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -13489,6 +13489,14 @@ msgstr "automatique (désactivé)"
 msgid "automatic (enabled)"
 msgstr "automatique (activé)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/ga/base.po
+++ b/modules/luci-base/po/ga/base.po
@@ -13743,6 +13743,14 @@ msgstr "uathoibríoch (míchumas)"
 msgid "automatic (enabled)"
 msgstr "uathoibríoch (cumasaithe)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "BaseT"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -12834,6 +12834,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -12806,6 +12806,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -13725,6 +13725,14 @@ msgstr "automatikus (letiltva)"
 msgid "automatic (enabled)"
 msgstr "automatikus (engedélyezve)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/id/base.po
+++ b/modules/luci-base/po/id/base.po
@@ -12804,6 +12804,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -13600,6 +13600,14 @@ msgstr "automatico (disattivato)"
 msgid "automatic (enabled)"
 msgstr "automatico (attivato)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -13160,6 +13160,14 @@ msgstr "自動 (無効)"
 msgid "automatic (enabled)"
 msgstr "自動 (有効)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/ka/base.po
+++ b/modules/luci-base/po/ka/base.po
@@ -12804,6 +12804,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -13092,6 +13092,14 @@ msgstr "자동 (비활성)"
 msgid "automatic (enabled)"
 msgstr "자동 (활성)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/lt/base.po
+++ b/modules/luci-base/po/lt/base.po
@@ -13842,6 +13842,14 @@ msgstr "automatinis (atjungtas)"
 msgid "automatic (enabled)"
 msgstr "automatinis (įjungtas)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "„baseT“"

--- a/modules/luci-base/po/lv/base.po
+++ b/modules/luci-base/po/lv/base.po
@@ -12827,6 +12827,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/ml/base.po
+++ b/modules/luci-base/po/ml/base.po
@@ -12798,6 +12798,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -12805,6 +12805,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -12838,6 +12838,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -12947,6 +12947,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -13458,6 +13458,14 @@ msgstr "automatisch (uitgeschakeld)"
 msgid "automatic (enabled)"
 msgstr "automatisch (ingeschakeld)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "basisT"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -13729,6 +13729,14 @@ msgstr "automatyczny (wyłączony)"
 msgid "automatic (enabled)"
 msgstr "automatyczny (włączony)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -13690,6 +13690,14 @@ msgstr "automático (desativado)"
 msgid "automatic (enabled)"
 msgstr "automático (ativado)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -13776,6 +13776,14 @@ msgstr "automático (desativado)"
 msgid "automatic (enabled)"
 msgstr "automático (ativado)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -13603,6 +13603,14 @@ msgstr "automat (dezactivat)"
 msgid "automatic (enabled)"
 msgstr "automat (activat)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "bazăT"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -13959,6 +13959,14 @@ msgstr "автоматически (отключено)"
 msgid "automatic (enabled)"
 msgstr "автоматически (включено)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT (технология Ethernet по витой паре)"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -13075,6 +13075,14 @@ msgstr "automaticky (zakázané)"
 msgid "automatic (enabled)"
 msgstr "automaticky (povolené)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -12846,6 +12846,14 @@ msgstr "automatiskt (avstängd)"
 msgid "automatic (enabled)"
 msgstr "automatiskt (aktiverat)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/ta/base.po
+++ b/modules/luci-base/po/ta/base.po
@@ -13519,6 +13519,14 @@ msgstr "தானியங்கி (முடக்கப்பட்டது)
 msgid "automatic (enabled)"
 msgstr "தானியங்கி (இயக்கப்பட்டது)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "வேண்டும்"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -12795,6 +12795,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -13514,6 +13514,14 @@ msgstr "otomatik (devre dışı)"
 msgid "automatic (enabled)"
 msgstr "otomatik (etkin)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -13755,6 +13755,14 @@ msgstr "автоматичний (вимкнено)"
 msgid "automatic (enabled)"
 msgstr "автоматичний (увімкнено)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -12804,6 +12804,14 @@ msgstr ""
 msgid "automatic (enabled)"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr ""

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -13487,6 +13487,14 @@ msgstr "tự động (vô hiệu hóa)"
 msgid "automatic (enabled)"
 msgstr "tự động (đã kích hoạt)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/yua/base.po
+++ b/modules/luci-base/po/yua/base.po
@@ -13612,6 +13612,14 @@ msgstr "automático (desactivado)"
 msgid "automatic (enabled)"
 msgstr "automático (activado)"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr ""
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -13206,6 +13206,14 @@ msgstr "自动（已禁用）"
 msgid "automatic (enabled)"
 msgstr "自动（已开启）"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr "根据Mobility Domain和PSK自动生成"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr "根据SSID自动生成"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -13091,6 +13091,14 @@ msgstr "自動（已停用）"
 msgid "automatic (enabled)"
 msgstr "自動（已啟用）"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1911
+msgid "automatically derived from Mobility Domain and PSK"
+msgstr "根據Mobility Domain和PSK自動產生"
+
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1882
+msgid "automatically derived from SSID"
+msgstr "根據SSID自動產生"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
 msgstr "baseT"

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1879,7 +1879,7 @@ return view.extend({
 
 					o = ss.taboption('roaming', form.Value, 'mobility_domain', _('Mobility Domain'), _('4-character hexadecimal ID'));
 					o.depends({ ieee80211r: '1' });
-					o.placeholder = '4f57';
+					o.placeholder = _('automatically derived from SSID');
 					o.datatype = 'and(hexstring,length(4))';
 					o.rmempty = true;
 
@@ -1908,7 +1908,7 @@ return view.extend({
 
 					o = ss.taboption('roaming', form.Value, 'r1_key_holder', _('R1 Key Holder'), _('6-octet identifier as a hex string - no colons'));
 					o.depends({ ieee80211r: '1' });
-					o.placeholder = '00004f577274';
+					o.placeholder = _('automatically derived from Mobility Domain and PSK');
 					o.datatype = 'and(hexstring,length(12))';
 					o.rmempty = true;
 


### PR DESCRIPTION
OpenWrt commit 3cc56a5 chaged the default value of `mobility_domain` and `r1_key_holder` options. This commit removes the stale hard-coded `4f57` from luci to avoid ambiguity.

Closes: openwrt/luci#8267

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
