### PR TITLE
luci-app-attendedsysupgrade: Activate only with LuCI

### DIFF
--- a/applications/luci-app-attendedsysupgrade/Makefile
+++ b/applications/luci-app-attendedsysupgrade/Makefile
@@ -9,7 +9,7 @@ LUCI_DEPENDS:=+luci-base +attendedsysupgrade-common +cgi-io
 PKG_MAINTAINER:=Eric Fahlgren <ericfahlgren@gmail.com>, Paul Spooren <paul@spooren.de>
 PKG_LICENSE:=GPL-2.0
 
-LUCI_DEFAULT:=y if BUILDBOT
+LUCI_DEFAULT:=y if (BUILDBOT && PACKAGE_luci)
 
 include ../../luci.mk
 


### PR DESCRIPTION
Activate luci-app-attendedsysupgrade in buildbots builds only when LuCI is also selected. This will prevent it form being activated in master buildbot builds.
