### PR TITLE
luci-mod-network: dns.js: move some related options to cache tab

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
@@ -266,6 +266,34 @@ return view.extend({
 		recordtypes.forEach(r => {
 			o.value(r);
 		});
+
+		o = s.taboption('cache', form.Flag, 'nonegcache',
+			_('No negative cache'),
+			_('Do not cache negative replies from upstream nameservers, e.g. for non-existent domains.') + '<br/>' +
+			_('Caching negative replies allows dnsmasq to answer identical queries without forwarding them again.'));
+		o.rmempty = false;
+
+		o = s.taboption('cache', form.Value, 'cachesize',
+			_('Size of DNS query cache'),
+			_('Number of cached DNS entries, 10000 is maximum, 0 is no caching.'));
+		o.optional = true;
+		o.datatype = 'range(0,10000)';
+		o.placeholder = 150;
+
+		o = s.taboption('cache', form.Value, 'min_cache_ttl',
+			_('Min cache TTL'),
+			_('Extend short TTL values to the seconds value given when caching them, one hour(3600s) is maximum.') + '<br/>' +
+			_('Use with caution.'));
+		o.optional = true;
+		o.datatype = 'range(0,3600)';
+		o.placeholder = 60;
+
+		o = s.taboption('cache', form.Value, 'max_cache_ttl',
+			_('Max cache TTL'),
+			_('Set a maximum seconds TTL value for entries in the cache.'));
+		o.optional = true;
+		o.datatype = 'uinteger';
+		o.placeholder = 3600;
 		// End cache
 
 		// Begin devices
@@ -662,10 +690,6 @@ return view.extend({
 			_('This prevents unreachable IPs in subnets not accessible to you.') + '<br />' +
 			_('Note: IPv4 only.'));
 
-		s.taboption('filteropts', form.Flag, 'nonegcache',
-			_('No negative cache'),
-			_('Do not cache negative replies, e.g. for non-existent domains.'));
-
 		o = s.taboption('filteropts', form.DynamicList, 'bogusnxdomain',
 			customi18n(_('IPs to override with {nxdomain}') ),
 			customi18n(_('Transform replies which contain the specified addresses or subnets into {nxdomain} responses.') )
@@ -734,26 +758,6 @@ return view.extend({
 		o.optional = true;
 		o.datatype = 'uinteger';
 		o.placeholder = 150;
-
-		o = s.taboption('limits', form.Value, 'cachesize',
-			_('Size of DNS query cache'),
-			_('Number of cached DNS entries, 10000 is maximum, 0 is no caching.'));
-		o.optional = true;
-		o.datatype = 'range(0,10000)';
-		o.placeholder = 150;
-
-		o = s.taboption('limits', form.Value, 'min_cache_ttl',
-			_('Min cache TTL'),
-			_('Extend short TTL values to the seconds value given when caching them. Use with caution.') +
-			_(' (Max 1h == 3600)'));
-		o.optional = true;
-		o.placeholder = 60;
-
-		o = s.taboption('limits', form.Value, 'max_cache_ttl',
-			_('Max cache TTL'),
-			_('Set a maximum seconds TTL value for entries in the cache.'));
-		o.optional = true;
-		o.placeholder = 3600;
 		// End limits
 
 		// Being logging


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86, openwrt SNAPSHOT, Chrome 144) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)

---

Originally part of #8102

- nonegcache, cachesize, min_cache_ttl and max_cache_ttl are moved to cache tab
- improved the help text of nonegcache and min_cache_ttl
- added datatype limit to min_cache_ttl and max_cache_ttl
