### PR TITLE
luci-app-tailscale-community: fix exit node conflict

### DIFF
--- a/applications/luci-app-tailscale-community/root/usr/share/rpcd/ucode/tailscale.uc
+++ b/applications/luci-app-tailscale-community/root/usr/share/rpcd/ucode/tailscale.uc
@@ -143,8 +143,8 @@ methods.set_settings = {
 		let args = ['set'];
 
 		push(args,'--accept-routes=' + (form_data.accept_routes == '1'));
-		push(args,'--advertise-exit-node=' + (form_data.advertise_exit_node == '1'));
-		push(args,'--exit-node-allow-lan-access=' + (form_data.exit_node_allow_lan_access == '1'));
+		push(args,'--advertise-exit-node=' + ((form_data.advertise_exit_node == '1')&&(form_data.exit_node == "")));
+		if (form_data.exit_node == "") push(args,'--exit-node-allow-lan-access=' + (form_data.exit_node_allow_lan_access == '1'));
 		push(args,'--ssh=' + (form_data.ssh == '1'));
 		push(args,'--accept-dns=' + (form_data.disable_magic_dns != '1'));
 		push(args,'--shields-up=' + (form_data.shields_up == '1'));
@@ -152,7 +152,7 @@ methods.set_settings = {
 		push(args,'--snat-subnet-routes=' + (form_data.nosnat != '1'));
 		push(args,'--advertise-routes ' + (shell_quote(join(',',form_data.advertise_routes)) || '\"\"'));
 		push(args,'--exit-node=' + (shell_quote(form_data.exit_node) || '\"\"'));
-		if (form_data.exit_node != "") push(args,' --exit-node-allow-lan-access');
+		if (form_data.exit_node != "") push(args,' --exit-node-allow-lan-access=true');
 		push(args,'--hostname ' + (shell_quote(form_data.hostname) || '\"\"'));
 
 		let cmd_array = 'tailscale '+join(' ', args);


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) aarch 24.10 EDGE
- [x] \( Optional ) Closes: e.g. openwrt/luci#8319
- [x] Description: (describe the changes proposed in this PR)

if user both enable advertise exit node and use another node as exit node, will report ERR.
same, if user both enable allowe LAN ACCESS and use another node as exit node, will conflict