### PR TITLE
luci-app-wifihistory: add i18n

### DIFF
--- a/applications/luci-app-wifihistory/po/cs/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/cs/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/de/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/de/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/el/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/el/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/es/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/es/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/fa/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/fa/wifihistory.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/fi/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/fi/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/fr/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/fr/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ga/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ga/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ja/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ja/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ko/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ko/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/lt/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/lt/wifihistory.po
@@ -1,0 +1,111 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/pl/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/pl/wifihistory.po
@@ -1,0 +1,111 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/pt/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/pt/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ro/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ro/wifihistory.po
@@ -1,0 +1,111 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ru/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ru/wifihistory.po
@@ -1,0 +1,111 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/sv/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/sv/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ta/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ta/wifihistory.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ta\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/templates/wifihistory.pot
+++ b/applications/luci-app-wifihistory/po/templates/wifihistory.pot
@@ -1,0 +1,102 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/tr/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/tr/wifihistory.po
@@ -1,0 +1,110 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/uk/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/uk/wifihistory.po
@@ -1,0 +1,111 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/zh_Hans/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/zh_Hans/wifihistory.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/zh_Hant/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/zh_Hant/wifihistory.po
@@ -1,0 +1,109 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""


### PR DESCRIPTION
@systemcrash That's all that was missing for the new app.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
