### PR TITLE
luci-mod-status: improve RDNS resolution workflow

### DIFF
--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -7,6 +7,7 @@
 			},
 			"ubus": {
 				"luci": [ "getConntrackList", "getRealtimeStats" ],
+				"luci-rpc": [ "getHostHints", "getNetworkDevices", "getDHCPLeases" ],
 				"network.rrdns": [ "lookup" ]
 			}
 		}


### PR DESCRIPTION
# Refactor host lookups and caching in connections view

## Summary
This PR refactors the connections view in `luci-mod-status` to improve **host resolution**, **service caching**, and **lookup efficiency**.

It introduces new RPC calls, centralized caching, and a more maintainable sequential lookup workflow.

---

## Changes

### 1️⃣ New RPC declarations
- `callLuciRpcGetNetworkDevices` → fetch network device info
- `callLuciRpcGetDHCPLeases` → fetch DHCP leases
- Purpose: reduce reliance on `callNetworkRrdnsLookup` + host hints

### 2️⃣ Cache improvements
- `dns_cache`, `service_cache` now use `Object.create(null)` to avoid prototype collisions
- Added `ethers_cache` for MAC-to-hostname mapping

### 3️⃣ Lookup queue and DNS resolution
- Converted `lookup_queue` from array → `Set` to simplify processing
- Added helper function `updateDnsCache(addr, name)` to:
  - Update caches
  - Remove addresses from lookup queues
- Re-write address resolution workflow as async/await sequential lookup steps:
  1. DHCP leases
  2. Reverse DNS via `callNetworkRrdnsLookup`
  3. Host hints / MAC-to-host mapping
  4. Network devices / MAC cache
- Re-write pollData() as async

### 4️⃣ Service lookup
- Adjusted cache access to match uppercase port/protocol keys
- Optional chaining prevents runtime errors if service/protocol missing

### 5️⃣ ACL updates
- Added `luci-rpc` permissions in `luci-mod-status.json`:
  - `getHostHints`
  - `getNetworkDevices`
  - `getDHCPLeases`

---

## Impact / Benefits
- Reduces redundant RPC calls by caching results more effectively
- Handles MAC-to-IP-to-hostname mapping via multiple sources
- Improves maintainability via sequential promise-based lookups
- Ensures consistent service display with uppercase normalization

---

## Testing Instructions
1. Open the **Connections** view in LuCI.
2. Verify that all hosts display names where available:
   - DHCP leases
   - Reverse DNS
   - Host hints
   - MAC-address mappings
3. Toggle `Disable DNS lookups` and confirm:
   - Lookup queue correctly populates
   - Resolved hosts are cached
4. Check that services display correctly with protocol and port (e.g., `80/TCP → HTTP`)
5. Confirm no console errors appear in browser developer tools

---

## Notes / Future Work
- Consider adding a **progress indicator** for long lookup batches
- Possible performance improvements by **debouncing repeated lookups** if the table updates frequently
- Could extend `ethers_cache` persistence across sessions for faster load

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture: armv7l, OpenWrt 25.12.0-rc3, browser: Chrome) :white_check_mark:
- [x] Description: (describe the changes proposed in this PR)
