### PR TITLE
luci-mod-network: add speed choices via rpc device status

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
@@ -8,6 +8,7 @@
 'require baseclass';
 'require validation';
 'require tools.widgets as widgets';
+'require rpc';
 
 function validateAddr(section_id, value) {
 	if (value == '')
@@ -362,6 +363,25 @@ var cbiTagValue = form.Value.extend({
 
 	remove: function() {}
 });
+
+var callDeviceStatus = rpc.declare({
+        object: 'network.device',
+        method: 'status',
+        params: [ 'name' ]
+});
+
+function extractSupportedSpeeds(status) {
+        var sup = (status && (status['link-supported'] || status['link_supported'])) || [];
+        var uniq = Object.create(null);
+
+        L.toArray(sup).forEach(function (v) {
+                var m = String(v).match(/^(\d+)/);
+                if (m) uniq[m[1]] = true;
+        });
+
+        return Object.keys(uniq).sort(function (a, b) { return (+a) - (+b); });
+}
+
 
 return baseclass.extend({
 
@@ -1140,6 +1160,35 @@ return baseclass.extend({
 		o = this.replaceOption(s, 'devgeneral', form.Value, 'txqueuelen', _('TX queue length'));
 		o.placeholder = dev ? dev._devstate('qlen') : '';
 		o.datatype = 'uinteger';
+
+		o = this.replaceOption(s, 'devgeneral', form.Value, 'speed', _('Speed'));
+
+o.editable = true;
+o.placeholder = '0';
+o.datatype = 'uinteger';
+o.rmempty = true;
+o.default=''
+
+
+o.value('', '');
+o.load = function (section_id) {
+
+        var ifn = this.section.formvalue(section_id, 'ifname_single')
+                || this.section.formvalue(section_id, 'name_simple')
+                || uci.get('network', section_id, 'name')
+                || (dev ? dev.getName() : '');
+
+        ifn = String(ifn || '').replace(/\.\d+$/, '');
+
+        if (!ifn) ifn = 'eth1';
+
+        var self = this;
+        return callDeviceStatus(ifn).then(function (st) {
+                extractSupportedSpeeds(st).forEach(function (sp) {
+                        self.value(sp, sp + ' Mbit/s');
+                });
+        });
+};
 
 		/* PSE / PoE options */
 		if (hasPSE) {

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -16,8 +16,8 @@
 				"iwinfo": [ "assoclist", "countrylist", "freqlist", "txpowerlist" ],
 				"luci": [ "getSwconfigFeatures", "getSwconfigPortState" ]
 			},
-			"uci": [ "dhcp", "firewall", "network", "wireless", "system" ]
-		},
+			"uci": [ "dhcp", "firewall", "network", "wireless", "system" ],
+			"network.device": [ "status" ]		},
 		"write": {
 			"cgi-io": [ "exec" ],
 			"file": {


### PR DESCRIPTION
This change adds a speed selection field to device settings in LuCI.

Available speeds are populated dynamically using `network.device status`
via RPC, while still allowing manual custom values to be entered.

ACL permissions were extended to allow read-only access to
`network.device status`.

Tested on Banana Pi BPI-R4.

- [x] This PR is not from my *main* or *master* branch, but a *separate* branch
- [x] Each commit has a valid `Signed-off-by: sion-111 <s.piotrowski91@gmail.com>`
- [x] Each commit and PR title has a valid `<package name>: title` first line subject
- [ ] Incremented any `PKG_VERSION` in the Makefile (not applicable)
- [x] Tested on: Banana Pi BPI-R4
- [ ] Screenshot or mp4 of changes
