### PR TITLE
luci-app-bcp38: fix missing closing parenthesis

### DIFF
--- a/applications/luci-app-bcp38/htdocs/luci-static/resources/view/bcp38/form.js
+++ b/applications/luci-app-bcp38/htdocs/luci-static/resources/view/bcp38/form.js
@@ -11,7 +11,7 @@ return view.extend({
 			_('This function blocks packets with private address destinations ' +
 			'from going out onto the internet as per %s'.format('<a href="http://tools.ietf.org/html/bcp38">BCP 38</a>') + '<br/>' +
 			_('For IPv6, only source specific default routes are installed, so ' +
-			'no BCP38 firewall routes are needed.'));
+			'no BCP38 firewall routes are needed.')));
 
 
 		s = m.section(form.TypedSection, 'bcp38', _('BCP38 config'));


### PR DESCRIPTION
fixes SyntaxError missing ) after argument list