### PR TITLE
luci-app-ustreamer: complete rewrite

### DIFF
--- a/applications/luci-app-ustreamer/Makefile
+++ b/applications/luci-app-ustreamer/Makefile
@@ -1,18 +1,16 @@
 #
-# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+# Copyright (C) 2008-2026 The LuCI Team <luci@lists.subsignal.org>
 #
 # This is free software, licensed under the Apache License, Version 2.0 .
 #
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=ustreamer service configuration module
+LUCI_TITLE:=uStreamer service configuration module
 LUCI_DEPENDS:=+luci-base +ustreamer
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
-
-PROVIDES:=luci-app-mjpeg-streamer
+PKG_MAINTAINER:=Georgi Valkov <gvalkov@gmail.com>
 
 include ../../luci.mk
 

--- a/applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js
+++ b/applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js
@@ -1,89 +1,221 @@
 'use strict';
+'require view';
 'require form';
-'require fs';
-'require poll';
 'require uci';
 'require ui';
-'require view';
+'require poll';
 
-/*  Licensed to the public under the Apache License 2.0. */
+
+/* Licensed to the public under the Apache License 2.0. */
 
 return view.extend({
-	load() {
+	load: function () {
+		let self = this;
+		self.stream = { ts: new Date().getTime(), timer: 0 };
+
+		poll.add(function () {
+			self.render();
+		}, 5);
+
 		document
 			.querySelector('head')
 			.appendChild(
 				E('style', { type: 'text/css' }, [
 					'.img-preview {display: inline-block !important;height: auto;width: 640px;padding: 4px;line-height: 1.428571429;background-color: #fff;border: 1px solid #ddd;border-radius: 4px;-webkit-transition: all .2s ease-in-out;transition: all .2s ease-in-out;margin-bottom: 5px;display: none;}',
+					'@media (prefers-color-scheme: dark){ .img-preview {background-color: #222;border-color: #333;} }',
 				]),
 			);
 
-		return Promise.all([
-			L.resolveDefault(fs.list('/dev/'), []).then(entries => entries.filter(e => /^video.*$/.test(e.name)) ),
-			uci.load('ustreamer'),
-		]);
+		return Promise.all([uci.load('ustreamer')]);
 	},
-	render([video_devs]) {
+	render: function () {
 		let m, s, o;
+		let stream = this.stream;
 
-		let self = this;
-		poll.add(() => {
-			self.load().then(([video_devs]) => {
-				self.render([video_devs]);
-			});
-		}, 5);
+		m = new form.Map(
+			'ustreamer', 'µStreamer', _('Lightweight and fast MJPEG-HTTP streamer')
+		);
 
-		m = new form.Map('ustreamer', 'ustreamer',
-			_('µStreamer is a lightweight and very quick server to stream MJPEG video from any V4L2 device to the net.'));
 
-		//General settings
+		// preview
 
-		const section_gen = m.section(form.TypedSection, 'ustreamer', _('General'));
-		section_gen.addremove = false;
-		section_gen.anonymous = true;
+		function stream_url() {
+			let login = '';
+			let user = uci.get('ustreamer', 'video0', 'user');
+			let pass = uci.get('ustreamer', 'video0', 'pass');
+			let port = uci.get('ustreamer', 'video0', 'port');
 
-		const enabled = section_gen.option(form.Flag, 'enabled', _('Enabled'));
+			if (port == undefined) {
+				port = '8080';
+			}
 
-		const log_level = section_gen.option(form.Value, 'log_level', _('Log level'));
-		log_level.placeholder = _('info');
-		log_level.value('0', _('info'));
-		log_level.value('1', _('performance'));
-		log_level.value('2', _('verbose'));
-		log_level.value('3', _('debug'));
+			if (user != undefined) {
+				if (pass == undefined) {
+					login = user + '@';
+				}
+				else {
+					login = user + ':' + pass + '@';
+				}
+			}
 
-		//Plugin settings
+			return 'http://' + login + location.hostname + ':' + port + '/';
+		}
 
-		s = m.section(form.TypedSection, 'ustreamer', _('Plugin settings'));
-		s.addremove = true;
+		const url = stream_url();
+
+		const stream_link = E(
+			'a',
+			{
+				'id': 'stream_link',
+				'target': '_blank',
+				'href': url,
+			},
+			_('Preview'),
+		);
+
+		const s_preview = m.section(form.TypedSection, 'ustreamer', stream_link);
+		s_preview.addremove = false;
+		s_preview.anonymous = true;
+
+		function _start_stream() {
+			let ts = new Date().getTime();
+			let dt = ts - stream.ts;
+			stream.ts = ts;
+			stream.timer = 0;
+			console.log('_start_stream ' + dt);
+
+			let img = document.getElementById('video_preview') || video_preview;
+			img.src = url + 'snapshot' + '?t=' + new Date().getTime();
+		}
+
+		function start_stream() {
+			if (stream.timer) {
+				return;
+			}
+
+			stream.timer = setTimeout(function () {
+				_start_stream();
+			}, 500);
+		}
+
+		function on_error() {
+			console.log('on_error');
+
+			let img = document.getElementById('video_preview') || video_preview;
+			img.style.display = 'none';
+
+			let status = document.getElementById('stream_status') || stream_status;
+			status.style.display = 'block';
+
+			let enabled = uci.get('ustreamer', 'video0', 'enabled');
+
+			if (enabled) {
+				start_stream();
+			}
+		}
+
+		function on_load() {
+			console.log('on_load');
+
+			let img = document.getElementById('video_preview') || video_preview;
+			img.style.display = 'block';
+
+			let status = document.getElementById('stream_status') || stream_status;
+			status.style.display = 'none';
+		}
+
+		// HTTP preview
+		const video_preview = E(
+			'img',
+			{
+				'id': 'video_preview',
+				'class': 'img-preview',
+				'error': on_error,
+				'load': on_load,
+			}
+		);
+
+		const stream_status = E(
+			'p',
+			{
+				'id': 'stream_status',
+				'style': 'text-align: center; color: orange; font-weight: bold;',
+			},
+			_('Stream unavailable'),
+		);
+
+		start_stream();
+
+		const preview = s_preview.option(form.DummyValue, '_dummy');
+
+		preview.render = L.bind(function (view, section_id) {
+			return E([], [
+				video_preview,
+				stream_status
+			]);
+		}, preview, this);
+
+		preview.depends('enabled', '1');
+
+
+		// settings
+
+		s = m.section(form.TypedSection, 'ustreamer', _('Settings'));
+		s.addremove = false;
 		s.anonymous = true;
 
-		s.tab('h264_sink', _('H264 sink'));
-		s.tab('output_http', _('HTTP output'));
+		s.tab('general', _('General'));
+		s.tab('capture', _('Capture'));
+		s.tab('server_http', _('HTTP server'));
+		s.tab('sink_jpeg', _('JPEG sink'));
+		s.tab('sink_raw', _('RAW sink'));
+		s.tab('sink_h264', _('H264 sink'));
+		s.tab('logging', _('Logging'));
 		s.tab('image_control', _('Image control'));
-		s.tab('jpeg_sink', _('JPEG sink'));
-		s.tab('raw_sink', _('RAW sink'));
-		s.tab('input_uvc', _('UVC input'));
 
-		// Input UVC settings
 
-		let this_tab = 'input_uvc';
+		// general
 
-		const device = s.taboption(this_tab, form.Value, 'device', _('Device'));
-		device.placeholder = '/dev/video0';
-		for (const dev of video_devs)
-			device.value(`/dev/${dev.name}`);
-		device.optional = false;
-		device.rmempty = false;
+		let this_tab = 'general';
 
-		const dtimeout = s.taboption(this_tab, form.Value, 'timeout', _('Timeout'), _('units: seconds'));
-		dtimeout.placeholder = '5';
-		dtimeout.datatype = 'uinteger';
+		const enabled = s.taboption(
+			this_tab, form.Flag, 'enabled', _('Enabled'), _('Enable µStreamer')
+		);
 
-		const input = s.taboption(this_tab, form.Flag, 'input', _('Input'));
-		input.default = input.disabled;
+		const device = s.taboption(
+			this_tab, form.Value, 'device', _('Device'), _(
+			'Path to V4L2 device. Default: /dev/video0'
+		));
 
-		const resolution = s.taboption(this_tab, form.Value, 'resolution', _('Resolution'));
-		resolution.placeholder = '640x480';
+		device.default = '/dev/video0';
+		device.value('/dev/video0', '/dev/video0');
+		device.value('/dev/video1', '/dev/video1');
+		device.value('/dev/video2', '/dev/video2');
+		device.optional = true;
+
+		const device_timeout = s.taboption(
+			this_tab, form.Value, 'device_timeout', _('Device timeout'), _(
+			'Timeout for device querying. Default: 1 second'
+		));
+
+		device_timeout.datatype = 'and(uinteger, range(0, 60))';
+		device_timeout.placeholder = '5';
+		device_timeout.optional = true;
+
+		const input = s.taboption(
+			this_tab, form.Value, 'input', _('Input'), _('Input channel. Default: 0')
+		);
+
+		input.datatype = 'and(uinteger, range(0, 128))';
+		input.placeholder = '0';
+		input.optional = true;
+
+		const resolution = s.taboption(
+			this_tab, form.Value, 'resolution', _('Resolution'), _(
+			'Initial image resolution. Default: 640x480'
+		));
+
+		resolution.default = '640x480';
 		resolution.value('320x240', '320x240');
 		resolution.value('640x480', '640x480');
 		resolution.value('800x600', '800x600');
@@ -95,433 +227,661 @@ return view.extend({
 		resolution.value('1920x1080', '1920x1080');
 		resolution.optional = true;
 
-		const fps = s.taboption(this_tab, form.Value, 'desired_fps', _('Frames per second'),
-			_('Default: maximum possible.'));
-		fps.datatype = 'and(uinteger, min(1))';
-		fps.placeholder = '5';
+		const fps = s.taboption(
+			this_tab, form.Value, 'desired_fps', _('Frames per second'), _(
+			'Desired FPS. Default: maximum possible'
+		));
+
+		fps.datatype = 'and(uinteger, min(0))';
+		fps.placeholder = '0';
 		fps.optional = true;
 
-		const format = s.taboption(this_tab, form.Value, 'format', _('Format'));
-		format.placeholder = 'YUYV';
-		format.value('BGR24');
-		format.value('GREY');
-		format.value('JPEG');
-		format.value('MJPEG');
-		format.value('RGB24');
-		format.value('RGB565');
-		format.value('UYVY');
-		format.value('YUV420');
-		format.value('YUYV');
-		format.value('YVU420');
-		format.value('YVYU');
+		const slowdown = s.taboption(
+			this_tab, form.Flag, 'slowdown', _('Slowdown'), _(
+			'Slowdown capturing to 1 FPS or less when no stream or sink clients are ' +
+			'connected.<br />Useful to reduce CPU consumption. Default: disabled'
+		));
 
-		const encoder = s.taboption(this_tab, form.Value, 'encoder', _('Encoder'));
-		encoder.value('CPU');
-		encoder.value('HW');
+		const format = s.taboption(
+			this_tab, form.Value, 'format', _('Image format'), _('Default: YUYV')
+		);
+
+		format.default = 'YUYV';
+		format.value('YUYV', 'YUYV');
+		format.value('YVYU', 'YVYU');
+		format.value('UYVY', 'UYVY');
+		format.value('YUV420', 'YUV420');
+		format.value('YVU420', 'YVU420');
+		format.value('RGB565', 'RGB565');
+		format.value('RGB24', 'RGB24');
+		format.value('BGR24', 'BGR24');
+		format.value('GREY', 'GREY');
+		format.value('MJPEG', 'MJPEG');
+		format.value('JPEG', 'JPEG');
+		format.optional = true;
+
+		const encoder = s.taboption(
+			this_tab, form.Value, 'encoder', _('Еncoder'), _(
+			'Use specified encoder. It may affect the number of workers<br />' +
+			'<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>' +
+			'<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>' +
+			'<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>' +
+			'<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>'
+		));
+
+		encoder.default = 'CPU';
+		encoder.value('CPU', 'CPU');
+		encoder.value('HW', 'HW');
+		encoder.value('M2M-VIDEO', 'M2M-VIDEO');
+		encoder.value('M2M-IMAGE', 'M2M-IMAGE');
+		encoder.optional = true;
 
 		const quality = s.taboption(
-			this_tab,
-			form.Value,
-			'quality',
-			_('Quality'),
-			_('Set the quality in percent.'),
-		);
-		quality.datatype = 'range(0, 100)';
+			this_tab, form.Value, 'quality', _('Quality'), _(
+			'Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />' +
+			'If HW encoding is used (JPEG source format), attempts to configure<br />' +
+			"the camera or capture device hardware's internal encoder.<br />" +
+			'MJPEG will not be recoded to MJPEG to change the quality'
+		));
+
+		quality.datatype = 'and(uinteger, range(0, 100))';
+		quality.placeholder = '0';
+		quality.optional = true;
+
+		const host = s.taboption(
+			this_tab, form.Value, 'host', _('Host'), _(
+			'Listen on Hostname or IP. Default: 127.0.0.1'
+		));
+
+		host.datatype = 'or(ip4addr, ip6addr, host)';
+		host.placeholder = '::';
+		host.optional = true;
+
+		const port = s.taboption(
+			this_tab, form.Value, 'port', _('Port'), _(
+			'Bind to this TCP port. Default: 8080'
+		));
+
+		port.datatype = 'port';
+		port.placeholder = '8080';
+		port.optional = true;
+
+		const user = s.taboption(
+			this_tab, form.Value, 'user', _('Username'), _(
+			'HTTP basic auth user. Default: disabled'
+		));
+
+		user.datatype = 'string';
+		user.placeholder = '';
+		user.optional = true;
+
+		const pass = s.taboption(
+			this_tab, form.Value, 'pass', _('Password'), _(
+			'HTTP basic auth passwd. Default: empty'
+		));
+
+		pass.datatype = 'string';
+		pass.placeholder = '';
+		pass.password = true;
+		pass.optional = true;
 
 
-		const allow_truncated_frames = s.taboption(this_tab, form.Flag, 'allow_truncated_frames', _('Allow truncated frames'));
-		allow_truncated_frames.default = allow_truncated_frames.disabled;
+		// capture
 
-		const format_swap_rgb = s.taboption(this_tab, form.Flag, 'format_swap_rgb', _('Format: Swap RGB'),
-			_('Enable R-G-B order swapping: RGB to BGR and vice versa.'));
-		format_swap_rgb.default = format_swap_rgb.disabled;
+		this_tab = 'capture';
 
-		const persistent = s.taboption(this_tab, form.Flag, 'persistent', _('Persistent'),
-			_("Don't re-initialize device on timeout. Default: disabled."));
-		persistent.default = persistent.disabled;
+		const allow_truncated_frames = s.taboption(
+			this_tab, form.Flag, 'allow_truncated_frames',
+			_('Allow truncated frames'), _(
+			'Allows to handle truncated frames. Default: disabled<br />' +
+			'Useful if the device produces incorrect but still acceptable frames'
+		));
 
-		const dv_timings = s.taboption(this_tab, form.Flag, 'dv_timings', _('DV Timings'),
-			_("Enable DV-timings querying and events processing to automatic resolution change. Default: disabled."));
-		dv_timings.default = dv_timings.disabled;
+		const format_swap_rgb = s.taboption(
+			this_tab, form.Flag, 'format_swap_rgb', _('R-G-B order swap'), _(
+			'RGB to BGR and vice versa. Default: disabled'
+		));
 
-		const tv_standard = s.taboption(this_tab, form.Value, 'tv_standard', _('TV standard'));
-		tv_standard.placeholder = '';
-		tv_standard.value('PAL');
-		tv_standard.value('NTSC');
-		tv_standard.value('SECAM');
+		const persistent = s.taboption(
+			this_tab, form.Flag, 'persistent', _('Persistent'), _(
+			"Don't re-initialize device on timeout. Default: disabled"
+		));
 
-		const io_method = s.taboption(this_tab, form.Value, 'io_method', _('IO method'));
-		io_method.placeholder = 'MMAP';
-		io_method.value('MMAP');
-		io_method.value('USERPTR');
+		const dv_timings = s.taboption(
+			this_tab, form.Flag, 'dv_timings', _('DV-timings'), _(
+			'Enable DV-timings querying and events processing to automatic ' +
+			'resolution change<br />Default: disable'
+		));
 
-		const buffers = s.taboption(this_tab, form.Value, 'buffers', _('Buffers'),
-			_('The number of buffers to receive data from the device.') + '<br/>' +
-			_('Each buffer may processed using an independent thread.') + '<br/>' +
-			_('Default: 3 (the number of CPU cores (but not more than 4) + 1).'));
-		buffers.datatype = 'and(uinteger, min(1))';
+		const tv_standard = s.taboption(
+			this_tab, form.ListValue, 'tv_standard', _('Force TV standard'), _(
+			'Default: disabled'
+		));
+
+		tv_standard.default = '';
+		tv_standard.value('', _('default'));
+		tv_standard.value('PAL', 'PAL');
+		tv_standard.value('NTSC', 'NTSC');
+		tv_standard.value('SECAM', 'SECAM');
+		tv_standard.optional = true;
+
+		const io_method = s.taboption(
+			this_tab, form.ListValue, 'io_method', _('V4L2 IO method'), _(
+			'Changing this parameter may increase the performance. Or not.<br />' +
+			'See kernel documentation. Default: MMAP'
+		));
+
+		io_method.default = '';
+		io_method.value('', _('default'));
+		io_method.value('MMAP', 'MMAP');
+		io_method.value('USERPTR', 'USERPTR');
+		io_method.optional = true;
+
+		const buffers = s.taboption(
+			this_tab, form.Value, 'buffers', _('Buffers'), _(
+			'The number of buffers to receive data from the device.<br />' +
+			'Each buffer may be processed using an independent thread.<br />' +
+			'Default: 3 (the number of CPU cores (but not more than 4) + 1)'
+		));
+
+		buffers.datatype = 'and(uinteger, range(0, 32))';
 		buffers.placeholder = '3';
 		buffers.optional = true;
 
-		const workers = s.taboption(this_tab, form.Value, 'workers', _('Workers'),
-			_('The number of worker threads but not more than buffers.') + '<br/>' +
-			_('Default: 2 (the number of CPU cores (but not more than 4)).'));
-		workers.datatype = 'and(uinteger, min(1))';
+		const workers = s.taboption(
+			this_tab, form.Value, 'workers', _('Workers'), _(
+			'The number of worker threads but not more than buffers.<br />' +
+			'Default: 2 (the number of CPU cores (but not more than 4))'
+		));
+
+		workers.datatype = 'and(uinteger, range(0, 32))';
 		workers.placeholder = '2';
 		workers.optional = true;
 
-		const m2m_device = s.taboption(this_tab, form.FileUpload, 'm2m_device', _('M2M device'));
+		const m2m_device = s.taboption(
+			this_tab, form.FileUpload, 'm2m_device', _('M2M device'), _(
+			'Path to V4L2 M2M encoder device. Default: auto select'
+		));
+
 		m2m_device.root_directory = '/dev';
-		m2m_device.show_hidden = true;
 		m2m_device.directory_create = false;
 		m2m_device.enable_download = false;
 		m2m_device.enable_upload = false;
 		m2m_device.enable_remove = false;
+		m2m_device.show_hidden = true;
 		m2m_device.optional = true;
 		m2m_device.datatype = 'file';
 
 		const min_frame_size = s.taboption(
-			this_tab,
-			form.Value,
-			'min_frame_size',
-			_('Drop frames smaller than this limit'),
-			_('Set the minimum size if the webcam produces small-sized garbage frames. May happen under low light conditions'),
-		);
-		min_frame_size.datatype = 'uinteger';
-		min_frame_size.placeholder = '128';
+			this_tab, form.Value, 'min_frame_size', _('Min frame size'), _(
+			'Drop frames smaller than this limit. Useful if the device<br />' +
+			'produces small-sized garbage frames. Default: 128 bytes'
+		));
 
-		const device_error_delay = s.taboption(this_tab, form.Value, 'device_error_delay', _('Device error delay'));
-		device_error_delay.datatype = 'and(uinteger, min(1))';
+		min_frame_size.datatype = 'and(uinteger, range(0, 8192))';
+		min_frame_size.placeholder = '128';
+		min_frame_size.optional = true;
+
+		const device_error_delay = s.taboption(
+			this_tab, form.Value, 'device_error_delay', _('Device error delay'), _(
+			'Delay before trying to connect to the device again<br />' +
+			'after an error (timeout for example). Default: 1 second'
+		));
+
+		device_error_delay.datatype = 'and(uinteger, range(0, 60))';
 		device_error_delay.placeholder = '1';
 		device_error_delay.optional = true;
 
-		// Output HTTP settings
 
-		this_tab = 'output_http';
+		// HTTP server
 
-		const host = s.taboption(this_tab, form.Value, 'host', _('Host'), _('TCP host for this HTTP server'));
-		host.datatype = 'host';
-		host.placeholder = '::';
-		host.datatype = 'or(hostname,ipaddr)';
-		host.optional = false;
+		this_tab = 'server_http';
 
-		const port = s.taboption(this_tab, form.Value, 'port', _('Port'), _('TCP port for this HTTP server'));
-		port.datatype = 'port';
-		port.placeholder = '8080';
-		port.optional = false;
+		const tcp_nodelay = s.taboption(
+			this_tab, form.Flag, 'tcp_nodelay', _('TCP no delay'), _(
+			'Set TCP_NODELAY flag to the client /stream socket. Only for TCP ' +
+			'socket<br >Default: disabled'
+		));
 
-		const enable_auth = s.taboption(this_tab, form.Flag, 'enable_auth', _('Authentication required'), _('Ask for username and password on connect'));
-		enable_auth.default = false;
+		const www = s.taboption(
+			this_tab, form.Value, 'static', _('WWW folder'), _(
+			'Path to dir with static files instead of embedded root index page<br />' +
+			'Symlinks are not supported for security reasons. Default: disabled'
+		));
 
-		const username = s.taboption(this_tab, form.Value, 'user', _('Username'));
-		username.depends('enable_auth', '1');
-		username.optional = false;
+		www.datatype = 'directory';
+		www.placeholder = '/www/webcam';
+		www.optional = true;
 
-		const password = s.taboption(this_tab, form.Value, 'pass', _('Password'));
-		password.depends('enable_auth', '1');
-		password.password = true;
-		password.optional = false;
-		password.default = false;
+		const unix = s.taboption(
+			this_tab, form.Value, 'unix', _('UNIX socket'), _(
+			'Bind to UNIX domain socket. Default: disabled'
+		));
 
-		const staticres = s.taboption(this_tab, form.Value, 'static', _('WWW folder'), _('Folder that contains webpages'));
-		staticres.datatype = 'directory';
-		staticres.placeholder = '/www/webcam/';
-		staticres.optional = false;
-
-		const unix = s.taboption(this_tab, form.Value, 'unix', _('Socket'), _('Folder that contains the socket'));
 		unix.datatype = 'file';
 		unix.placeholder = '/path/to/socket';
+		unix.optional = true;
 
-		const unix_mode = s.taboption(this_tab, form.Value, 'unix_mode', _('Socket Permissions'));
-		unix_mode.datatype = 'string';
+		const unix_rm = s.taboption(
+			this_tab, form.Flag, 'unix_rm', _('UNIX socket remove old'), _(
+			'Try to remove old UNIX socket file before binding. Default: disabled'
+		));
+
+		function validate_file_mode (section_id, value) {
+			if (!value || /^[0-7]{3,4}$/.test(value)) return true;
+			return _('Expecting: file mode, e.g. 640 or 0640');
+		}
+
+		const unix_mode = s.taboption(
+			this_tab, form.Value, 'unix_mode', _('UNIX socket permissions'), _(
+			'Set UNIX socket file permissions (like 777). Default: disabled'
+		));
+
+		unix_mode.validate = validate_file_mode;
 		unix_mode.placeholder = '660';
+		unix_mode.optional = true;
 
-		const drop_same_frames = s.taboption(this_tab, form.Flag, 'drop_same_frames', _('Drop same frames'));
-		drop_same_frames.default = drop_same_frames.disabled;
+		const drop_same_frames = s.taboption(
+			this_tab, form.Value, 'drop_same_frames', _('Drop same frames'), _(
+			"Don't send identical frames to clients, but no more than specified " +
+			"number.<br />" +
+			"It can significantly reduce the outgoing traffic, but will increase" +
+			"<br />" +
+			"the CPU loading. Don't use this option with analog signal sources<br />" +
+			"or webcams, it's useless. Default: disabled"
+		));
 
-		const fake_resolution = s.taboption(this_tab, form.Value, 'fake_resolution', _('Fake resolution'));
-		fake_resolution.placeholder = '640x480';
+		drop_same_frames.datatype = 'and(uinteger, min(0))';
+		drop_same_frames.placeholder = '0';
+		drop_same_frames.optional = true;
+
+		const fake_resolution = s.taboption(
+			this_tab, form.Value, 'fake_resolution', _('Fake resolution'), _(
+			'Override image resolution for the /state. Default: disabled'
+		));
+
+		fake_resolution.default = '';
 		fake_resolution.keylist = resolution.keylist;
 		fake_resolution.vallist = resolution.vallist;
+		fake_resolution.optional = true;
 
-		const allow_origin = s.taboption(this_tab, form.Value, 'allow_origin', _('Allow origin'));
-		allow_origin.values = resolution.values;
+		const allow_origin = s.taboption(
+			this_tab, form.Value, 'allow_origin', _('Allow origin'), _(
+			'Set Access-Control-Allow-Origin header. Default: disabled'
+		));
 
-		const instance_id = s.taboption(this_tab, form.Value, 'instance_id', _('Instance ID'));
+		allow_origin.datatype = 'string';
+		allow_origin.optional = true;
 
-		const server_timeout = s.taboption(this_tab, form.Value, 'server_timeout', _('Server timeout'));
-		server_timeout.datatype = 'uinteger';
+		const instance_id = s.taboption(
+			this_tab, form.Value, 'instance_id', _('Instance ID'), _(
+			'A short string identifier to be displayed in the /state handle.<br />' +
+			'It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string'
+		));
+
+		instance_id.datatype = 'string';
+		instance_id.optional = true;
+
+		const server_timeout = s.taboption(
+			this_tab, form.Value, 'server_timeout', _('Server timeout'), _(
+			'Timeout for client connections. Default: 10 seconds'
+		));
+
+		server_timeout.datatype = 'and(uinteger, range(0, 60))';
 		server_timeout.placeholder = '10';
+		server_timeout.optional = true;
 
 
+		// JPEG sink
 
-		function init_stream() {
-			console.debug('init_stream');
-			start_stream();
-		}
+		this_tab = 'sink_jpeg';
 
-		function _start_stream() {
-			console.debug('_start_stream');
+		const jpeg_sink = s.taboption(
+			this_tab, form.Value, 'jpeg_sink', _('JPEG sink'), _(
+			'Use the shared memory to sink JPEG frames. Default: disabled<br />' +
+			'The name should end with a suffix .jpg or .jpeg'
+		));
 
-			const port = uci.get('ustreamer', 'core', 'port');
-			let login;
-
-			if (uci.get('ustreamer', 'core', 'enable_auth') == '1') {
-				const user = uci.get('ustreamer', 'core', 'username');
-				const pass = uci.get('ustreamer', 'core', 'password');
-				login = `${user}:${pass}@`;
-			} else {
-				login = '';
-			}
-
-			const img = document.getElementById('video_preview') || video_preview;
-			img.src = 'http://' + login + location.hostname + ':' + port + '/?action=snapshot' + '&t=' + new Date().getTime();
-		}
-
-		function start_stream() {
-			console.debug('start_stream');
-
-			setTimeout(function () {
-				_start_stream();
-			}, 5000);
-		}
-
-		function on_error() {
-			console.warn('on_error');
-
-			const img = video_preview;
-			img.style.display = 'none';
-
-			const stream_stat = document.getElementById('stream_status') || stream_status;
-			stream_stat.style.display = 'block';
-
-			// start_stream();
-		}
-
-		function on_load() {
-			console.debug('on_load');
-
-			const img = video_preview;
-			img.style.display = 'block';
-
-			const stream_stat = stream_status;
-			stream_stat.style.display = 'none';
-		}
-
-		//HTTP preview
-		const video_preview = E('img', {
-			'id': 'video_preview',
-			'class': 'img-preview',
-			'error': on_error,
-			'load': on_load,
-		});
-
-		const stream_status = E('p', {
-				'id': 'stream_status',
-				'style': 'text-align: center; color: orange; font-weight: bold;',
-			},
-			_('Stream unavailable'),
-		);
-
-
-		init_stream();
-
-		const preview = s.taboption(this_tab, form.DummyValue, '_dummy');
-		preview.render = L.bind(function (view, section_id) {
-			return E([], [
-				video_preview,
-				stream_status
-			]);
-		}, preview, this);
-		preview.depends('output', 'http');
-
-		// JPEG sink settings
-
-		this_tab = 'jpeg_sink';
-
-		const jpeg_sink = s.taboption(this_tab, form.Value, 'jpeg_sink', _('JPEG sink'),
-			_('Use the shared memory to sink JPEG frames. Default: disabled.') + '<br/>' +
-			_('The name should end with a suffix ".jpeg".') + '<br/>' +
-			_('Default: disabled.'));
+		jpeg_sink.datatype = 'file';
 		jpeg_sink.placeholder = 'name.jpeg';
 		jpeg_sink.optional = true;
 
-		const jpeg_sink_mode = s.taboption(this_tab, form.Value, 'jpeg_sink_mode', _('JPEG sink mode'),
-			_('Set JPEG sink permissions (like 777). Default: 660.'));
-		jpeg_sink_mode.datatype = 'string';
+		const jpeg_sink_mode = s.taboption(
+			this_tab, form.Value, 'jpeg_sink_mode', _('Sink permissions'), _(
+			'Set sink file permissions. Default: 660'
+		));
+
+		jpeg_sink_mode.validate = validate_file_mode;
 		jpeg_sink_mode.placeholder = '660';
 		jpeg_sink_mode.optional = true;
 
-		const jpeg_sink_client_ttl = s.taboption(this_tab, form.Value, 'jpeg_sink_client_ttl', _('Client TTL'),
-			_('Default: 10.'));
-		jpeg_sink_client_ttl.datatype = 'uinteger';
+		const jpeg_sink_client_ttl = s.taboption(
+			this_tab, form.Value, 'jpeg_sink_client_ttl', _('Client TTL'), _(
+			'Default: 10 seconds'
+		));
+
+		jpeg_sink_client_ttl.datatype = 'and(uinteger, range(0, 60))';
 		jpeg_sink_client_ttl.placeholder = '10';
 		jpeg_sink_client_ttl.optional = true;
 
-		const jpeg_sink_timeout = s.taboption(this_tab, form.Value, 'jpeg_sink_timeout', _('JPEG sink timeout'),
-			_('Timeout for lock. Default: 1.'));
-		jpeg_sink_timeout.datatype = 'uinteger';
+		const jpeg_sink_timeout = s.taboption(
+			this_tab, form.Value, 'jpeg_sink_timeout', _('Timeout for lock'), _(
+			'Default: 1 second'
+		));
+
+		jpeg_sink_timeout.datatype = 'and(uinteger, range(0, 60))';
 		jpeg_sink_timeout.placeholder = '1';
 		jpeg_sink_timeout.optional = true;
 
-		const jpeg_sink_rm = s.taboption(this_tab, form.Flag, 'jpeg_sink_rm', _('Remove JPEG sink'),
-			_('Remove JPEG sink file on exit'));
-		jpeg_sink_rm.default = jpeg_sink_rm.disabled;
+		const jpeg_sink_rm = s.taboption(
+			this_tab, form.Flag, 'jpeg_sink_rm', _('Remove on stop'), _(
+			'Remove shared memory on stop. Default: disabled'
+		));
 
-		// RAW sink settings
 
-		this_tab = 'raw_sink';
+		// RAW sink
 
-		const raw_sink = s.taboption(this_tab, form.Value, 'raw_sink', _('RAW sink'),
-			_('Use the shared memory to sink RAW frames. Default: disabled.') + '<br/>' +
-			_('The name should end with a suffix ".raw".') + '<br/>' +
-			_('Default: disabled.'));
+		this_tab = 'sink_raw';
+
+		const raw_sink = s.taboption(
+			this_tab, form.Value, 'raw_sink', _('RAW sink'), _(
+			'Use the shared memory to sink RAW frames. Default: disabled<br />' +
+			'The name should end with a suffix .raw'
+		));
+
+		raw_sink.datatype = 'file';
 		raw_sink.placeholder = 'name.raw';
 		raw_sink.optional = true;
 
-		const raw_sink_mode = s.taboption(this_tab, form.Value, 'raw_sink_mode', _('RAW sink mode'),
-			_('Set RAW sink permissions (like 777). Default: 660.'));
-		raw_sink_mode.datatype = 'string';
+		const raw_sink_mode = s.taboption(
+			this_tab, form.Value, 'raw_sink_mode', _('Sink permissions'), _(
+			'Set sink file permissions. Default: 660'
+		));
+
+		raw_sink_mode.validate = validate_file_mode;
 		raw_sink_mode.placeholder = '660';
 		raw_sink_mode.optional = true;
 
-		const raw_sink_client_ttl = s.taboption(this_tab, form.Value, 'raw_sink_client_ttl', _('RAW sink client TTL'),
-			_('Client TTL. Default: 10.'));
-		raw_sink_client_ttl.datatype = 'uinteger';
+		const raw_sink_client_ttl = s.taboption(
+			this_tab, form.Value, 'raw_sink_client_ttl', _('Client TTL'), _(
+			'Default: 10 seconds'
+		));
+
+		raw_sink_client_ttl.datatype = 'and(uinteger, range(0, 60))';
 		raw_sink_client_ttl.placeholder = '10';
 		raw_sink_client_ttl.optional = true;
 
-		const raw_sink_timeout = s.taboption(this_tab, form.Value, 'raw_sink_timeout', _('RAW sink timeout'),
-			_('Timeout for lock. Default: 1.'));
-		raw_sink_timeout.datatype = 'uinteger';
+		const raw_sink_timeout = s.taboption(
+			this_tab, form.Value, 'raw_sink_timeout', _('Timeout for lock'), _(
+			'Default: 1 second'
+		));
+
+		raw_sink_timeout.datatype = 'and(uinteger, range(0, 60))';
 		raw_sink_timeout.placeholder = '1';
 		raw_sink_timeout.optional = true;
 
-		const raw_sink_rm = s.taboption(this_tab, form.Flag, 'raw_sink_rm', _('Remove RAW sink'),
-			_('Remove shared memory on stop. Default: disabled.'));
-		raw_sink_rm.default = raw_sink_rm.disabled;
+		const raw_sink_rm = s.taboption(
+			this_tab, form.Flag, 'raw_sink_rm', _('Remove on stop'), _(
+			'Remove shared memory on stop. Default: disabled'
+		));
 
-		// H264 sink settings
 
-		this_tab = 'h264_sink';
+		// H264 sink
 
-		const h264_sink = s.taboption(this_tab, form.Value, 'h264_sink', _('H264 sink'),
-			_('Use the shared memory to sink H264 frames. Default: disabled.') + '<br/>' +
-			_('The name should end with a suffix ".h264"') + '<br/>' +
-			_('Default: disabled.'));
+		this_tab = 'sink_h264';
+
+		const h264_sink = s.taboption(
+			this_tab, form.Value, 'h264_sink', _('H264 sink'), _(
+			'Use the shared memory to sink H264 frames. Default: disabled<br />' +
+			'The name should end with a suffix .h264'
+		));
+
+		h264_sink.datatype = 'file';
 		h264_sink.placeholder = 'name.h264';
 		h264_sink.optional = true;
 
-		const h264_sink_mode = s.taboption(this_tab, form.Value, 'h264_sink_mode', _('H264 sink mode'),
-			_('Set H264 sink permissions (like 777). Default: 660.'));
-		h264_sink_mode.datatype = 'string';
+		const h264_sink_mode = s.taboption(
+			this_tab, form.Value, 'h264_sink_mode', _('Sink permissions'), _(
+			'Set sink file permissions. Default: 660'
+		));
+
+		h264_sink_mode.validate = validate_file_mode;
 		h264_sink_mode.placeholder = '660';
 		h264_sink_mode.optional = true;
 
-		const h264_sink_rm = s.taboption(this_tab, form.Flag, 'h264_sink_rm', _('Remove'),
-			_('Remove shared memory on stop. Default: disabled.'));
-		h264_sink_rm.default = h264_sink_rm.disabled;
+		const h264_sink_client_ttl = s.taboption(
+			this_tab, form.Value, 'h264_sink_client_ttl', _('Client TTL'), _(
+			'Default: 10 seconds'
+		));
 
-		const h264_sink_client_ttl = s.taboption(this_tab, form.Value, 'h264_sink_client_ttl', _('Sink client TTL'),
-			_('Client TTL. Default: 10.'));
-		h264_sink_client_ttl.datatype = 'uinteger';
+		h264_sink_client_ttl.datatype = 'and(uinteger, range(0, 60))';
 		h264_sink_client_ttl.placeholder = '10';
 		h264_sink_client_ttl.optional = true;
 
-		const h264_sink_timeout = s.taboption(this_tab, form.Value, 'h264_sink_timeout', _('Sink timeout'),
-			_('Timeout for lock. Default: 1.'));
-		h264_sink_timeout.datatype = 'uinteger';
+		const h264_sink_timeout = s.taboption(
+			this_tab, form.Value, 'h264_sink_timeout', _('Timeout for lock'), _(
+			'Default: 1 second'
+		));
+
+		h264_sink_timeout.datatype = 'and(uinteger, range(0, 60))';
 		h264_sink_timeout.placeholder = '1';
 		h264_sink_timeout.optional = true;
 
-		const h264_bitrate = s.taboption(this_tab, form.Value, 'h264_bitrate', _('Bitrate'),
-			_('H264 bitrate in Kbps. Default: 5000.'));
-		h264_bitrate.datatype = 'uinteger';
+		const h264_sink_rm = s.taboption(
+			this_tab, form.Flag, 'h264_sink_rm', _('Remove on stop'), _(
+			'Remove shared memory on stop. Default: disabled'
+		));
+
+		const h264_boost = s.taboption(
+			this_tab, form.Flag, 'h264_boost', _('H264 boost'), _(
+			'Increase encoder performance on PiKVM V4. Default: disabled'
+		));
+
+		const h264_bitrate = s.taboption(
+			this_tab, form.Value, 'h264_bitrate', _('Bitrate (kbps)'), _(
+			'Default: 5000 kbps'
+		));
+
+		h264_bitrate.datatype = 'and(uinteger, range(25, 20000))';
 		h264_bitrate.placeholder = '5000';
 		h264_bitrate.optional = true;
 
-		const h264_gop = s.taboption(this_tab, form.Value, 'h264_gop', _('H264 GOP'),
-			_('Interval between keyframes. Default: 30.'));
-		h264_gop.datatype = 'uinteger';
+		const h264_gop = s.taboption(
+			this_tab, form.Value, 'h264_gop', _('Keyframe interval'), _(
+			'Default: 30'
+		));
+
+		h264_gop.datatype = 'and(uinteger, range(0, 60))';
 		h264_gop.placeholder = '30';
 		h264_gop.optional = true;
 
-		const h264_m2m_device = s.taboption(this_tab, form.FileUpload, 'h264_m2m_device', _('H264 M2M device'),
-			_('Path to V4L2 M2M encoder device. Default: auto select.'));
+		const h264_m2m_device = s.taboption(
+			this_tab, form.FileUpload, 'h264_m2m_device', _('M2M device'), _(
+			'Path to V4L2 M2M encoder device. Default: auto select'
+		));
+
 		h264_m2m_device.root_directory = '/dev';
-		h264_m2m_device.show_hidden = true;
 		h264_m2m_device.directory_create = false;
 		h264_m2m_device.enable_download = false;
 		h264_m2m_device.enable_upload = false;
 		h264_m2m_device.enable_remove = false;
+		h264_m2m_device.show_hidden = true;
 		h264_m2m_device.optional = true;
 		h264_m2m_device.datatype = 'file';
 
-		const h264_boost = s.taboption(this_tab, form.Flag, 'h264_boost', _('H264 boost'),
-			_('Increase encoder performance on PiKVM V4. Default: disabled.'));
-		h264_boost.default = h264_boost.disabled;
 
-		const exit_on_no_clients = s.taboption(this_tab, form.Flag, 'exit_on_no_clients', _('Exit on no clients'),
-			_('Exit the program if there have been no stream or sink clients ') + 
-			_('or any HTTP requests in the last N seconds. Default: 0 (disabled).'));
-		exit_on_no_clients.default = exit_on_no_clients.disabled;
+		// logging
 
-		// Image control settings
+		this_tab = 'logging';
+
+		const log_level = s.taboption(
+			this_tab, form.ListValue, 'log_level', _('Log level'), _(
+			'Verbosity level of messages from 0 (info) to 3 (debug)<br />' +
+			'Enabling debugging messages can slow down the program<br />' +
+			'Default: 0 (info)'
+		));
+
+		log_level.default = '';
+		log_level.datatype = 'and(uinteger, range(0, 3))';
+		log_level.value('', _('default'));
+		log_level.value('0', '0 ' + _('Info'));
+		log_level.value('1', '1 ' + _('Performance'));
+		log_level.value('2', '2 ' + _('Verbose'));
+		log_level.value('3', '3 ' + _('Debug'));
+		log_level.optional = true;
+
+		const exit_on_no_clients = s.taboption(
+			this_tab, form.Value, 'exit_on_no_clients', _('Exit on no clients'), _(
+			'Exit the program if there have been no stream or sink clients<br />' +
+			'or any HTTP requests in the last N seconds. Default: 0 (disabled)'
+		));
+
+		exit_on_no_clients.datatype = 'and(uinteger, range(0, 86400))';
+		exit_on_no_clients.placeholder = '0';
+		exit_on_no_clients.optional = true;
+
+
+		// image control
 
 		this_tab = 'image_control';
 
-		const image_default = s.taboption(this_tab, form.Flag, 'image_default', _('Use device defaults'));
-		image_default.default = image_default.disabled;
+		const image_default = s.taboption(
+			this_tab, form.Flag, 'image_default', _('Image default'), _(
+			'Reset all image settings below to default. Unchecked: no change'
+		));
 
-		const brightness = s.taboption(this_tab, form.Value, 'brightness', _('Brightness'));
-		brightness.placeholder = '128 | auto';
+		function validate_int_default (section_id, value) {
+			if (!value || (value == 'default')) return true;
+			value = parseInt(value);
+			if (!isNaN(value)) return true;
+			return _('Expecting: number | default');
+		}
+
+		function validate_int_default_auto (section_id, value) {
+			if (!value || (value == 'default') || (value == 'auto')) return true;
+			value = parseInt(value);
+			if (!isNaN(value)) return true;
+			return _('Expecting: number | default | auto');
+		}
+
+		const brightness = s.taboption(
+			this_tab, form.Value, 'brightness', _('Brightness'), _(
+			'number | default | auto. Blank: no change'
+		));
+
+		brightness.validate = validate_int_default_auto;
+		brightness.placeholder = '128 | default | auto';
 		brightness.optional = true;
 
-		const contrast = s.taboption(this_tab, form.Value, 'contrast', _('Contrast'));
-		contrast.placeholder = '128';
+		const contrast = s.taboption(
+			this_tab, form.Value, 'contrast', _('Contrast'), _(
+			'number | default. Blank: no change'
+		));
+
+		contrast.validate = validate_int_default;
+		contrast.placeholder = '128 | default';
 		contrast.optional = true;
 
-		const saturation = s.taboption(this_tab, form.Value, 'saturation', _('Saturation'));
-		saturation.placeholder = '128';
+		const saturation = s.taboption(
+			this_tab, form.Value, 'saturation', _('Saturation'), _(
+			'number | default. Blank: no change'
+		));
+
+		saturation.validate = validate_int_default;
+		saturation.placeholder = '128 | default';
 		saturation.optional = true;
 
-		const hue = s.taboption(this_tab, form.Value, 'hue', _('Hue'));
-		hue.placeholder = '128 | auto';
-		hue.optional = true;
+		const gamma = s.taboption(
+			this_tab, form.Value, 'gamma', _('Gamma'), _(
+			'number | default. Blank: no change'
+		));
 
-		const gamma = s.taboption(this_tab, form.Value, 'gamma', _('Gamma'));
-		gamma.placeholder = '128';
+		gamma.validate = validate_int_default;
+		gamma.placeholder = 'default';
 		gamma.optional = true;
 
-		const sharpness = s.taboption(this_tab, form.Value, 'sharpness', _('Sharpness'));
-		sharpness.placeholder = '128';
-		sharpness.optional = true;
+		const gain = s.taboption(
+			this_tab, form.Value, 'gain', _('Gain'), _(
+			'number | default | auto. Blank: no change'
+		));
 
-		const backlight_compensation = s.taboption(this_tab, form.Value, 'backlight_compensation', _('Backlight compensation'));
-		backlight_compensation.placeholder = '128';
-		backlight_compensation.optional = true;
-
-		const white_balance = s.taboption(this_tab, form.Value, 'white_balance', _('White balance'));
-		white_balance.placeholder = '128 | auto';
-		white_balance.optional = true;
-
-		const gain = s.taboption(this_tab, form.Value, 'gain', _('Gain'));
-		gain.placeholder = '128 | auto';
+		gain.validate = validate_int_default_auto;
+		gain.placeholder = '0 | default | auto';
 		gain.optional = true;
 
-		const color_effect = s.taboption(this_tab, form.Value, 'color_effect', _('Color effect'));
-		color_effect.placeholder = '128';
+		const hue = s.taboption(
+			this_tab, form.Value, 'hue', _('Hue'), _(
+			'number | default | auto. Blank: no change'
+		));
+
+		hue.validate = validate_int_default_auto;
+		hue.placeholder = 'number | default | auto';
+		hue.optional = true;
+
+		const sharpness = s.taboption(
+			this_tab, form.Value, 'sharpness', _('Sharpness'), _(
+			'number | default. Blank: no change'
+		));
+
+		sharpness.validate = validate_int_default;
+		sharpness.placeholder = '128 | default';
+		sharpness.optional = true;
+
+		const color_effect = s.taboption(
+			this_tab, form.Value, 'color_effect', _('Colour effect'), _(
+			'number | default. Blank: no change'
+		));
+
+		color_effect.validate = validate_int_default;
+		color_effect.placeholder = 'default';
 		color_effect.optional = true;
 
-		const rotate = s.taboption(this_tab, form.Value, 'rotate', _('Rotate'));
-		rotate.datatype = 'uinteger';
+		const white_balance = s.taboption(
+			this_tab, form.Value, 'white_balance', _('White balance'), _(
+			'temperature | default | auto. Blank: no change'
+		));
+
+		white_balance.validate = validate_int_default_auto;
+		white_balance.placeholder = '4000 | default | auto';
+		white_balance.optional = true;
+
+		const backlight_compensation = s.taboption(
+			this_tab, form.Value, 'backlight_compensation',
+			_('Backlight compensation'), _(
+			'number | default. Blank: no change'
+		));
+
+		backlight_compensation.validate = validate_int_default;
+		backlight_compensation.placeholder = '0 | default';
+		backlight_compensation.optional = true;
+
+		const flip_horizontal = s.taboption(
+			this_tab, form.Value, 'flip_horizontal', _('Flip horizontal'), _(
+			'number | default. Blank: no change'
+		));
+
+		flip_horizontal.validate = validate_int_default;
+		flip_horizontal.placeholder = '0 | default';
+		flip_horizontal.optional = true;
+
+		const flip_vertical = s.taboption(
+			this_tab, form.Value, 'flip_vertical', _('Flip vertical'), _(
+			'number | default. Blank: no change'
+		));
+
+		flip_vertical.validate = validate_int_default;
+		flip_vertical.placeholder = '0 | default';
+		flip_vertical.optional = true;
+
+		const rotate = s.taboption(
+			this_tab, form.Value, 'rotate', _('Rotate'), _(
+			'number | default. Blank: no change'
+		));
+
+		rotate.validate = validate_int_default;
+		rotate.placeholder = '0 | default';
 		rotate.optional = true;
 
-		const flip_horizontal = s.taboption(this_tab, form.Flag, 'flip_horizontal', _('Flip horizontally'));
-		flip_horizontal.default = flip_horizontal.disabled;
-
-		const flip_vertical = s.taboption(this_tab, form.Flag, 'flip_vertical', _('Flip vertically'));
-		flip_vertical.default = flip_vertical.disabled;
 
 		return m.render();
 	},

--- a/applications/luci-app-ustreamer/po/ar/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ar/ustreamer.po
@@ -3,7 +3,7 @@ msgstr ""
 "PO-Revision-Date: 2024-07-15 18:06+0000\n"
 "Last-Translator: Rex_sa <rex.sa@pm.me>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/ar/>\n"
+"luciapplicationsustreamer/ar/>\n"
 "Language: ar\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -11,172 +11,227 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "استمع على منفذ TCP هذا. القيمة الافتراضية: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "جهاز"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "مفعَّل"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"مسار المجلد الذي يحتوي على ملفات ثابتة بدلاً من صفحة الفهرس الجذرية المضمنة"
+"<br />"
+"الروابط الرمزية غير مدعومة لأسباب أمنية. الإعداد الافتراضي: معطل"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "عامّ"
 
@@ -184,327 +239,354 @@ msgstr "عامّ"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "كلمة المرور"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "المنفذ"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "إعدادات"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "اسم المستخدم"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "اسم المستخدم"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Off"
-#~ msgstr "مغلق"
-
-#~ msgid "On"
-#~ msgstr "مفتوح"

--- a/applications/luci-app-ustreamer/po/bg/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/bg/ustreamer.po
@@ -1,507 +1,657 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2025-05-30 02:35+0000\n"
-"Last-Translator: 109247019824 <109247019824@users.noreply.hosted.weblate.org>"
+"PO-Revision-Date: 2026-02-14 13:00+0000\n"
+"Last-Translator: Georgi Valkov <gvalkov@gmail.com>"
 "\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/bg/>\n"
+"luciapplicationsustreamer/bg/>\n"
 "Language: bg\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+"Кратък низов идентификатор, който да се показва в манипулатора /state"
+"Трябва да съответства на регулярен израз regexp ^[a-zA-Z0-9\./+_-]*$."
+"По подразбиране: празен низ"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
-msgstr ""
+msgstr "Allow origin хедър"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
-msgstr ""
+msgstr "Позволи непълни кадри"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
+"Позволява обработката на непълни кадри. По подразбиране: деактивирано<br />"
+"Полезно когато устройството генерира дефектни, но използваеми кадри"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
-msgstr ""
+msgstr "Компенсация на фонова осветеност"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr "Свързване към UNIX домейн сокет. По подразбиране: деактивирано"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Слушай на този TCP порт. По подразбиране: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "Битрейт (kbps)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
-msgstr ""
+msgstr "Яркост"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
-msgid "Client TTL"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
-msgid "Contrast"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr ""
+msgstr "Буфери"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
-msgstr ""
+msgid "Capture"
+msgstr "Заснемане"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
 msgstr ""
+"Промяната на този параметър може да подобри производителността. Или не."
+"<br />Прочетете документацията на Линукс ядрото. По подразбиране: MMAP"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
+msgid "Client TTL"
+msgstr "TTL на клиента"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
+msgstr "Цветен ефект"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "Contrast"
+msgstr "Контраст"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
+msgstr "DV-тайминги"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "Дебъг"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
+msgstr "По подразбиране: 1 секунда"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "По подразбиране: 10 секунди"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
+msgstr "По подразбиране: 30"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
+msgstr "По подразбиране: 5000 kbps"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr "По подразбиране: YUYV"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
 msgstr ""
+"Изчакване, преди повторен опит за връзка с устройството<br />"
+"след грешка (например таймаут). По подразбиране: 1 секунда"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr "Желан FPS. По подразбиране: максимално възможен"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Устройство"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
-msgstr ""
+msgstr "Изчакване след грешка на устройство"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
+msgstr "Таймаут на устройство"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
+"Да не се инициализира устройството повторно, при таймаут. "
+"По подразбиране: деактивирано"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
-msgid "Drop same frames"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
 msgstr ""
+"Да не се изпращат идентични кадри на клиентите, но не повече от зададения "
+"брой.<br />"
+"Може значително да намали изходящия трафик, но ще увеличи натоварването на "
+"процесора.<br />Не използвайте тази опция с аналогови източници на сигнал "
+"или уеб камери, тя е безполезна.<br />По подразбиране: деактивирано"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
 msgstr ""
+"Изпускане на кадри, по-малки от това ограничение. Полезно, ако устройството"
+"<br />генерира малки по размер повредени кадри. По подразбиране: 128 байта"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
+msgid "Drop same frames"
+msgstr "Изпускане на еднакви кадри"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
+msgid ""
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
+msgstr ""
+"Активиране на заявките за DV-тайминги и обработката на събития за<br />"
+"автоматична промяна на резолюцията. По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Разреши µStreamer"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
-msgstr "Включено"
+msgstr "Включен"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
+msgstr "Енкодер"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
-msgstr ""
+msgstr "Изход при липса на клиенти"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
+"Изход на програмата, ако не е имало клиенти за поточно предаване или "
+"приемник,<br />както и HTTP заявки през последните N секунди.<br />"
+"По подразбиране: 0 (деактивирано)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr "Очаква се: file mode, на пример 640 или 0640"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr "Очаква се: число | default"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr "Очаква се: число | default | auto"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
-msgstr ""
+msgstr "Фалшива резолюция"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
+msgstr "Обърни хоризонтално"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr "Обърни вертикално"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
 msgstr ""
+"Път до директория със статични файлове, вместо до вградена коренна "
+"индексна страница<br />"
+"Символични връзки не се поддържат от съображения за сигурност. "
+"По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr "Телевизионен стандарт"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
-msgstr ""
+msgstr "Кадри в секунда (FPS)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
-msgstr ""
+msgstr "Усилване"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
-msgstr ""
+msgstr "Гама"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Общи"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Позволи достъп на luci-app-ustreamer до UCI"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
-msgstr ""
+msgstr "H264 ускорение"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
+msgstr "H264 приемник (sink)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
+msgstr "Парола за HTTP удостоверяване. По подразбиране: празна"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr "Потребител за HTTP удостоверяване. По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr "HTTP сървър"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
+msgid "Адрес на хост"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "Host"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
-msgstr ""
+msgstr "Оттенък"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
-msgstr ""
+msgstr "Картина"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
+msgstr "Картина по подразбиране"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr "Формат на картината"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+"Увеличаване на производителността на енкодера на PiKVM V4. "
+"По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "Информация"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr "Резолюция. По подразбиране: 640x480"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
-msgstr ""
+msgstr "Вход"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr "Входен канал. По подразбиране: 0"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
-msgstr ""
+msgstr "Индентификатор на инстанция"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
-msgstr ""
+msgstr "JPEG приемник"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
+msgstr "Интервал между ключовите кадри"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Лек и бърз MJPEG-HTTP стример"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr "Слушай на име на хост или IP адрес. По подразбиране: 127.0.0.1"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
-msgstr ""
+msgstr "Детайлост на дневника"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr "Дневник"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
-msgstr ""
+msgstr "M2M устройство"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr "Минимален размер на кадъра"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+"Замяна на резолюцията на изображението за /state. "
+"По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
-msgstr ""
+msgstr "Парола"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
+msgstr "Път към V4L2 M2M енкодер. По подразбиране: автоматичен избор"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr "Път към V4L2 устройство. По подразбиране: /dev/video0"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "Производителност"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
-msgstr ""
+msgstr "Неименен"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr "Преглед"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
-msgstr ""
+msgstr "Качество"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr "Обръщане на поредността R-G-B"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
-msgstr ""
+msgstr "RAW приемник"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
+msgstr "RGB към BGR и обратно. По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
+msgstr "Премахни при спиране"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
+"Премахване на споделена памет при спиране. По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
+msgstr ""
+"Възстанови всички настройки на картината до фабричните. "
+"По подразбиране: без промяна"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
+msgid "Resolution"
+msgstr "Резолюция"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
+msgid "Rotate"
+msgstr "Завъртане"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
+msgid "Saturation"
+msgstr "Цвят"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
+msgid "Server timeout"
+msgstr "Таймаут на сървъра"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
+msgstr ""
+"Задаване на хедър Access-Control-Allow-Origin. "
+"По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
+msgid ""
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
+msgstr ""
+"Активирай флаг TCP_NODELAY на клиентския /stream сокет. Само за TCP сокет"
+"<br />По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+"Задаване на разрешения за UNIX socket файлове (например 777). "
+"По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr "Задаване на разрешения за файлове на приемника. По подразбиране: 660"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+"Качеството на JPEG кодиране: от 1 до 100 (най-добро). По подразбиране: 80"
+"Ако се използва хардуерно кодиране (JPEG изходен формат), се прави опит за"
+"<br />конфигуриране на вътрешния енкодер на камерата или хардуера на "
+"устройството за заснемане. MJPEG няма да бъде прекодиран в MJPEG, "
+"за да се промени качеството"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Настройки"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
+msgid "Sharpness"
+msgstr "Острота"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
+msgstr "Разрешения на приемника"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
+msgstr "Забавяне"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
+"Забавяне на заснемането до 1 FPS или по-малко, когато няма свързани "
+"клиенти за стрийминг или приемник.<br />Полезно за намаляване на "
+"консумацията на процесора. По подразбиране: деактивирано"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+msgid "Stream unavailable"
+msgstr "Видео потокът не е наличен"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
+msgstr "TCP no delay"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
-msgid "Resolution"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
-msgid "Rotate"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
-msgid "Saturation"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
-msgid "Server timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
+"Брой буфери за получаване на данни от устройството.<br />"
+"Всеки буфер може да бъде обработен с помощта на независима нишка.<br />"
+"По подразбиране: 3 (броят на ядрата на процесора (но не повече от 4) + 1)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
+"Брой на работните нишки, но не повече от буферите.<br />"
+"По подразбиране: 2 (броят на ядрата на процесора (но не повече от 4))"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
-msgid "Sharpness"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
+msgstr "Таймаут за клиентски връзки. По подразбиране: 10 секунди"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
+msgstr "Таймаут за запитване на устройство. По подразбиране: 1 секунда"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
+msgstr "Таймаут за заключване"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
+"Опит за премахнете стария UNIX socket файл преди свързване. "
+"По подразбиране: деактивирано"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
+msgstr "UNIX сокет"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
+msgstr "Разрешения за UNIX сокет"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr "Премахване на стария UNIX сокет"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
 msgstr ""
+"Избор на енкодер. Това може да повлияе на броя на работниците<br />"
+"<li><kbd>CPU  ──────── </kbd>Софтуерно MJPEG кодиране (по подразбиране)</li>"
+"<li><kbd>HW  ───────── </kbd>Използване на MJPEG кадри директно от хардуера на камерата</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-ускорено MJPEG кодиране с помощта на V4L2 M2M видео интерфейс</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-ускорено JPEG кодиране с помощта на V4L2 M2M интерфейс за изображения</li>"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
+"Използване на споделена памет за приемане на H264 кадри. "
+"По подразбиране: деактивирано<br />Името трябва да завършва с .h264"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
 msgstr ""
+"Използване на споделена памет за приемане на JPEG кадри. "
+"По подразбиране: деактивирано<br />Името трябва да завършва с .jpg или .jpeg"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
 msgstr ""
+"Използване на споделена памет за приемане на RAW кадри. "
+"По подразбиране: деактивирано<br />Името трябва да завършва с .raw"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
-msgid "Stream unavailable"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "Потребителско име"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr "V4L2 IO метод"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "Подробно"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+"Ниво на детайлност на съобщенията от 0 (информация) до 3 (дебъг)<br />"
+"Съобщенията за отстраняване на грешки, може да забавят програмата<br />"
+"По подразбиране: 0 (информация)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
-msgstr ""
+msgstr "WWW папка"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
-msgstr ""
+msgstr "Баланс на бялото"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
-msgstr ""
+msgstr "Работници"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr "по подразбиране"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr "число | default | auto"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr "число | default | auto. Празно: без промяна"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr "число | default. Празно: без промяна"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
+msgstr "температура | default | auto. Празно: без промяна"
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Позволи на ringbuffer да надвиши лимита с тази стойност"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/bn_BD/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/bn_BD/ustreamer.po
@@ -1,181 +1,235 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-10-08 17:53+0000\n"
+"PO-Revision-Date: 2021-10-08 17:169+0000\n"
 "Last-Translator: Rayhan Nabi <rayhanjanam@gmail.com>\n"
 "Language-Team: Bengali (Bangladesh) <https://hosted.weblate.org/projects/"
-"openwrt/luciapplicationsmjpg-streamer/bn_BD/>\n"
+"openwrt/luciapplicationsustreamer/bn_BD/>\n"
 "Language: bn_BD\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "এই TCP পোর্টে শুনুন। ডিফল্ট: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "ডিভাইস"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "সক্রিয়"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"এমবেডেড রুট ইনডেক্স পৃষ্ঠার পরিবর্তে স্ট্যাটিক ফাইল সহ dir-এর পথ<br />"
+"নিরাপত্তার কারণে সিমলিঙ্কগুলি সমর্থিত নয়। ডিফল্ট: অক্ষম"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "সার্বিক"
 
@@ -183,321 +237,354 @@ msgstr "সার্বিক"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "পোর্ট"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "সেটিংস"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
+msgid "µStreamer"
 msgstr ""

--- a/applications/luci-app-ustreamer/po/ca/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ca/ustreamer.po
@@ -3,179 +3,235 @@ msgstr ""
 "PO-Revision-Date: 2021-09-17 06:52+0000\n"
 "Last-Translator: Roger Pueyo Centelles <weblate@rogerpueyo.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/ca/>\n"
+"luciapplicationsustreamer/ca/>\n"
 "Language: ca\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Us cal autenticació"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Vincula a aquest port TCP. Per defecte: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Dispositiu"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Camí al directori amb fitxers estàtics en lloc de la pàgina d'índex arrel"
+" incrustada<br />"
+"Els enllaços simbòlics no són compatibles per motius de seguretat. "
+"Per defecte: desactivat"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Carpeta que conté pàgines web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Fotogrames per segon"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "General"
 
@@ -183,339 +239,354 @@ msgstr "General"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Sortida HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Contrasenya"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Configuració del connector"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Resolució"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Configuració"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Auto"
-#~ msgstr "Automàtic"
-
-#~ msgid "Command to run"
-#~ msgstr "Ordre a executar"
-
-#~ msgid "File output"
-#~ msgstr "Sortida de fitxers"
-
-#~ msgid "Folder"
-#~ msgstr "Carpeta"
-
-#~ msgid "Off"
-#~ msgstr "Apagat"
-
-#~ msgid "On"
-#~ msgstr "Encès"

--- a/applications/luci-app-ustreamer/po/cs/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/cs/ustreamer.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-02-10 18:12+0000\n"
+"PO-Revision-Date: 2026-01-28 10:51+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/cs/>\n"
@@ -10,607 +10,595 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.16-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr "Umožnit původ"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Zeptat se při připojení na uživatelské jméno a heslo"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Je nutné přihlášení"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr "Kompenzace podsvětlení"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "Bitová rychlost"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Vázat se na tento TCP port. Výchozí: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "Bitová rychlost (kbps)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "Jas"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr "Vyrovnávací paměti"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr "TTL klienta"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr "Barevný efekt"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "Kontrast"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr "Časování DV"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr "Výchozí: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "Ladění"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
-msgstr "Výchozí: 2 (počet jader procesoru (ale ne více než 4))."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
-msgstr "Výchozí: 3 (počet jader procesoru (ale ne více než 4) + 1)."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
-msgstr "Výchozí: vypnuto."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "Výchozí: 10 sekund"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "Výchozí: vypnuto"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Zařízení"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Zahazovat rámce menší, než tento limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr "Každá z vyrovnávacích paměti může být zpracovávána nezávislým vláknem."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
-"Zapnout zařazování DV časování do fronty a zpracovávání událostí pro "
-"automatické měnění rozlišení. Výchozí: vypnuto."
+"Zapnout zařazování DV časování do fronty a zpracovávání událostí pro<br />"
+"automatické měnění rozlišení. Výchozí: vypnuto"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr "Zapnout přehazování pořadí R-G-B (Č-Z-M): RGB na BGR a obráceně."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Povolit µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr "Enkodér"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
-msgstr "Pokud neexistuje žádný proud nebo klienti odchodu, ukončit program"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr "Nastrčené rozlišení"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr "Převrátit vodorovně"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr "Převrátit svisle"
 
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Cesta k adresáři se statickými soubory místo vložené kořenové indexové"
+" stránky<br />"
+"Symbolické odkazy nejsou z bezpečnostních důvodů podporovány. "
+"Výchozí nastavení: zakázáno"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr ""
+
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Složka, která obsahuje webové stránky"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "Formát"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Snímků za sekundu"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr "Zisk"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "Gamma"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Obecné"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Udělit luci-app-ustreamer přístup do UCI nastavování"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr "H264 GOP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr "H264 posílení"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
-msgstr "odchod H264"
+msgstr "Odchod H264"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP výstup"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr "Hostitel"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr "Odstín"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr "Metoda vstupu/výstupu"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "Ovládání obrazu"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
-msgstr "Zvýšit výkon enkodéru na PiKVM v4. Výchozí: vypnuto."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr "Zvýšit výkon enkodéru na PiKVM v4. Výchozí: vypnuto"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "Informace"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
-msgstr "Vstup"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "Identif. instance"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr "Odchod JPEG"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Lehký a rychlý MJPEG-HTTP streamer"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "Stupeň podrobnosti záznamu událostí"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Heslo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
-"Popis umístění souboru, představujícího zařízení V4l2 M2M enkodéru. Výchozí: "
-"vybrat automaticky."
+"Popis umístění souboru, představujícího zařízení V4l2 M2M enkodéru.<br />"
+"Výchozí: vybrat automaticky"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "Výkon"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr "Trvalé"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Nastavení zásuvného modulu"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "Kvalita"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr "Odebrat"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Rozlišení"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr "Otočit"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr "Sytost"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
-msgstr "Nastavit práva na odchodu H264 (jako např. 777). Výchozí: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr "Nastavit práva na odchodu JPEG (jako např. 777). Výchozí: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr "Nastavit práva na odchodu RAW (jako např. 777). Výchozí: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Pokud webová kamera vytváří nepoužitelné snímky s malou velikostí, nastavte "
-"nejmenší umožněnou velikost. Může se dít při nedostatečném osvětlení"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Nastavení"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "Ostrost"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "Soket"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Proud není k dispozici"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP port pro tento HTTP server"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
-msgstr "Název by měl končit na příponu „.h264“."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
-msgstr "Název by měl končit na příponu „.jpeg“."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
-msgstr "Název by měl končit na příponu „.h264“."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
-msgstr "Počet vyrovnávacích pamětí pro obdržování dat ze zařízení."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
-"Počet zpracovávajících vláken (ale ne vyšší než počet vyrovnávacích pamětí)."
+"Počet zpracovávajících vláken (ale ne vyšší než počet vyrovnávacích "
+"pamětí).<br />Výchozí: 2 (počet jader procesoru (ale ne více než 4))"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "Časový limit"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC vstup"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr "Použít pro snímky odchodu H264 sdílenou paměť. Výchozí: vypnuto."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr "Použít pro snímky odchodu JPEG sdílenou paměť. Výchozí: vypnuto."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr "Použít pro snímky odchodu RAW sdílenou paměť. Výchozí: vypnuto."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr ""
+"Použít pro snímky odchodu H264 sdílenou paměť. Výchozí: vypnuto.<br />"
+"Název by měl končit na příponu „.h264“"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+"Použít pro snímky odchodu JPEG sdílenou paměť. Výchozí: vypnuto<br />"
+"Název by měl končit na příponu „.jpg“ nebo „.jpeg“"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+"Použít pro snímky odchodu RAW sdílenou paměť. Výchozí: vypnuto<br />"
+"Název by měl končit na příponu „.raw“"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "Výřečné"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "WWW složka"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr "Zpracovávající vlákna"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "ladění"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "informace"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
 msgstr ""
-"nebo jakékoli HTTP požadavky za uplynulých N sekund. Výchozí: 0 (vypnuto)."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "výkon"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr "ustreamer"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "výřečné"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-"µStreamer je na systémové prostředky nenáročný a velmi rychlý server pro "
-"proudové vysílání MJPEG videa z libovolného V4L2 zařízení do sítě."
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Povolit cyklické vyrovnávací paměti překročit limit o tuto hodnotu"
-
-#~ msgid "Auto"
-#~ msgstr "Automaticky"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatické vypnutí režimu MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Mrknutí"
-
-#~ msgid "Command to run"
-#~ msgstr "Příkaz který spustit"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Neinicializovat dynctrl ovladače Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Neinicializovat dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Povolit MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Povolit formát YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Překračovat"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Vykonat příkaz po uložení obrázku. Mjpg-streamer zpracuje název souboru "
-#~ "jako první parametr vašemu skriptu."
-
-#~ msgid "File output"
-#~ msgstr "Výstup souboru"
-
-#~ msgid "Folder"
-#~ msgstr "Složka"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Udělit luci-app-mjpg-streamer přístup do UCI nastavování"
-
-#~ msgid "Input plugin"
-#~ msgstr "Vstupní zásuvný modul"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Interval mezi ukládáním obrázků"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Intenzita komprese JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Ovládání kontrolek"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Odkázat nejnovější obraz na pevný název souboru"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Poskytnut odkaz na poslední obrázek v kruhové vyrovnávací paměti na pevně "
-#~ "nazvaný soubor."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Nejvyšší počet obrázků, který držet"
-
-#~ msgid "Off"
-#~ msgstr "Vypnuto"
-
-#~ msgid "On"
-#~ msgstr "Zapnuto"
-
-#~ msgid "Output plugin"
-#~ msgstr "Zásuvný modul výstupu"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Velikost kruhové vyrovnávací paměti"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Nastavit složku pro ukládání obrázků"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Nastavit interval (v milisekundách)"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Nastavit kvalitu (v procentech). Toto nastavení aktivuje formát YUYV "
-#~ "(vypne MJPEG)"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer je streamingová aplikace pro webové kamery kompatibilní s "
-#~ "Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/da/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/da/ustreamer.po
@@ -1,607 +1,592 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2024-01-25 02:53+0000\n"
+"PO-Revision-Date: 2024-01-25 02:169+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/da/>\n"
+"luciapplicationsustreamer/da/>\n"
 "Language: da\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Spørg efter brugernavn og adgangskode ved tilslutning"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Autentificering påkrævet"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Bind til denne TCP-port. Standard: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Enhed"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Drop frames, der er mindre end denne grænse"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Aktiver µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Sti til mappen med statiske filer i stedet for den integrerede "
+"rodindeksside<br />"
+"Symlinks understøttes ikke af sikkerhedsmæssige årsager. "
+"Standard: deaktiveret"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Mappe, der indeholder websider"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Billeder pr. sekund"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Generel"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Giv UCI-adgang til luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Let og hurtig MJPEG-HTTP streamer"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Adgangskode"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Plugin-indstillinger"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Opløsning"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Indstil minimumsstørrelsen, hvis webkameraet producerer små garbage frames. "
-"Kan ske under dårlige lysforhold"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Indstillinger"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
-msgstr "Stream unavailable"
+msgstr "Stream ikke tilgængelig"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP-port for denne HTTP-server"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC input"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Brugernavn"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW mappe"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Brugernavn"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW mappe"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Tillad ringbuffer at overskride grænsen med denne mængde"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatisk deaktivering af MJPEG-tilstand"
-
-#~ msgid "Blink"
-#~ msgstr "Blink"
-
-#~ msgid "Command to run"
-#~ msgstr "Kommando, der skal køres"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Initialiser ikke dynctrls i Linux-UVC-driveren"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Initialiser ikke dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Aktiver MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Aktiver YUYV-format"
-
-#~ msgid "Exceed"
-#~ msgstr "Overskrid"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Udfør kommando efter at have gemt billedet. Mjpg-streamer analyserer "
-#~ "filnavnet som den første parameter til dit script."
-
-#~ msgid "File output"
-#~ msgstr "Filoutput"
-
-#~ msgid "Folder"
-#~ msgstr "Mappe"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Giv UCI-adgang til luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Input plugin"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Interval mellem lagring af billeder"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG-komprimeringskvalitet"
-
-#~ msgid "Led control"
-#~ msgstr "Led-kontrol"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Link nyeste billede til fast filnavn"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Link det sidste billede i ringbufferen til en fast navngiven fil, der er "
-#~ "angivet."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Max. antal billeder, der kan opbevares"
-
-#~ msgid "Off"
-#~ msgstr "Off"
-
-#~ msgid "On"
-#~ msgstr "On"
-
-#~ msgid "Output plugin"
-#~ msgstr "Output plugin"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Ringbufferstørrelse"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Angive mappe til lagring af billeder"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Angive intervallet i millisekunder"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Angiv kvaliteten i procent. Denne indstilling aktiverer YUYV-format, "
-#~ "deaktiverer MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer er et streamingprogram til Linux-UVC-kompatible webkameraer"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/de/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/de/ustreamer.po
@@ -1,605 +1,592 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-02-11 13:58+0000\n"
-"Last-Translator: Werner Schleifer <werner.schleifer@gmail.com>\n"
+"PO-Revision-Date: 2025-12-30 17:00+0000\n"
+"Last-Translator: Steve <secure@mail.az>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/de/>\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.16-dev\n"
+"X-Generator: Weblate 5.15.1\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Bei Verbindung nach Benutzername und Passwort fragen"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Authentifizierung benötigt"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "An diesen TCP-Port binden. Standard: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Gerät"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Verwerfe Bilder, die kleiner als dieses Limit sind"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Aktiviere µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Pfad zum Verzeichnis mit statischen Dateien anstelle der eingebetteten "
+"Stammindexseite<br />"
+"Symlinks werden aus Sicherheitsgründen nicht unterstützt. "
+"Standard: deaktiviert"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Ordner der Webseiten enthält"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Bildrate"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Allgemein"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "UCI-Zugriff für luci-app-ustreamer erlauben"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP-Ausgabe"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Leichtgewichtiger und schneller MJPEG-HTTP Streamer"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Passwort"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Plugin-Einstellungen"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Auflösung"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Setze die Minimalgröße, falls die Webcam kleine Dateigrößen / schlechte "
-"Bilder erzeugt. Dies kann bei schlechten Lichtverhältnissen passieren"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Stream nicht verfügbar"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP-Port des HTTP-Servers"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC-Input"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Benutzername"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW-Ordner"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "Leistung"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Benutzername"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW-Ordner"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Erlaube dem Ringpuffer das Limit um diesen Betrag zu überschreiten"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatische Deaktivierung des MJPEG Modus"
-
-#~ msgid "Blink"
-#~ msgstr "Blinken"
-
-#~ msgid "Command to run"
-#~ msgstr "Befehl zum Ausführen"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Dynctrls des Linux-UVC Treibers nicht initialisieren"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Dynctrls nicht initialisieren"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Aktiviere MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Aktiviere YUYV Format"
-
-#~ msgid "Exceed"
-#~ msgstr "Überschreiten"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Führe Kommando nach dem Speichern des Bilds aus. Mjpg-Streamer gibt den "
-#~ "Dateinamen als ersten Parameter ans Skript weiter."
-
-#~ msgid "File output"
-#~ msgstr "Dateiausgabe"
-
-#~ msgid "Folder"
-#~ msgstr "Ordner"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "UCI-Zugriff für luci-app-mjpg-streamer erlauben"
-
-#~ msgid "Input plugin"
-#~ msgstr "Eingabe-Plugin"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervall zwischen dem Speichern von Bildern"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG-Kompressionsqualität"
-
-#~ msgid "Led control"
-#~ msgstr "LED-Steuerung"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Verlinke das neueste Bild auf einen festen Pfad"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr "Verlinke das letzte Bild im Ringpuffer auf einen festgelegten Pfad."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-Streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Max. Anzahl an vorgehaltenen Bildern"
-
-#~ msgid "Off"
-#~ msgstr "Aus"
-
-#~ msgid "On"
-#~ msgstr "An"
-
-#~ msgid "Output plugin"
-#~ msgstr "Ausgabe-Plugin"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Größe des Ringpuffers"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Lege Ordner für gespeicherte Bilder fest"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Lege Intervall in Millisekunden fest"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Setze die Qualität in Prozent. Diese Einstellung aktiviert das YUYV-"
-#~ "Format und deaktiviert MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer ist eine Streaminganwendung für Linux-UVC-kompatible Webcams"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/el/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/el/ustreamer.po
@@ -3,179 +3,235 @@ msgstr ""
 "PO-Revision-Date: 2024-11-09 08:59+0000\n"
 "Last-Translator: Mac Mac <nofxmac@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/el/>\n"
+"luciapplicationsustreamer/el/>\n"
 "Language: el\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Ακρόαση σε αυτήν τη θύρα TCP. Προεπιλογή: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Συσκευή"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Ενεργοποιήθηκε"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Διαδρομή προς τον κατάλογο με στατικά αρχεία αντί για ενσωματωμένη σελίδα "
+"ευρετηρίου ρίζας<br />"
+"Οι συμβολικοί σύνδεσμοι δεν υποστηρίζονται για λόγους ασφαλείας. "
+"Προεπιλογή: απενεργοποιημένος"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Γενικά"
 
@@ -183,324 +239,354 @@ msgstr "Γενικά"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Θύρα"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Ρυθμίσεις"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "On"
-#~ msgstr "κατά την"

--- a/applications/luci-app-ustreamer/po/es/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/es/ustreamer.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-02-11 13:57+0000\n"
+"PO-Revision-Date: 2025-07-12 02:01+0000\n"
 "Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/es/>\n"
@@ -11,612 +11,612 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.16-dev\n"
+"X-Generator: Weblate 5.13-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr "Permitir origen"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr "Permitir marcos truncados"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Pregunte por nombre de usuario y contraseña en conectar"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Autenticacion requerida"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr "Compensación de contraluz"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "Tasa de bits"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Vincular a este puerto TCP. Valor predeterminado: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "Tasa de bits (kbps)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "Brillo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr "Búfers"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr "TTL del cliente"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr "TTL del cliente. Predeterminado: 10."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr "Efecto de color"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "Contraste"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr "Tiempos de DV"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr "Predeterminado: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "Depurar"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
-msgstr "Predeterminado: 2 (la cantidad de núcleos de CPU (pero no más de 4))."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
-"Predeterminado: 3 (la cantidad de núcleos de CPU (pero no más de 4) + 1)."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
-msgstr "Predeterminado: desactivado."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "Predeterminado: 10 segundos"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
-msgstr "Predeterminado: máximo posible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "Predeterminado: desactivado"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Dispositivo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr "Retraso por error del dispositivo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 "No reinicializar el dispositivo tras el tiempo de espera. Valor "
 "predeterminado: desactivado."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Drop frames más pequeños que este límite"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Drop frames más pequeños que este límite. Útil si el dispositivo<br />"
+"produce tramas basura de tamaño pequeño. Valor predeterminado: 128 bytes."
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr "Eliminar los mismos fotogramas"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr "Cada búfer puede procesarse usando un hilo independiente."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
-"Activar la consulta de tiempos de DV y el procesamiento de eventos para el "
-"cambio automático de resolución. Predeterminado: desactivado."
+"Activar la consulta de tiempos de DV y el procesamiento de eventos<br />"
+"para el cambio automático de resolución. Predeterminado: desactivado."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr "Activar el intercambio de orden R-G-B: RGB a BGR y viceversa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Activar µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Activado"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr "Codificador"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr "Salir sin clientes"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
+msgstr ""
+"Salir del programa si no ha habido clientes de transmisión o de destino"
+"<br />"
+"o cualquier solicitud HTTP en los últimos N segundos. Predeterminado: 0 "
+"(desactivado)."
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr "Resolución falsa"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr "Voltear horizontalmente"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr "Voltear verticalmente"
 
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Ruta al directorio con archivos estáticos en lugar de la página de índice "
+"raíz incorporada<br />"
+"Los enlaces simbólicos no son compatibles por razones de seguridad. "
+"Valor predeterminado: deshabilitado"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr "Estándar de TV de fuerza"
+
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr "Carpeta que contiene el socket"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Carpeta que contiene páginas web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "Formato"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr "Formato: Intercambio RGB"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Cuadros por segundo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr "Ganancia"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "Gama"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "General"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr "Otorgar acceso UCI para luci-app-ustreamer"
+msgstr "Conceder acceso UCI para luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr "Tasa de bits H264 en Kbps. Predeterminado: 5000."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Salida HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "Control de imagen"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
 msgstr ""
 "Aumentar el rendimiento del codificador en PiKVM V4. Predeterminado: "
 "desactivado."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "Info"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr "Entrada"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "ID de instancia"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr "Intervalo entre fotogramas clave. Predeterminado: 30."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Transmisor MJPEG-HTTP ligero y rápido"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "Nivel de registro"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr "Dispositivo M2M"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Contraseña"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
-msgstr "Ruta al codificador M2M V4L2. Predeterminado: selección automática."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
+msgstr "Ruta al codificador M2M V4L2. Predeterminado: selección automática"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "Pendimiento"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr "Persistente"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Configuración de plugin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Puerto"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "Calidad"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
+msgstr "Eliminar memoria compartida al detener. Predeterminado: desactivado"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr "Eliminar"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr "Eliminar memoria compartida al detener. Predeterminado: desactivado."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Resolución"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr "Girar"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr "Saturación"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr "Tiempo de espera del servidor"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
-"Establezca el tamaño mínimo si la cámara web produce marcos de basura de "
-"tamaño pequeño. Puede ocurrir en condiciones de poca luz"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
-msgstr "Establecer la calidad en porcentaje."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Configuración"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "Nitidez"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr "Permisos de socket"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Transmisión no disponible"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
-msgstr "Host TCP para este servidor HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Puerto TCP para este servidor HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
-msgstr "Estándar de TV"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
-msgstr "El nombre debe terminar con el sufijo \".h264\""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
-msgstr "El nombre debe terminar con el sufijo \".jpeg\"."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
-msgstr "El nombre debe terminar con el sufijo \".raw\"."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
+msgstr ""
+"El número de buffers para recibir datos del dispositivo.<br />"
+"Cada buffer puede ser procesado usando un hilo independiente.<br />"
+"Predeterminado: 3 (la cantidad de núcleos de CPU "
+"(pero no más de 4) + 1)<br />"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
+msgstr ""
+"El número de subprocesos de trabajo, pero no más que los buffers.<br />"
+"Predeterminado: 2 (la cantidad de núcleos de CPU (pero no más de 4))"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "Tiempo de espera"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr "Tiempo de espera para el bloqueo. Predeterminado: 1."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Entrada UVC"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr "Usar valores predeterminados del dispositivo"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr ""
+"Utilizar la memoria compartida para recibir tramas H264. "
+"Predeterminado: deshabilitado<br />"
+"El nombre debe terminar con el sufijo \".h264\""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+"Usar la memoria compartida para guardar fotogramas JPEG. "
+"Predeterminado: deshabilitado<br />"
+"El nombre debe terminar con el sufijo \".jpg\" o \".jpeg\""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+"Usar la memoria compartida para guardar fotogramas RAW. "
+"Predeterminado: deshabilitado<br />"
+"El nombre debe terminar con el sufijo \".raw\"."
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "Verboso"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "Carpeta WWW"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr "Balance de blancos"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "depurar"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "info"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
 msgstr ""
-"o cualquier solicitud HTTP en los últimos N segundos. Predeterminado: 0 "
-"(desactivado)."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "rendimiento"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
-msgstr "unidades: segundos"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
+msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "verboso"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-"µStreamer es un servidor liviano y muy rápido para transmitir video MJPEG "
-"desde cualquier dispositivo V4L2 a la red."
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Permitir que Ringbuffer exceda el límite en esta cantidad"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Desactivación automática del modo MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Parpadeo"
-
-#~ msgid "Command to run"
-#~ msgstr "Comando para ejecutar"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "No inicialice dynctrls del controlador Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "No inicialice dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Activar MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Activar formato YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Exceder"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Ejecute el comando después de guardar la imagen. Mjpg-streamer analiza el "
-#~ "nombre del archivo como primer parámetro de tu script."
-
-#~ msgid "File output"
-#~ msgstr "Salida de archivo"
-
-#~ msgid "Folder"
-#~ msgstr "Carpeta"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Conceder acceso UCI para luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Complemento de entrada"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervalo entre guardar imágenes"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Calidad de compresión JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Control led"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Vincula la imagen más reciente al nombre de archivo fijo"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Enlace la última imagen en ringbuffer a un archivo con nombre fijo "
-#~ "proporcionado."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Max. número de imágenes para mantener"
-
-#~ msgid "Off"
-#~ msgstr "Apagado"
-
-#~ msgid "On"
-#~ msgstr "Encendido"
-
-#~ msgid "Output plugin"
-#~ msgstr "Plugin de salida"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Tamaño del búfer de anillo"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Establecer carpeta para guardar imágenes"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Establecer el intervalo en milisegundos"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Establecer la calidad en porcentaje. Esta configuración activa el formato "
-#~ "YUYV, desactiva MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "MJPG-streamer es una aplicación de transmisión para webcams compatibles "
-#~ "con Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/et/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/et/ustreamer.po
@@ -7,172 +7,224 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr ""
 
@@ -180,321 +232,354 @@ msgstr ""
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
+msgid "µStreamer"
 msgstr ""

--- a/applications/luci-app-ustreamer/po/fi/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/fi/ustreamer.po
@@ -3,179 +3,234 @@ msgstr ""
 "PO-Revision-Date: 2025-05-04 15:04+0000\n"
 "Last-Translator: Ricky Tigg <ricky.tigg@gmail.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/fi/>\n"
+"luciapplicationsustreamer/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Sido tähän TCP-porttiin. Oletusarvo: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Laite"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Otettu käyttöön"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Polku hakemistoon, jossa on staattisia tiedostoja upotetun "
+"juurihakemistosivun sijaan<br />"
+"Symbolisia linkkejä ei tueta turvallisuussyistä. Oletusarvo: ei käytössä"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Yleinen"
 
@@ -183,330 +238,354 @@ msgstr "Yleinen"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Salasana"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Portti"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Asetukset"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Käyttäjätunnus"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Käyttäjätunnus"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Off"
-#~ msgstr "Pois päältä"
-
-#~ msgid "On"
-#~ msgstr "Päälle"

--- a/applications/luci-app-ustreamer/po/fr/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/fr/ustreamer.po
@@ -3,605 +3,590 @@ msgstr ""
 "PO-Revision-Date: 2025-12-12 15:40+0000\n"
 "Last-Translator: liolio6 <fliolio@free.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/fr/>\n"
+"luciapplicationsustreamer/fr/>\n"
 "Language: fr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Demander un nom d'utilisateur et un mot de passe lors de la connexion"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Authentification requise"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Écouter sur ce port TCP. Par défaut : 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Appareil"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Ignore les trames plus petites que cette limite"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Activer µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Activé"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Chemin d'accès au répertoire contenant les fichiers statiques au lieu de la "
+"page d'index racine intégrée<br />"
+"Les liens symboliques ne sont pas pris en charge pour des raisons de "
+"sécurité. Par défaut : désactivés."
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Dossier contenant les pages Web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Images par seconde"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Général"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Accorder l’accès UCI pour luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Sortie HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Streamer MJPEG-HTTP léger et rapide"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Mot de passe"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Paramètres du plugin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Résolution"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Définir la taille minimale si la webcam produit des images parasites de "
-"petite taille. Peut se produire dans des conditions de faible luminosité"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Paramètres"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Port TCP pour ce serveur HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Entrée UVC"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Nom d'utilisateur"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Dossier WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Nom d'utilisateur"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Dossier WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Autoriser le tampon circulaire à dépasser la limite de ce montant"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Désactivation automatique du mode MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Clignoter"
-
-#~ msgid "Command to run"
-#~ msgstr "Commande à exécuter"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Ne pas initialiser les dynctrls du pilote Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Ne pas initialiser dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Activer MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Activer le format YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Dépasser"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Exécuter la commande après avoir enregistré l’image. Mjpg-streamer "
-#~ "analyse le nom de fichier comme premier paramètre de votre script."
-
-#~ msgid "File output"
-#~ msgstr "Fichier de sortie"
-
-#~ msgid "Folder"
-#~ msgstr "Répertoire"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Accorder l’accès UCI pour luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Plugin d'entrée"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervalle entre l'enregistrement des images"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Qualité de compression JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Contrôle des LED"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Lier l’image la plus récente au nom de fichier fixe"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Liez la dernière image dans le ringbuffer au fichier nommé fixe fourni."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Nombre maximal d'images à conserver"
-
-#~ msgid "Off"
-#~ msgstr "Éteint"
-
-#~ msgid "On"
-#~ msgstr "Allumé"
-
-#~ msgid "Output plugin"
-#~ msgstr "Plugin de sortie"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Ring Taille du tampon"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Définir un dossier pour enregistrer les images"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Définir l'intervalle en millisecondes"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Définir la qualité en pourcentage. Ce paramètre active le format YUYV, "
-#~ "désactive MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer est une application de streaming pour les webcams "
-#~ "compatibles Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/ga/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ga/ustreamer.po
@@ -1,187 +1,247 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-02-10 18:10+0000\n"
+"PO-Revision-Date: 2024-10-17 17:11+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/ga/>\n"
 "Language: ga\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :(n>"
-"6 && n<11) ? 3 : 4;\n"
-"X-Generator: Weblate 5.16-dev\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.8-rc\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr "Ceadaigh bunús"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr "Ceadaigh frámaí gearrtha"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Iarr ainm úsáideora agus pasfhocal ar an nasc"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Fíordheimhniú ag teastáil"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr "Cúiteamh ar an solas cúil"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "Ráta Giotáin"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Éist ar an gcalafort TCP seo. Réamhshocrú: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "Ráta Giotáin (kbps)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "Gile"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr "Maoláin"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr "TTL Cliant"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr "TTL an chliaint. Réamhshocrú: 10."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr "Éifeacht datha"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "Codarsnacht"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr "Amanna DV"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr "Réamhshocrú: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "Dífhabhtú"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
-msgstr "Réamhshocrú: 2 (líon chroíthe an LAP (ach gan níos mó ná 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
-msgstr "Réamhshocrú: 3 (líon chroíthe an LAP (ach gan níos mó ná 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "Réamhshocrú: 10 soicind"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
-msgstr "Réamhshocrú: díchumasaithe."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
-msgstr "Réamhshocrú: an t-uasmhéid is féidir."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "Réamhshocrú: díchumasaithe"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Gléas"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr "Moill earráide gléis"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
-"Ná hath-thosaigh an gléas nuair a bhíonn an t-am críochnaithe. Réamhshocrú: "
-"díchumasaithe."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Íosluchtaigh frámaí níos lú ná an teorainn seo"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
+"Ná hath-thosaigh an gléas nuair a bhíonn an t-am críochnaithe. "
+"Réamhshocrú: díchumasaithe."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Íosluchtaigh frámaí níos lú ná an teorainn seo. Úsáideach má<br />"
+"tháirgeann an gléas frámaí bruscair beaga. Réamhshocrú: 128 beart"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr "Scaoil na frámaí céanna"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-"Féadfar gach maolán a phróiseáil ag baint úsáide as snáithe neamhspleách."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
-"Cumasaigh fiosrúcháin uainiúcháin DV agus próiseáil imeachtaí chun athrú "
-"uathoibríoch réitigh a dhéanamh. Réamhshocrú: díchumasaithe."
+"Cumasaigh fiosrúcháin uainiúcháin DV agus próiseáil imeachtaí chun<br />"
+"athrú uathoibríoch réitigh a dhéanamh. Réamhshocrú: díchumasaithe."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr "Cumasaigh malartú ord R-G-B: RGB go BGR agus a mhalairt."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Cumasaigh µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Cumasaithe"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr "Ionchódóir"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr "Scoir nuair nach bhfuil aon chliaint ann"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
-msgstr "Scoir an clár mura raibh aon chliaint sruthaithe nó doirteal ann"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
+msgstr ""
+"Scoir an clár mura raibh aon chliaint sruthaithe nó doirteal ann"
+"nó aon iarratais HTTP sna N soicind dheireanacha. "
+"Réamhshocrú: 0 (díchumasaithe)."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr "Rún bréige"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr "Smeach go cothrománach"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr "Smeach go hingearach"
 
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Cosán chuig an eolaire le comhaid statach in ionad leathanach innéacs "
+"fréimhe leabaithe<br />"
+"Ní thacaítear le naisc shiombalacha ar chúiseanna slándála. "
+"Réamhshocrú: díchumasaithe"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr "Caighdeán teilifíse Fórsa"
+
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr "Fillteán ina bhfuil an soicéad"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Fillteán ina bhfuil leathanaigh ghréasáin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "Formáid"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr "Formáid: Malartaigh RGB"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Frámaí in aghaidh an tsoicind"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr "Gnóthachan"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "Gáma"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Ginearálta"
 
@@ -189,438 +249,370 @@ msgstr "Ginearálta"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr "Deonaigh rochtain UCI do luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr "H264 GOP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr "Gléas H264 M2M"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr "Ráta giotán H264 i Kbps. Réamhshocrú: 5000."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr "Borradh H264"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr "Doirteal H264"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
-msgstr "Mód doirteal H264"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Aschur HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr "Óstach"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr "Lí"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr "Modh IO"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "Rialú íomhá"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
 msgstr ""
 "Méadaigh feidhmíocht an ionchódóra ar PiKVM V4. Réamhshocrú: díchumasaithe."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "Eolas"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr "Ionchur"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "Aitheantas an Cháis"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr "Eatramh idir eochairfhrámaí. Réamhshocrú: 30."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr "Doirteal JPEG"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
-msgstr "Mód doirteal JPEG"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
-msgstr "Am críochnaithe doirteal JPEG"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Sruthaitheoir MJPEG-HTTP éadrom agus tapa"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "Leibhéal loga"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr "Gléas M2M"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Pasfhocal"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
-msgstr "Cosán chuig gléas ionchódóra V4L2 M2M. Réamhshocrú: rogha uathoibríoch."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
+msgstr "Cosán chuig gléas ionchódóra V4L2 M2M. Réamhshocrú: rogha uathoibríoch"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "Feidhmíocht"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr "Buan"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Socruithe breiseán"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "Cáilíocht"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr "Doirteal RAW"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
-msgstr "Cliant doirteal RAW TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
-msgstr "Mód doirteal RAW"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
-msgstr "Am scoir doirteal RAW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr "Bain"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr "Bain an doirteal JPEG"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr "Bain comhad doirteal JPEG ag an scoir"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr "Bain an doirteal RAW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 "Bain cuimhne chomhroinnte nuair a stopann sé. Réamhshocrú: díchumasaithe."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Taifeach"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr "Rothlaigh"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr "Sáithiú"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr "Am críochnaithe freastalaí"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
-msgstr "Socraigh ceadanna doirteal H264 (cosúil le 777). Réamhshocrú: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr "Socraigh ceadanna doirteal JPEG (cosúil le 777). Réamhshocrú: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr "Socraigh ceadanna doirteal RAW (cosúil le 777). Réamhshocrú: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
-msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
-"Socraigh an t-íosmhéid má tháirgeann an ceamara gréasáin frámaí truflais "
-"beagmhéide. D'fhéadfadh sé tarlú faoi choinníollacha solais íseal"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
-msgstr "Socraigh an caighdeán i gcéatadán."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
+msgid ""
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Socruithe"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "Géire"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
-msgstr "TTL cliant doirteal"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
-msgstr "Am scoir doirteal"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "Soicéad"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr "Ceadanna Soicéad"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Níl an sruth ar fáil"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
-msgstr "Óstach TCP don fhreastalaí HTTP seo"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Port TCP don fhreastalaí HTTP seo"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
-msgstr "Caighdeán teilifíse"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
-msgstr "Ba chóir go mbeadh iarmhír \".h264\" ag críochnú an ainm"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
-msgstr "Ba chóir go mbeadh iarmhír \".jpeg\" ag críochnú an ainm."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
-msgstr "Ba chóir go mbeadh iarmhír \".raw\" ag críochnú an ainm."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
-msgstr "Líon na maolán chun sonraí a fháil ón bhfeiste."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
-msgstr "Líon na snáitheanna oibrithe ach gan níos mó ná maoláin."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "Am críochnaithe"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr "Am scoir don ghlasáil. Réamhshocrú: 1."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Ionchur UVC"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr "Úsáid réamhshocruithe gléis"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
-"Úsáid an chuimhne chomhroinnte chun frámaí H264 a shíneadh. Réamhshocrú: "
-"díchumasaithe."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
-"Úsáid an chuimhne chomhroinnte chun frámaí JPEG a shíneadh. Réamhshocrú: "
-"díchumasaithe."
+"Líon na maolán chun sonraí a fháil ón bhfeiste.<br />"
+"Féadfar gach maolán a phróiseáil ag baint úsáide as snáithe neamhspleách."
+"<br />Réamhshocrú: 3 (líon chroíthe an LAP (ach gan níos mó ná 4) + 1)."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
-"Úsáid an chuimhne chomhroinnte chun frámaí RAW a shíneadh. Réamhshocrú: "
-"díchumasaithe."
+"Líon na snáitheanna oibrithe ach gan níos mó ná maoláin.<br />"
+"Réamhshocrú: 2 (líon chroíthe an LAP (ach gan níos mó ná 4))"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr ""
+"Úsáid an chuimhne chomhroinnte chun frámaí H264 a shíneadh. "
+"Réamhshocrú: díchumasaithe<br />"
+"Ba chóir go mbeadh iarmhír \".h264\" ag críochnú an ainm"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+"Úsáid an chuimhne chomhroinnte chun frámaí JPEG a shíneadh. "
+"Réamhshocrú: díchumasaithe<br />"
+"Ba chóir go mbeadh iarmhír \".jpg\" nó \".jpeg\" ag críochnú an ainm"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+"Úsáid an chuimhne chomhroinnte chun frámaí RAW a shíneadh. "
+"Réamhshocrú: díchumasaithe<br />"
+"Ba chóir go mbeadh iarmhír \".raw\" ag críochnú an ainm"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "Ainm úsáideora"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "Focal"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "WWW fillteán"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr "Cothromaíocht bán"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr "Oibrithe"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "dífhabhtú"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "eolas"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
 msgstr ""
-"nó aon iarratais HTTP sna N soicind dheireanacha. Réamhshocrú: 0 "
-"(díchumasaithe)."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "feidhmíocht"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
-msgstr "aonaid: soicindí"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
+msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr "ustreamer"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "focal"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-"Is freastalaí éadrom agus an-tapa é µStreamer chun físeán MJPEG a shruthú ó "
-"aon fheiste V4L2 chuig an ngréasán."
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Lig don mhaolán fáinne dul thar an teorainn faoin méid seo"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Mód MJPEG a dhíchumasú go huathoibríoch"
-
-#~ msgid "Blink"
-#~ msgstr "Blink"
-
-#~ msgid "Command to run"
-#~ msgstr "Ordú a rith"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Ná tosaigh dynctrls tiománaí Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Ná cuir dinctrls i dtosach"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Cumasaigh MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Cumasaigh formáid YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Dul thar"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Rith ordú tar éis an pictiúr a shábháil. Déanann Mjpg-streamer ainm an "
-#~ "chomhaid a pharsáil mar an chéad pharaiméadar le do script."
-
-#~ msgid "File output"
-#~ msgstr "Aschur comhaid"
-
-#~ msgid "Folder"
-#~ msgstr "Fillteán"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Deonaigh rochtain UCI do luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Breiseán ionchuir"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Eatramh idir pictiúir a shábháil"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Caighdeán comhbhrú JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Rialú faoi stiúir"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Nasc an pictiúr is déanaí le hainm seasta comhaid"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Nasc an pictiúr deireanach i maolán fáinne leis an gcomhad seasta "
-#~ "ainmnithe a cuireadh ar fáil."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "uas. líon na bpictiúr le coinneáil"
-
-#~ msgid "Off"
-#~ msgstr "As"
-
-#~ msgid "On"
-#~ msgstr "Ar"
-
-#~ msgid "Output plugin"
-#~ msgstr "Breiseán aschuir"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Méid maoláin fáinne"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Socraigh fillteán chun pictiúir a shábháil"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Socraigh an t-eatramh i milleasoicind"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Socraigh an caighdeán i faoin gcéad. Gníomhachtaíonn an socrú seo formáid "
-#~ "YUYV, díchumasaítear MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "Is feidhmchlár sruthaithe é mjpg streamer le haghaidh ceamaraí gréasáin "
-#~ "atá comhoiriúnach le Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/he/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/he/ustreamer.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2023-09-07 05:53+0000\n"
+"PO-Revision-Date: 2023-09-07 05:169+0000\n"
 "Last-Translator: Oren Bahar <shavitbit@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/he/>\n"
+"luciapplicationsustreamer/he/>\n"
 "Language: he\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -11,172 +11,227 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "היקשר ליציאת TCP זו. ברירת מחדל: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "מכשיר"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"נתיב לתיקייה עם קבצים סטטיים במקום דף אינדקס שורש מוטמע"
+"<br />"
+"קישורים סימבוליים אינם נתמכים מסיבות אבטחה. ברירת מחדל: מושבת"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "כללי"
 
@@ -184,321 +239,354 @@ msgstr "כללי"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "פתחה"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "הגדרות"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
+msgid "µStreamer"
 msgstr ""

--- a/applications/luci-app-ustreamer/po/hi/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/hi/ustreamer.po
@@ -4,172 +4,224 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr ""
 
@@ -177,321 +229,354 @@ msgstr ""
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
+msgid "µStreamer"
 msgstr ""

--- a/applications/luci-app-ustreamer/po/hu/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/hu/ustreamer.po
@@ -3,608 +3,593 @@ msgstr ""
 "PO-Revision-Date: 2025-06-20 09:25+0000\n"
 "Last-Translator: hmzs <hmzs@1szer1.hu>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/hu/>\n"
+"luciapplicationsustreamer/hu/>\n"
 "Language: hu\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Kérjen felhasználónevet és jelszót kapcsolódáskor"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Hitelesítés szükséges"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Kötés ehhez a TCP porthoz. Alapértelmezett: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Eszköz"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Ennél a korlátnál kisebb képkockák eldobása"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Ennél a korlátnál kisebb képkockák eldobása. Hasznos, ha az eszköz<br />"
+"kis méretű szemét kereteket generál. Alapértelmezett: 128 bájt"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "µStreamer engedélyezése"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Statikus fájlokkal rendelkező könyvtár elérési útja beágyazott "
+"gyökérindexoldal helyett<br />"
+"A szimbolikus linkek biztonsági okokból nem támogatottak. "
+"Alapértelmezett: letiltva"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Egy mappa, amely weboldalakat tartalmaz"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Másodpercenkénti képkockák"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Általános"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
+"UCI hozzáférés engedélyezése a <em>luci-app-ustreamer</em> alkalmazásnak"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP kimenet"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Könnyű és gyors MJPEG-HTTP streamer"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Jelszó"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Bővítmény beállításai"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Felbontás"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"A legkisebb méret beállítása, ha a webkamera kis méretű szemét képkockákat "
-"állít elő. Ez gyenge fényviszonyok esetén fordulhat elő"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Beállítások"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Az adatközvetítés elérhetetlen"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP port ehhez a HTTP-kiszolgálóhoz"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC bemenet"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Felhasználónév"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW mappa"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Felhasználónév"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW mappa"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Gyűrűpuffer engedélyezése a korlát eléréséhez ezzel a mennyiséggel"
-
-#~ msgid "Auto"
-#~ msgstr "Automatikus"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Az MJPEG mód automatikus letiltása"
-
-#~ msgid "Blink"
-#~ msgstr "Villogás"
-
-#~ msgid "Command to run"
-#~ msgstr "Futtatandó parancs"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Ne készítse elő a Linux-UVC illesztőprogram dynctrls programját"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Ne készítse elő a dynctrls programot"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "MJPG-adatközvetítő engedélyezése"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "YUYV formátum engedélyezése"
-
-#~ msgid "Exceed"
-#~ msgstr "Meghaladás"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Parancs végrehajtása a fénykép mentése után. Az MJPG-adatközvetítő a "
-#~ "parancsfájl első paramétereként dolgozza fel a fájlnevet."
-
-#~ msgid "File output"
-#~ msgstr "Fájlkimenet"
-
-#~ msgid "Folder"
-#~ msgstr "Mappa"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr ""
-#~ "UCI hozzáférés engedélyezése a <em>luci-app-mjpg-streamer</em> "
-#~ "alkalmazásnak"
-
-#~ msgid "Input plugin"
-#~ msgstr "Bemeneti bővítmény"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Fényképek mentése közti időköz"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG tömörítési minőség"
-
-#~ msgid "Led control"
-#~ msgstr "LED vezérlés"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Legújabb fénykép összekapcsolása rögzített fájlnévvel"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Az utolsó kép összekapcsolása a gyűrűpufferben a megadott rögzített nevű "
-#~ "fájlhoz."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-adatközvetítő"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Megtartandó fényképek legnagyobb száma"
-
-#~ msgid "Off"
-#~ msgstr "Ki"
-
-#~ msgid "On"
-#~ msgstr "Be"
-
-#~ msgid "Output plugin"
-#~ msgstr "Kimeneti bővítmény"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Gyűrűpuffer mérete"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Mappa beállítása a fényképek mentéséhez"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Az időköz beállítása ezredmásodpercben"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "A minőség beállítása százalékban. Ez a beállítás bekapcsolja a YUYV "
-#~ "formátumot, és letiltja a MJPEG-et"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "Az MJPG-adatközvetítő egy adatközvetítő alkalmazás a Linux-UVC "
-#~ "kompatibilis webkamerákhoz"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/it/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/it/ustreamer.po
@@ -3,179 +3,235 @@ msgstr ""
 "PO-Revision-Date: 2024-07-03 10:09+0000\n"
 "Last-Translator: moreno <morenomatassini95@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/it/>\n"
+"luciapplicationsustreamer/it/>\n"
 "Language: it\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Richiedi nome utente e password alla connessione"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Autenticazione richiesta"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Ascolta su questa porta TCP. Predefinita: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Dispositivo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Abilita"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Percorso verso la directory con file statici anziché la pagina indice "
+"radice incorporata<br />"
+"I collegamenti simbolici non sono supportati per motivi di sicurezza. "
+"Predefinito: disabilitato"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Generale"
 
@@ -183,343 +239,354 @@ msgstr "Generale"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Password"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Impostazioni"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Nome utente"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Nome utente"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr ""
-#~ "Permetti al buffer circolare di eccedere il limite di questa quantità"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Disabilito automaticamente la modalità MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Blink"
-
-#~ msgid "Command to run"
-#~ msgstr "Comando da eseguire"
-
-#~ msgid "Off"
-#~ msgstr "Off"
-
-#~ msgid "On"
-#~ msgstr "On"

--- a/applications/luci-app-ustreamer/po/ja/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ja/ustreamer.po
@@ -5,7 +5,7 @@ msgstr ""
 "PO-Revision-Date: 2024-07-15 18:06+0000\n"
 "Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/ja/>\n"
+"luciapplicationsustreamer/ja/>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13,599 +13,584 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "接続時にユーザー名とパスワードを確認します"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "認証が必要"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "このTCPポートにバインドします。デフォルト: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "デバイス"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "この制限よりも小さいフレームをドロップする"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"この制限よりも小さいフレームをドロップする。"
+"<br />"
+"デバイスが小さなサイズのガベージフレームを生成する場合に便利です。デフォルト: 128バイト"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "µStreamerを有効化"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"埋め込まれたルートインデックスページの代わりに静的ファイルを含むディレクトリへのパス<br />"
+"セキュリティ上の理由により、シンボリックリンクはサポートされていません。デフォルト: 無効"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "ウェブページを含むフォルダー"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "1秒当たりのフレーム数"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "全般"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "luci-app-ustreamer に UCIアクセスを許可"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP 出力"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "軽量で高速な MJPEG-HTTP ストリーマー"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "パスワード"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "プラグイン設定"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "ポート"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "解像度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"もしウェブカメラが小さなサイズの余分なフレームを生成する場合は、最小サイズを"
-"設定します。光量の低い条件下で発生することがあります"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "設定"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "ストリーム利用不可"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "このHTTPサーバーのTCPポート"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC 入力"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "ユーザー名"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW フォルダー"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "ユーザー名"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW フォルダー"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "リングバッファーがこの量だけ制限を超過することを許可します"
-
-#~ msgid "Auto"
-#~ msgstr "自動"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "MJPEGモードの自動無効化"
-
-#~ msgid "Blink"
-#~ msgstr "点滅"
-
-#~ msgid "Command to run"
-#~ msgstr "実行するコマンド"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Linux-UVC ドライバーのdynctrlsを初期化しない"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "dynctrlsを初期化しない"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "MJPG-streamerを有効化"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "YUYV形式を有効化"
-
-#~ msgid "Exceed"
-#~ msgstr "超過"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "画像保存後にコマンドを実行します。Mjpg-streamerは、ファイル名をスクリプト"
-#~ "の最初の引数として解釈します。"
-
-#~ msgid "File output"
-#~ msgstr "ファイル出力"
-
-#~ msgid "Folder"
-#~ msgstr "フォルダー"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "luci-app-mjpg-streamer に UCIアクセスを許可"
-
-#~ msgid "Input plugin"
-#~ msgstr "入力プラグイン"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "画像の保存間隔"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG 圧縮品質"
-
-#~ msgid "Led control"
-#~ msgstr "LED 制御"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "最新の画像を固定ファイル名にリンク"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "提供されている固定の名前付きファイルにリングバッファの最後の画像をリンクし"
-#~ "ます。"
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "保持する画像の最大数"
-
-#~ msgid "Off"
-#~ msgstr "オフ"
-
-#~ msgid "On"
-#~ msgstr "オン"
-
-#~ msgid "Output plugin"
-#~ msgstr "出力プラグイン"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "リングバッファー サイズ"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "画像を保存するフォルダーを設定"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "間隔をミリ秒で設定"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "品質をパーセントで設定します。この設定はYUYV形式を有効にし、MJPEGを無効に"
-#~ "します"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "Mjpg streamerは、Linux-UVC互換ウェブカメラのためのストリーミング アプリ"
-#~ "ケーションです"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/ko/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ko/ustreamer.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-02-11 13:57+0000\n"
+"PO-Revision-Date: 2026-01-27 12:49+0000\n"
 "Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/ko/>\n"
@@ -10,172 +10,226 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.16-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr "잘린 프레임 허용"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "인증 사용"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr "역광 보정"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "비트레이트"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "이 TCP 포트에 바인딩하십시오. 기본값: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "비트레이트 (kbps)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "밝기"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "대비"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "디버그(Debug)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "기기"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "활성화"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr "인코더"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr "가상 해상도"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr "좌우 반전"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr "상하 반전"
 
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"내장된 루트 인덱스 페이지 대신 정적 파일이 있는 디렉터리의 경로<br />"
+"보안상의 이유로 심볼릭 링크는 지원되지 않습니다. 기본값: 비활성화됨"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr ""
+
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "형식"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "초당 프레임 수(FPS)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "감마"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "일반"
 
@@ -183,342 +237,354 @@ msgstr "일반"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr "luci-app-ustreamer의 UCI 접근 권한 부여"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP 출력"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr "호스트"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr "색조"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr "입출력(I/O) 방식"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "이미지 제어"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "정보(info)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "인스턴스 ID"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "로그 수준"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr "M2M 장치"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "암호"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "성능(Performance)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "플러그인 설정"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "포트"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "품질"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "해상도"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr "회전"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr "채도"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "설정"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "선명도"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "소켓"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr "소켓 권한"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "대기 시간"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC 입력"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "사용자 이름"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "상세(Verbose)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "WWW 폴더"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr "화이트 밸런스"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "디버그(debug)"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "정보(info)"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "성능(performance)"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr "ustreamer"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "상세(verbose)"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
+msgid "µStreamer"
 msgstr ""
-"µStreamer는 모든 V4L2 장치의 MJPEG 비디오를 네트워크로 스트리밍하는 가볍고 "
-"매우 빠른 서버입니다."
-
-#~ msgid "Auto"
-#~ msgstr "자동"
-
-#~ msgid "Folder"
-#~ msgstr "폴더"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "luci-app-mjpg-streamer의 UCI 접근 권한 부여"
-
-#~ msgid "Input plugin"
-#~ msgstr "입력 플러그인"
-
-#~ msgid "Off"
-#~ msgstr "비활성"
-
-#, fuzzy
-#~ msgid "On"
-#~ msgstr "활성"

--- a/applications/luci-app-ustreamer/po/lt/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/lt/ustreamer.po
@@ -4,7 +4,7 @@ msgstr ""
 "PO-Revision-Date: 2026-01-29 18:22+0000\n"
 "Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/lt/>\n"
+"luciapplicationsustreamer/lt/>\n"
 "Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13,601 +13,586 @@ msgstr ""
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.16-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
-"Prašyti naudotojo/vartotojo vardo (t.y. slapyvardžio) ir slaptažodžio "
-"prisijungiant"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Reikalingas autentifikavimas"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Susieti su šiuo TCP prievadu. Numatytasis: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Įrenginys"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Išmesti kadrus, kurie mažesni negu šis limitas/ribojimas"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Išmesti kadrus, kurie mažesni negu šis limitas/ribojimas.<br />"
+"Naudinga, jei įrenginys generuoja mažo dydžio šiukšlių kadrus.<br />"
+"Numatytoji reikšmė: 128 baitai"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Įjungti/Įgalinti „µStreamer“"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Įjungtas/Įgalintas"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Kelias į katalogą su statiniais failais, o ne įterptuoju šakniniu indekso "
+"puslapiu<br />"
+"Simbolinės nuorodos nepalaikomos dėl saugumo priežasčių. "
+"Numatytoji reikšmė: išjungta"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Aplankalas, kuriame randami tinklapiai"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Kadrai per sekundę"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Bendra/-i/-ai/-s"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Suteikti „UCI“ prieigą – „luci-app-ustreamer“"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "„HTTP“ išvestis"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Lengvas ir greitas MJPEG-HTTP srautinio perdavimo įrenginys"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Plėtinio nustatymai"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Prievadas"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Rezoliucija"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Nustatyti minimalų dydį, jeigu vaizdo kamera sukuria mažo dydžio netinkamus "
-"(šūdinus) kadrus. Gali nutikti mažo apšvietimo sąlygomis"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Nustatymai"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Transliavimas nepasiekiamas"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "„TCP“ prievadas šiam „HTTP“ serveriui"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "„UVC“ įvestis"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Naudotojo/Vartotojo vardas (t.y. Slapyvardis)"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "„WWW“ aplankas"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Naudotojo/Vartotojo vardas (t.y. Slapyvardis)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "„WWW“ aplankas"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Leisti „ringbuffer“ peržengti limitą, šia suma"
-
-#~ msgid "Auto"
-#~ msgstr "Automatiškai"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatinis išjungimas „MJPEG“ veiksenos"
-
-#~ msgid "Blink"
-#~ msgstr "Mirksėti"
-
-#~ msgid "Command to run"
-#~ msgstr "Vykdomoji komanda"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Neinicializuoti „Linux-UVC“ tvarkyklės „dynctrls“"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Neinicializuoti „dynctrls“"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Įjungti/Įgalinti „MJPG-transliuotoją“"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Įjungti „YUYV“ formatą"
-
-#~ msgid "Exceed"
-#~ msgstr "Viršyti"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Vykdyti komandą po išsaugojant nuotrauką/vaizdą. „Mjpg-steamer“ "
-#~ "parsiduoda failo pavadinimą kaip pirmą parametrą Jūsų skriptui."
-
-#~ msgid "File output"
-#~ msgstr "Failo išvestis"
-
-#~ msgid "Folder"
-#~ msgstr "Aplankas/Aplankalas"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Suteikti „UCI“ prieigą – „luci-app-mjpg-streamer“"
-
-#~ msgid "Input plugin"
-#~ msgstr "Įvesties plėtinys"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervalas tarp išsaugojant nuotraukas/vaizdus/paveikslus"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "„JPEG“ suglaudinimo kokybė"
-
-#~ msgid "Led control"
-#~ msgstr "„LED“ (Lemputės) valdymas"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Sujungti naujausią nuotrauką/vaizdą į įtvirtintą failo pavadinimą"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Sujungti paskiausią nuotrauką/vaizdą, randama per – „ringbuffer“ į "
-#~ "pateiktą įtvirtintą failo pavadinimą."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "„MJPG-transliuotojas“"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Maksimalus nuotraukų/vaizdų skaičius, kuriuos reikėtų laikyti"
-
-#~ msgid "Off"
-#~ msgstr "Išjungtas/Išgalintas"
-
-#~ msgid "On"
-#~ msgstr "Įjungta/Įgalinta (-s)"
-
-#~ msgid "Output plugin"
-#~ msgstr "Išvesties plėtinys"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "„Žiedo buferio“ dydis"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Nustatyti aplankalą į kurį išsaugoti nuotraukas/vaizdus"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Nustatyti intervalą milisekundėmis"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Nustatyti kokybę procentais. Šis nustato ir aktyvuoją „YUYV“ formatą, "
-#~ "išjungia „MJPEG“"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "„mjpg-streamer“ yra transliavimo programėlė skirta „Linux-UVC“ "
-#~ "palaikomoms vaizdo kameroms"
+msgid "µStreamer"
+msgstr "„µStreamer“"

--- a/applications/luci-app-ustreamer/po/mr/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/mr/ustreamer.po
@@ -3,179 +3,233 @@ msgstr ""
 "PO-Revision-Date: 2020-02-07 09:19+0000\n"
 "Last-Translator: Prachi Joshi <josprachi@yahoo.com>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/mr/>\n"
+"luciapplicationsustreamer/mr/>\n"
 "Language: mr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "या TCP पोर्टशी बांधा. डीफॉल्ट: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "डिव्हाइस"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "सक्षम केले"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"एम्बेडेड रूट इंडेक्स पेजऐवजी स्टॅटिक फाइल्ससह डायरेक्टरीकडे जाण्याचा मार्ग<br />"
+"सुरक्षेच्या कारणास्तव सिमलिंक्स समर्थित नाहीत. डीफॉल्ट: अक्षम"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "सामान्य"
 
@@ -183,324 +237,354 @@ msgstr "सामान्य"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "संकेतशब्द"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "पोर्ट"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "सेटिंग्ज"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "वापरकर्तानाव"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "वापरकर्तानाव"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Off"
-#~ msgstr "बंद"

--- a/applications/luci-app-ustreamer/po/ms/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ms/ustreamer.po
@@ -3,179 +3,234 @@ msgstr ""
 "PO-Revision-Date: 2025-04-22 05:24+0000\n"
 "Last-Translator: Abdul Muizz Bin Abdul Jalil <abmuizz@gmail.com>\n"
 "Language-Team: Malay <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/ms/>\n"
+"luciapplicationsustreamer/ms/>\n"
 "Language: ms\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.11.1-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Ikat pada port TCP ini. Lalai: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Peranti"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Dibolehkan"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Laluan ke direktori dengan fail statik dan bukannya halaman indeks root "
+"terbenam<br />"
+"Pautan simbolik tidak disokong atas sebab keselamatan. Lalai: dinyahdayakan"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr ""
 
@@ -183,324 +238,354 @@ msgstr ""
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Tetapan"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Nama pengguna"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Nama pengguna"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Auto"
-#~ msgstr "Auto"

--- a/applications/luci-app-ustreamer/po/nb_NO/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/nb_NO/ustreamer.po
@@ -3,179 +3,233 @@ msgstr ""
 "PO-Revision-Date: 2024-01-26 16:51+0000\n"
 "Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/nb_NO/>\n"
+"luciapplicationsustreamer/nb_NO/>\n"
 "Language: nb_NO\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Bind til denne TCP-porten. Standard: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Enhet"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Påskrudd"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Sti til mappen med statiske filer i stedet for innebygd rotindeksside<br />"
+"Symlinker støttes ikke av sikkerhetsmessige årsaker. Standard: deaktivert"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr ""
 
@@ -183,330 +237,354 @@ msgstr ""
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Passord"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Innstillinger"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Off"
-#~ msgstr "Av"
-
-#~ msgid "On"
-#~ msgstr "På"

--- a/applications/luci-app-ustreamer/po/nl/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/nl/ustreamer.po
@@ -3,607 +3,592 @@ msgstr ""
 "PO-Revision-Date: 2023-04-23 07:04+0000\n"
 "Last-Translator: xtz1983 <xtz1983@gmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/nl/>\n"
+"luciapplicationsustreamer/nl/>\n"
 "Language: nl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Vraag om gebruikersnaam en wachtwoord bij verbinding"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Verificatie vereist"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Maak verbinding met deze TCP-poort. Standaard: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Apparaat"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Laat frames kleiner dan deze limiet vallen"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Laat frames kleiner dan deze limiet vallen. Handig als het apparaat<br />"
+"kleine, ongewenste frames produceert. Standaardwaarde: 128 bytes"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "µStreamer inschakelen"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Pad naar de map met statische bestanden in plaats van de ingebedde "
+"root-indexpagina<br />"
+"Symlinks worden om veiligheidsredenen niet ondersteund. "
+"Standaard: uitgeschakeld"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Map die webpagina's bevat"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Frames per seconde"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Algemeen"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Verleen UCI toegang voor luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP-uitvoer"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Lichtgewicht en snelle MJPEG-HTTP-streamer"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Plugin-instellingen"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Poort"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Resolutie"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Stel de minimumgrootte in als de webcam kleine afvalframes produceert. Kan "
-"gebeuren bij weinig licht"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Instellingen"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP-poort voor deze HTTP-server"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC-ingang"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Gebruikersnaam"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW-map"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW-map"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr ""
-#~ "Sta ringbuffer toe om de limiet met deze hoeveelheid te overschrijden"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatische uitschakeling van de MJPEG-modus"
-
-#~ msgid "Blink"
-#~ msgstr "Knipperen (Blink)"
-
-#~ msgid "Command to run"
-#~ msgstr "Opdracht om uit te voeren"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Initialiseer geen dynctrls van Linux-UVC-stuurprogramma"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Niet initialiseren dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "MJPG-streamer inschakelen"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Schakel het YUYV-formaat in"
-
-#~ msgid "Exceed"
-#~ msgstr "Overtreffen"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Voer het commando uit na het opslaan van de afbeelding. Mjpg-streamer "
-#~ "parseert de bestandsnaam als eerste parameter van uw script."
-
-#~ msgid "File output"
-#~ msgstr "Bestand uitvoer"
-
-#~ msgid "Folder"
-#~ msgstr "Map"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Verleen UCI toegang voor luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Invoer plugin"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Interval tussen het opslaan van foto's"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG-compressiekwaliteit"
-
-#~ msgid "Led control"
-#~ msgstr "Led controle"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Koppel nieuwste foto aan vaste bestandsnaam"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Koppel de laatste afbeelding in ringbuffer aan het opgegeven bestand met "
-#~ "een vaste naam."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Max. aantal foto's om vast te houden"
-
-#~ msgid "Off"
-#~ msgstr "Uit"
-
-#~ msgid "On"
-#~ msgstr "Op"
-
-#~ msgid "Output plugin"
-#~ msgstr "Output plugin"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Grootte ringbuffer"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Map instellen om afbeeldingen op te slaan"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Stel het interval in milliseconden in"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Stel de kwaliteit in procenten in. Deze instelling activeert het YUYV-"
-#~ "formaat en schakelt MJPEG uit"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer is een streaming-toepassing voor Linux-UVC-compatibele "
-#~ "webcams"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/pl/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/pl/ustreamer.po
@@ -1,187 +1,247 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-02-10 18:12+0000\n"
-"Last-Translator: Piotr Kołtun <pkoltungm@gmail.com>\n"
+"PO-Revision-Date: 2023-11-07 22:37+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/pl/>\n"
 "Language: pl\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2);\n"
-"X-Generator: Weblate 5.16-dev\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 5.2-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr "Zezwalaj na źródło"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr "Zezwalaj na obcięte klatki"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Pytaj o nazwę użytkownika i hasło przy połączeniu"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Wymagane uwierzytelnienie"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr "Kompensacja podświetlenia"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "Szybkość transmisji"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Nasłuchuj na tym porcie TCP. Domyślnie: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "Szybkość transmisji (kbps)"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "Jasność"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr "Bufory"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr "TTL klienta"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr "TTL klienta. Domyślnie: 10."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr "Efekt kolorystyczny"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "Kontrast"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr "Parametry sygnału wideo (DV)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr "Domyślnie: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "Debugowanie"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
-msgstr "Domyślnie: 2 (liczba rdzeni CPU (ale nie większa niż 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
-msgstr "Domyślnie: 3 (liczba rdzeni CPU (ale nie większa niż 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "Domyślnie: 10 sekund"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
-msgstr "Domyślnie: wyłączone."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
-msgstr "Domyślnie: maksymalna możliwa wartość."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "Domyślnie: wyłączone"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Urządzenie"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr "Opóźnienie po błędzie urządzenia"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 "Nie inicjuj ponownie urządzenia po przekroczeniu limitu czasu. Domyślnie: "
 "wyłączone."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Porzucaj klatki mniejsze niż ten limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Porzucaj klatki mniejsze niż ten limit. Przydatne, jeśli<br />"
+"urządzenie generuje małe ramki śmieci. Domyślnie: 128 bajtów."
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr "Porzucaj te same klatki"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr "Każdy bufor może być przetwarzany przy użyciu niezależnego wątku."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 "Włącz zapytania o czasy DV i przetwarzanie zdarzeń, aby automatycznie "
-"zmieniać rozdzielczość. Domyślnie: wyłączone."
+"zmieniać rozdzielczość.<br />Domyślnie: wyłączone"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr "Włącz zamianę kolejności RGB na BGR i odwrotnie."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Włącz µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Włączone"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr "Koder"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr "Wyjście przy braku klientów"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 "Wyjdź z programu, jeśli nie było klientów strumieniowych ani odbiorczych"
+"<br />lub dowolne żądania HTTP w ciągu ostatnich N sekund. "
+"Domyślnie: 0 (wyłączone)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr "Fałszywa rozdzielczość"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr "Odwróć poziomo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr "Odwróć pionowo"
 
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Ścieżka do katalogu ze statycznymi plikami zamiast osadzonej strony indeksu "
+"głównego<br />"
+"Dowiązania symboliczne nie są obsługiwane ze względów bezpieczeństwa. "
+"Domyślnie: wyłączone"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr "Wymuś standard TV"
+
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr "Folder zawierający gniazdo"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Folder zawierający strony sieci Web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "Format"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr "Format: zamień RGB"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Klatki na sekundę"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr "Wzmocnienie"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "Gamma"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Ogólne"
 
@@ -189,432 +249,365 @@ msgstr "Ogólne"
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr "Przyznaj luci-app-ustreamer dostęp do UCI"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr "GOP H264"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr "Urządzenie M2M H264"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr "Szybkość transmisji H264 w Kbps. Domyślnie: 5000."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr "Wzmocnienie H264"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr "Odpływ H264"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
-msgstr "Tryb odpływu H264"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Wyjście HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
-msgstr "Host"
+msgstr Host
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr "Odcień"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr "Metoda wejścia-wyjścia"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "Sterowanie obrazem"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
-msgstr "Zwiększ wydajność kodera w PiKVM v4. Domyślnie: wyłączone."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr "Zwiększ wydajność kodera w PiKVM v4. Domyślnie: wyłączone"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "Info"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr "Ruch przychodzący"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "Identyfikator instancji"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr "Odstęp między klatkami kluczowymi. Domyślnie: 30."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr "Odpływ JPEG"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
-msgstr "Tryb odpływu JPEG"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
-msgstr "Limit czasu odpływu JPEG"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Lekki i szybki streamer MJPEG-HTTP"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "Poziom rejestrowania"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr "Urządzenie M2M"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Hasło"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
-msgstr "Ścieżka do urządzenia kodera M2M V4L2. Domyślnie: wybór automatyczny."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
+msgstr "Ścieżka do urządzenia kodera M2M V4L2. Domyślnie: wybór automatyczny"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "Wydajność"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr "Trwałe"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Ustawienia wtyczki"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "Jakość"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr "Odpływ RAW"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
-msgstr "TTL klienta odpływu RAW"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
-msgstr "Tryb odpływu RAW"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
-msgstr "Limit czasu odpływu RAW"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
+msgstr "Usuń pamięć współdzieloną przy zatrzymywaniu. Domyślnie: wyłączone"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr "Usuń"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr "Usuń odpływ JPEG"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr "Usuń plik odpływu JPEG przy wyjściu"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr "Usuń odpływ RAW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr "Usuń pamięć współdzieloną przy zatrzymywaniu. Domyślnie: wyłączone."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Rozdzielczość"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr "Obróć"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr "Nasycenie"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr "Limit czasu serwera"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
-msgstr "Ustaw uprawnienia odpływu H264 (np. 777). Domyślnie: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr "Ustaw uprawnienia odpływu JPEG (np. 777). Domyślnie: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr "Ustaw uprawnienia odpływu RAW (np. 777). Domyślnie: 660."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
-msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
-"Ustaw minimalny rozmiar, jeśli kamera wytwarza małe, bezużyteczne klatki. "
-"Może występować w warunkach słabego oświetlenia"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
-msgstr "Ustaw jakość w procentach."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
+msgid ""
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Ustawienia"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "Ostrość"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
-msgstr "TTL klienta odpływu"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
-msgstr "Limit czasu odpływu"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "Gniazdo"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr "Uprawnienia gniazda"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Strumień niedostępny"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
-msgstr "Host TCP dla tego serwera HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Port TCP dla tego serwera HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
-msgstr "Standard TV"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
-msgstr "Nazwa powinna kończyć się sufiksem „.h264”."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
-msgstr "Nazwa powinna kończyć się sufiksem „.jpeg”."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
-msgstr "Nazwa powinna kończyć się sufiksem „.raw”."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
-msgstr "Liczba buforów do odbierania danych z urządzenia."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
-msgstr "Liczba wątków roboczych, ale nie większa niż liczba buforów."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "Limit czasu"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr "Limit czasu blokady. Domyślnie: 1."
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Wejście UVC"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr "Użyj ustawień domyślnych urządzenia"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
-"Użyj pamięci współdzielonej do odpływu klatek H264. Domyślnie: wyłączone."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
-"Użyj pamięci współdzielonej do odpływu klatek JPEG. Domyślnie: wyłączone."
+"Liczba buforów do odbierania danych z urządzenia.<br />"
+"Każdy bufor może być przetwarzany przy użyciu niezależnego wątku.<br />"
+"Domyślnie: 3 (liczba rdzeni CPU (ale nie większa niż 4) + 1)"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
-"Użyj pamięci współdzielonej do odpływu klatek RAW. Domyślnie: wyłączone."
+"Liczba wątków roboczych, ale nie większa niż liczba buforów.<br />"
+"Domyślnie: 2 (liczba rdzeni CPU (ale nie większa niż 4))"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
+msgstr "Limit czasu blokady"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr ""
+"Użyj pamięci współdzielonej do odpływu klatek H264. Domyślnie: wyłączone"
+"<br />Nazwa powinna kończyć się sufiksem „.h264”"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+"Użyj pamięci współdzielonej do odpływu klatek JPEG. Domyślnie: wyłączone"
+"<br />Nazwa powinna kończyć się sufiksem „.jpg” lub „.jpeg”"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+"Użyj pamięci współdzielonej do odpływu klatek RAW. Domyślnie: wyłączone"
+"<br />Nazwa powinna kończyć się sufiksem „.raw”"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "Pełne"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "Folder WWW"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr "Balans bieli"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr "Wątki robocze"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "debugowanie"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "info"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
 msgstr ""
-"lub dowolne żądania HTTP w ciągu ostatnich n sekund. Domyślnie: 0 (wyłączone)"
-"."
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "wydajność"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
-msgstr "jednostki: sekundy"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
+msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr "ustreamer"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "pełne"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-"µStreamer to lekki i bardzo szybki serwer umożliwiający strumieniowanie "
-"wideo MJPEG z dowolnego urządzenia V4L2 do sieci."
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Zezwól, aby bufor pierścieniowy przekroczył limit o tę ilość"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatyczne wyłączanie trybu MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Migacz"
-
-#~ msgid "Command to run"
-#~ msgstr "Polecenie do uruchomienia"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Nie ładuj dynamicznych kontroli sterownika Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Nie ładuj dynamicznych kontroli"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Włącz MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Włącz format YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Przekraczać"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Wykonaj komendę po wykonaniu zdjęcia. Mjpg-streamer analizuje nazwę pliku "
-#~ "jako pierwszy parametr do Twojego skryptu."
-
-#~ msgid "File output"
-#~ msgstr "Plik wyjściowy"
-
-#~ msgid "Folder"
-#~ msgstr "Katalog"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Przyznaj luci-app-mjpg-streamer dostęp do UCI"
-
-#~ msgid "Input plugin"
-#~ msgstr "Wtyczka wejściowa"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Odstęp między zapisywaniem zdjęć"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Jakość kompresji JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Kontrola LED"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Połącz najnowsze zdjęcie ze stałą nazwą pliku"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Połącz ostatnie zdjęcie w buforze pierścieniowym z dostarczonym z "
-#~ "ustaloną nazwą plikiem."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-Streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Maksymalna liczba zdjęć do przechowywania"
-
-#~ msgid "Off"
-#~ msgstr "Wyłączone"
-
-#~ msgid "On"
-#~ msgstr "Włączone"
-
-#~ msgid "Output plugin"
-#~ msgstr "Wtyczka wyjściowa"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Rozmiar bufora pierścienia"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Ustaw folder, aby zapisać zdjęcia"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Ustaw interwał w milisekundach"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Ustaw jakość w procentach. To ustawienie włącza format YUYV, wyłącza MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer jest aplikacją do strumieniowania dla kamer zgodnych z UVC "
-#~ "i Linuxem"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/pt/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/pt/ustreamer.po
@@ -3,605 +3,592 @@ msgstr ""
 "PO-Revision-Date: 2024-07-20 20:09+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/pt/>\n"
+"luciapplicationsustreamer/pt/>\n"
 "Language: pt\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Pergunte por um utilizador e palavra-passe na conexão"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Requer autenticação"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Escute nesta porta TCP. Padrão: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Aparelho"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Descarte quadros menores que este limite"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Descarte quadros menores que este limite. Útil se o dispositivo<br />"
+"produzir quadros de lixo de tamanho pequeno. Padrão: 128 bytes"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Ativa o µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Caminho para o diretório com ficheiros estáticos em vez da página de índice "
+"raiz incorporada<br />"
+"Os links simbólicos não são suportados por motivos de segurança. "
+"Padrão: desativado"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Pasta que contém páginas web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Quadros por segundos"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Geral"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Conceder UCI acesso ao luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Saída HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Streamer MJPEG-HTTP leve e rápido"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Configurações do Plugin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Resolução"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Defina o tamanho mínimo se a webcam produz quadros lixo de tamanho pequeno. "
-"Pode acontecer sob condições de pouca luz"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Configurações"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Fluxo indisponível"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Porta TCP para este servidor HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Dispositivo UVC de entrada"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Nome do utilizador"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Pasta WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Nome do utilizador"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Pasta WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Permitir que o buffer em anel exceda o limite por essa quantidade"
-
-#~ msgid "Auto"
-#~ msgstr "Automático"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Desativação automática do modo MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Pisca"
-
-#~ msgid "Command to run"
-#~ msgstr "Comando para executar"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Não inicie o dynctrls do driver do Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Não iniciar o dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Ativa o MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Ativar Formato YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Ultrapassado"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Execute o comando depois de gra\\var a imagem. Mjpg-streamer passa o nome "
-#~ "do ficheiro como primeiro parâmetro para o comando."
-
-#~ msgid "File output"
-#~ msgstr "Saída do ficheiro"
-
-#~ msgid "Folder"
-#~ msgstr "Pasta"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Conceder UCI acesso ao luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Plugins de entrada"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervalo entre gravamentos de imagens"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Qualidade da compressão JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Controle de LED"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Ligar a imagem mais nova ao nome fixo do ficheiro"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Ligar a última imagem no ringbuffer ao ficheiro nomeado fixo fornecido."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Número máximo de imagens a serem mantidas"
-
-#~ msgid "Off"
-#~ msgstr "Desligado"
-
-#~ msgid "On"
-#~ msgstr "Ligado"
-
-#~ msgid "Output plugin"
-#~ msgstr "Plugin de saída"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Tamanho do buffer em anel"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Definir pasta para gravar imagens"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Defina o intervalo em milisegundos"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Defina a qualidade em percentagem. Esta definição ativa o formato YUYV, "
-#~ "desativa MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "Mjpg streamer é uma aplicação de streaming para webcams compatíveis com o "
-#~ "Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/pt_BR/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/pt_BR/ustreamer.po
@@ -5,7 +5,7 @@ msgstr ""
 "PO-Revision-Date: 2025-06-25 14:52+0000\n"
 "Last-Translator: Douglas Garda <douglasgarda@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
-"openwrt/luciapplicationsmjpg-streamer/pt_BR/>\n"
+"openwrt/luciapplicationsustreamer/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13,599 +13,585 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Pergunte por um usuário e senha na conexão"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Requer autenticação"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Vincule-se a esta porta TCP. Padrão: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Dispositivo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Descarte quadros menores que este limite"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Descarte quadros menores que este limite. Útil se o dispositivo<br />"
+"produzir quadros de lixo de tamanho pequeno. Padrão: 128 bytes"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Ativa o µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Caminho para o diretório com arquivos estáticos em vez da página de índice "
+"raiz incorporada<br />"
+"Links simbólicos não são suportados por motivos de segurança. "
+"Padrão: desativado"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Pasta que contém páginas web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Quadros por segundos"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Geral"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Conceda acesso UCI ao luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Saída HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Streamer MJPEG-HTTP leve e rápido"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Senha"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Configurações do Plugin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Resolução"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Defina o tamanho mínimo se a webcam produz quadros lixo de tamanho pequeno. "
-"Pode acontecer sob condições de pouca luz"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Configurações"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Transmissão indisponível"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Porta TCP para este servidor HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Dispositivo UVC de entrada"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Nome do usuário"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Pasta WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Nome do usuário"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Pasta WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Permitir que o buffer em anel exceda o limite por essa quantidade"
-
-#~ msgid "Auto"
-#~ msgstr "Automatico"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Desativação automática do modo MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Pisca"
-
-#~ msgid "Command to run"
-#~ msgstr "Comando para executar"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Não inicie o dynctrls do driver do Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Não inicia o dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Ativa o MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Ativar Formato YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Ultrapassado"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Execute o comando depois de salvar a imagem. Mjpg-streamer passa o nome "
-#~ "do arquivo como primeiro parâmetro para o comando."
-
-#~ msgid "File output"
-#~ msgstr "Saída do arquivo"
-
-#~ msgid "Folder"
-#~ msgstr "Pasta"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Conceda acesso UCI ao luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Plugins de entrada"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervalo entre o salvamento das imagens"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Qualidade da compressão JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Controle de LED"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Vincule a imagem mais recente ao nome de arquivo fixo"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Vincule a última imagem no ringbuffer para o arquivo com o nome fixo "
-#~ "fornecido."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Número máximo de imagens a serem mantidas"
-
-#~ msgid "Off"
-#~ msgstr "Desligado"
-
-#~ msgid "On"
-#~ msgstr "Ligado"
-
-#~ msgid "Output plugin"
-#~ msgstr "Plugin de saída"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Tamanho do buffer em anel"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Definir pasta para salvas as imagens"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Defina o intervalo em milisegundos"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Defina a qualidade em porcentagem. Esta definição ativa o formato YUYV, "
-#~ "desativa MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "Mjpg streamer é uma aplicação de streaming para webcams compatíveis com o "
-#~ "Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/ro/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ro/ustreamer.po
@@ -3,7 +3,7 @@ msgstr ""
 "PO-Revision-Date: 2025-08-23 17:45+0000\n"
 "Last-Translator: CRISTIAN ANDREI <cristianvdr@gmail.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/ro/>\n"
+"luciapplicationsustreamer/ro/>\n"
 "Language: ro\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -11,598 +11,585 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 5.13\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Cereți numele de utilizator și parola la conectare"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Autentificare necesară"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Legătură la acest port TCP. Implicit: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Dispozitiv"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Aruncă cadrele mai mici decât această limită"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Aruncă cadrele mai mici decât această limită. Util dacă dispozitivul<br />"
+"produce cadre de tip gunoi de dimensiuni mici. Implicit: 128 octeți"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Activați µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Calea către directorul cu fișiere statice în loc de pagina index rădăcină "
+"încorporată<br />"
+"Legăturile simbolice nu sunt acceptate din motive de securitate. "
+"Implicit: dezactivat"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Dosar care conține pagini web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Imagini pe secundă"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "General"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Acordă acces UCI pentru luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Ieșire HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Streamer MJPEG-HTTP ușor și rapid"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Parolă"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Setări Plugin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Rezoluție"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Setați dimensiunea minimă dacă camera web produce cadre de gunoi de "
-"dimensiuni mici. Se poate întâmpla în condiții de iluminare slabă"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Setări"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Fluxul nu este disponibil"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Portul TCP pentru acest server HTTP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Intrare UVC"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Nume Utilizator"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Folderul WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Nume Utilizator"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Folderul WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Permiteți ca ringbuffer-ul să depășească limita cu această valoare"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Dezactivarea automată a modului MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Clipește"
-
-#~ msgid "Command to run"
-#~ msgstr "Comandă de executat"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Nu inițializați dynctrls de driver Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Nu inițializați dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Activați MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Activați formatul YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Depășește"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Execută comanda după salvarea imaginii. Mjpg-streamer analizează numele "
-#~ "fișierului ca prim parametru al scriptului."
-
-#~ msgid "File output"
-#~ msgstr "Fișier de ieșire"
-
-#~ msgid "Folder"
-#~ msgstr "Dosar"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Acordă acces UCI pentru luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Plugin de intrare"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervalul dintre salvarea imaginilor"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Calitatea compresiei JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Led de control"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Legătura cea mai nouă imagine la un nume de fișier fix"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Conectează ultima imagine din ringbuffer la fișierul cu nume fix furnizat."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Numărul maxim de imagini care pot fi păstrate"
-
-#~ msgid "Off"
-#~ msgstr "Oprit"
-
-#~ msgid "On"
-#~ msgstr "Pornit"
-
-#~ msgid "Output plugin"
-#~ msgstr "Plugin de ieșire"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Dimensiunea bufferului de inel"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Setați folderul pentru salvarea imaginilor"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Setați intervalul în milisecunde"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Setați calitatea în procente. Această setare activează formatul YUYV, "
-#~ "dezactivează MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer este o aplicație de streaming pentru camere web compatibile "
-#~ "cu Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/ru/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ru/ustreamer.po
@@ -1,10 +1,9 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: LuCI: mjpg-streamer\n"
+"Project-Id-Version: LuCI: ustreamer\n"
 "POT-Creation-Date: 2017-10-17 14:30+0300\n"
-"PO-Revision-Date: 2026-02-12 22:14+0000\n"
-"Last-Translator: SnIPeRSnIPeR <snipersniper@users.noreply.hosted.weblate.org>"
-"\n"
+"PO-Revision-Date: 2026-01-09 19:56+0000\n"
+"Last-Translator: vanapro1 <law820314@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsustreamer/ru/>\n"
 "Language: ru\n"
@@ -13,606 +12,589 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Weblate 5.16-dev\n"
+"X-Generator: Weblate 5.15.1\n"
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Спрашивать имя пользователя и пароль при подключении"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Логин и пароль"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Привязаться к этому TCP-порту. По умолчанию: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Устройство"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Отбрасывать кадры меньше, чем"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Отбрасывать кадры меньше, чем. Полезно, если устройство создает<br />"
+"небольшие по размеру кадры мусора. По умолчанию: 128 байт."
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Включить µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Включено"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Путь к каталогу со статическими файлами вместо встроенной корневой "
+"индексной страницы<br />"
+"Символические ссылки не поддерживаются по соображениям безопасности. "
+"По умолчанию: отключено"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Директория с веб-страницами"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Кадров в секунду"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Общие"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Разрешить UCI доступ к luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP-вывод"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
-msgstr "Хост"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Лёгкий и быстрый стример MJPEG-HTTP"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Парoль"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Настройки плагинов"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Разрешение"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Укажите минимальный размер корректных кадров, чтобы отфильтровать "
-"\"мусорные\" кадры. Настройка особенно актуальна, если веб-камера при плохом "
-"освещении не справляется с работой"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Настройки"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Поток недоступен"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Укажите TCP-порт для HTTP-сервера"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC-ввод"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Имя пользователя"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Директория WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Имя пользователя"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Директория WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr ""
-#~ "Разрешить кольцевому буферу превысить ограничение на данное значение"
-
-#~ msgid "Auto"
-#~ msgstr "Автоматически"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Автоматическое отключение режима MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Мигает"
-
-#~ msgid "Command to run"
-#~ msgstr "Введите команду"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Не инициализировать dynctrls из драйвера Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Отключить dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Включить MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Включить формат YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Превышение"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Выполнить команду после сохранения изображения. Mjpg-streamer передаст "
-#~ "имя файла первым параметром."
-
-#~ msgid "File output"
-#~ msgstr "Вывод в файл"
-
-#~ msgid "Folder"
-#~ msgstr "Директория"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Разрешить UCI доступ к luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Плагин ввода"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Интервал между снимками"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Качество JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "Управление светодиодным индикатором веб-камеры"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Ссылка на самый свежий снимок"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr "Связать последнюю фотографию с указанным именем файла."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr ""
-#~ "Ограничение по количеству изображений из кольцевого буфера, которые будут "
-#~ "храниться на накопителе"
-
-#~ msgid "Off"
-#~ msgstr "Выключена"
-
-#~ msgid "On"
-#~ msgstr "Включена"
-
-#~ msgid "Output plugin"
-#~ msgstr "Плагин вывода"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Размер буфера"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Директория для сохранения снимков"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Интервал в миллисекундах"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Задайте качество в процентах. Данная настройка активирует формат YUYV, "
-#~ "отключая MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "Приложение для трансляции потокового видео для Linux-UVC совместимых веб-"
-#~ "камер.<br />Просмотр в браузере по умолчанию http://192.168.1.1:8080/?"
-#~ "action=stream"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/sk/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/sk/ustreamer.po
@@ -3,179 +3,235 @@ msgstr ""
 "PO-Revision-Date: 2025-05-30 20:29+0000\n"
 "Last-Translator: Jan Vongrej <jan.vongrej@gmail.com>\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/sk/>\n"
+"luciapplicationsustreamer/sk/>\n"
 "Language: sk\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Vyžadovať uživatelské meno a heslo pri pripojení"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Naviazať sa na tento TCP port. Predvolená hodnota: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Zariadenie"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Zapnuté"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Cesta k adresáru so statickými súbormi namiesto vloženej koreňovej "
+"indexovej stránky<br />"
+"Symbolické odkazy nie sú z bezpečnostných dôvodov podporované. "
+"Predvolená hodnota: vypnutá"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr ""
 
@@ -183,327 +239,354 @@ msgstr ""
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Heslo"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Nastavenia"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Používateľské meno"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Používateľské meno"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
+msgid "µStreamer"
 msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Auto"
-#~ msgstr "Automatické"
-
-#~ msgid "Off"
-#~ msgstr "Vypnuté"

--- a/applications/luci-app-ustreamer/po/sv/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/sv/ustreamer.po
@@ -3,569 +3,588 @@ msgstr ""
 "PO-Revision-Date: 2025-11-14 21:04+0000\n"
 "Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/sv/>\n"
+"luciapplicationsustreamer/sv/>\n"
 "Language: sv\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Fråga efter användarnamn och lösenord vid anslutning"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Autentisering krävs"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Bind till denna TCP-port. Standard: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Enhet"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Aktivera µStrömmer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Sökväg till mapp med statiska filer istället för inbäddad rotindexsida<br />"
+"Symboliska länkar stöds inte av säkerhetsskäl. Standard: inaktiverad"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Mappen som innehåller hemsidor"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Bildrutor i sekunden"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Generell"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Godkänn UCI-åtkomst för luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP-utmatning"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Lösenord"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Inställningar för instickprogrammet"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Upplösning"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Inställningar"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Strömmen är otillgänglig"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP-porten för den här HTTP-servern"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC-inmatning"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Användarnamn"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW-mapp"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Användarnamn"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW-mapp"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Låt ringbuffern överskrida gränsen med detta belopp"
-
-#~ msgid "Auto"
-#~ msgstr "Auto"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Automatisk avstängning av MJPEG-läget"
-
-#~ msgid "Blink"
-#~ msgstr "Blinka"
-
-#~ msgid "Command to run"
-#~ msgstr "Kommando att köra"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Initialisera inte dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Aktivera MJPG-strömmare"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Aktivera YUYV-format"
-
-#~ msgid "Exceed"
-#~ msgstr "Överskrid"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Kör kommandot efter att bilden har sparats. Mjpg-strömmaren tolkar "
-#~ "filnamnet som den första parametern till ditt skript."
-
-#~ msgid "Folder"
-#~ msgstr "Mapp"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Godkänn UCI-åtkomst för luci-app-mjpg-streamer"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Intervall mellan sparandet av bilder"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Kompressionskvalité för JPEG"
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-strömmare"
-
-#~ msgid "Off"
-#~ msgstr "Av"
-
-#~ msgid "On"
-#~ msgstr "På"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Ställ in mapp att spara bilder i"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Ställ in intervallet i millisekunden"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Ställ in kvalitén i procent. Den här inställningen aktiverar YUYV-"
-#~ "formatet, stänger av MJPEG"
+msgid "µStreamer"
+msgstr "µStrömmare"

--- a/applications/luci-app-ustreamer/po/ta/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/ta/ustreamer.po
@@ -3,604 +3,592 @@ msgstr ""
 "PO-Revision-Date: 2025-01-25 19:51+0000\n"
 "Last-Translator: தமிழ்நேரம் <anishprabu.t@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/ta/>\n"
+"luciapplicationsustreamer/ta/>\n"
 "Language: ta\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.10-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "இணைப்பில் பயனர்பெயர் மற்றும் கடவுச்சொல்லைக் கேளுங்கள்"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "ஏற்பு தேவை"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "இந்த TCP போர்ட்டுடன் பிணைக்கவும். இயல்புநிலை: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "சாதனம்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "இந்த வரம்பை விட சிறிய பிரேம்களை விடுங்கள்"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"இந்த வரம்பை விட சிறிய பிரேம்களை விடுங்கள். சாதனம் சிறிய அளவிலான குப்பை<br />"
+"பிரேம்களை உருவாக்கினால் பயனுள்ளதாக இருக்கும். இயல்புநிலை: 128 பைட்டுகள்"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "µச்ட்ரீமரை இயக்கவும்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "இயக்கப்பட்டது"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"உட்பொதிக்கப்பட்ட ரூட் குறியீட்டு பக்கத்திற்கு பதிலாக நிலையான கோப்புகளுடன் "
+"dir க்கான பாதை<br />"
+"பாதுகாப்பு காரணங்களுக்காக சிம்லிங்க்குகள் ஆதரிக்கப்படவில்லை. "
+"இயல்புநிலை: முடக்கப்பட்டது"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "வலைப்பக்கங்களைக் கொண்ட கோப்புறை"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "நொடிக்கு பிரேம்கள்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "பொது"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "லூசி-ஆப்-எம்.சே.பி.சி-ச்ட்ரீமருக்கு யுசிஐ அணுகல் வழங்கவும்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP வெளியீடு"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "இலகுரக மற்றும் வேகமான MJPEG-HTTP ஸ்ட்ரீமர்"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "கடவுச்சொல்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "சொருகி அமைப்புகள்"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "துறைமுகம்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "பகுத்தல்"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"வெப்கேம் சிறிய அளவிலான குப்பை பிரேம்களை விளைவாக்கம் செய்தால் குறைந்தபட்ச அளவை "
-"அமைக்கவும். குறைந்த ஒளி நிலைமைகளின் கீழ் நிகழலாம்"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "அமைப்புகள்"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "ச்ட்ரீம் கிடைக்கவில்லை"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "இந்த HTTP சேவையகத்திற்கான TCP துறைமுகம்"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC உள்ளீடு"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "பயனர்பெயர்"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Www கோப்புறை"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "பயனர்பெயர்"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Www கோப்புறை"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "இந்த தொகையால் வரம்பை மீற ரிங்பஃபர் அனுமதிக்கவும்"
-
-#~ msgid "Auto"
-#~ msgstr "தானி"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "MJPEG பயன்முறையின் தானியங்கி முடக்குதல்"
-
-#~ msgid "Blink"
-#~ msgstr "கண் சிமிட்டுங்கள்"
-
-#~ msgid "Command to run"
-#~ msgstr "இயக்க கட்டளை"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "லினக்ச்-யு.யு.சி டிரைவரின் DynCtrls ஐ துவக்க வேண்டாம்"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "DynCtrls ஐ துவக்க வேண்டாம்"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "MJPG- ச்ட்ரீமரை இயக்கவும்"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "YUYV வடிவத்தை இயக்கவும்"
-
-#~ msgid "Exceed"
-#~ msgstr "அதிகமாக"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "படத்தைச் சேமித்த பிறகு கட்டளையை இயக்கவும். Mjpg-streamer உங்கள் ச்கிரிப்ட்டின் முதல் "
-#~ "அளவுருவாக கோப்பு பெயரை பாகுபடுத்துகிறது."
-
-#~ msgid "File output"
-#~ msgstr "கோப்பு வெளியீடு"
-
-#~ msgid "Folder"
-#~ msgstr "கோப்புறை"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "லூசி-ஆப்-எம்.சே.பி.சி-ச்ட்ரீமருக்கு யுசிஐ அணுகல் வழங்கவும்"
-
-#~ msgid "Input plugin"
-#~ msgstr "உள்ளீட்டு சொருகி"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "படங்களை சேமிப்பதற்கு இடையில் இடைவெளி"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG சுருக்க தகுதி"
-
-#~ msgid "Led control"
-#~ msgstr "எல்.ஈ.டி கட்டுப்பாடு"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "புதிய படத்தை நிலையான கோப்பு பெயருடன் இணைக்கவும்"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr "ரிங்பஃபரில் கடைசி படத்தை நிலையான பெயரிடப்பட்ட கோப்புடன் இணைக்கவும்."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "எம்.சே.பி.சி-ச்ட்ரீமர்"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "அதிகபட்சம். வைத்திருக்க வேண்டிய படங்களின் எண்ணிக்கை"
-
-#~ msgid "Off"
-#~ msgstr "அணை"
-
-#~ msgid "On"
-#~ msgstr "ஆன்"
-
-#~ msgid "Output plugin"
-#~ msgstr "வெளியீட்டு சொருகி"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "வளைய இடையக அளவு"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "படங்களை சேமிக்க கோப்புறையை அமைக்கவும்"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "மில்லி விநாடியில் இடைவெளியை அமைக்கவும்"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "தரத்தை சதவீதமாக அமைக்கவும். இந்த அமைப்பு YUYV வடிவத்தை செயல்படுத்துகிறது, MJPEG ஐ "
-#~ "முடக்குகிறது"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "எம்.சே.பி.சி ச்ட்ரீமர் என்பது லினக்ச்-யு.வி.சி இணக்கமான வெப்கேம்களுக்கான ச்ட்ரீமிங் "
-#~ "பயன்பாடாகும்"
+msgid "µStreamer"
+msgstr "µஸ்ட்ரீமர்"

--- a/applications/luci-app-ustreamer/po/templates/ustreamer.pot
+++ b/applications/luci-app-ustreamer/po/templates/ustreamer.pot
@@ -1,172 +1,224 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr ""
 
@@ -174,321 +226,354 @@ msgstr ""
 msgid "Grant UCI access for luci-app-ustreamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:877
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br >Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
+msgid "µStreamer"
 msgstr ""

--- a/applications/luci-app-ustreamer/po/tr/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/tr/ustreamer.po
@@ -3,603 +3,592 @@ msgstr ""
 "PO-Revision-Date: 2024-04-01 08:36+0000\n"
 "Last-Translator: Oğuz Han <h4n.3545@gmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/tr/>\n"
+"luciapplicationsustreamer/tr/>\n"
 "Language: tr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Bağlanıldığında kullanıcı adı ve şifre isteyin"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Kimlik doğrulama gerekli"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Bu TCP portunda dinleyin. Varsayılan: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Cihaz"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Bu sınırdan daha küçük kareleri düşür"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Bu sınırdan daha küçük kareleri düşür. Cihaz küçük boyutlu çöp<br />"
+"çerçeveleri üretiyorsa kullanışlıdır. Varsayılan: 128 bayt"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "µStreamer'ı etkinleştirin"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Etkin"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Gömülü kök dizin sayfası yerine statik dosyaların bulunduğu dizinin yolu"
+"<br />"
+"Güvenlik nedenleriyle sembolik bağlantılar desteklenmemektedir. "
+"Varsayılan: devre dışı"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Web sayfalarını içeren klasör"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Saniyedeki kare sayısı"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Genel"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "luci-app-ustreamer için UCI erişimi verin"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP çıktısı"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Hafif ve hızlı MJPEG-HTTP akış programı"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Parola"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Eklenti ayarları"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Bağlantı Noktası"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Çözünürlük"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Web kamerası küçük boyutlu gereksiz çerçeveler oluşturuyorsa minimum boyutu "
-"ayarlayın. Bu düşük ışık koşullarında oluşabilir"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Ayarlar"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Akış kullanılamıyor"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Bu HTTP sunucusu için TCP bağlantı noktasıdır"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC girişi"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Kullanıcı Adı"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "WWW klasörü"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Kullanıcı Adı"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "WWW klasörü"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Ringbuffer'ın bu miktar kadar sınırı aşmasına izin ver"
-
-#~ msgid "Auto"
-#~ msgstr "Otomatik"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "MJPEG modunun otomatik olarak devre dışı bırakılması"
-
-#~ msgid "Blink"
-#~ msgstr "Goz kırpma"
-
-#~ msgid "Command to run"
-#~ msgstr "Çalıştırılacak komut"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Linux-UVC sürücüsünün dynctrls'ini başlatmayın"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Dynctrls'i başlatmayın"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "MJPG yayıncıyı etkinleştirin"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "YUYV biçimini etkinleştir"
-
-#~ msgid "Exceed"
-#~ msgstr "Aşan"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Resmi kaydettikten sonra komutu yürütün. Mjpg-streamer, dosya adını "
-#~ "betiğinizin ilk parametresi olarak ayrıştırır."
-
-#~ msgid "File output"
-#~ msgstr "Dosya çıktısı"
-
-#~ msgid "Folder"
-#~ msgstr "Klasör"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "luci-app-mjpg-streamer için UCI erişimi verin"
-
-#~ msgid "Input plugin"
-#~ msgstr "Giriş eklentisi"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Resimleri kaydetme aralığı"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG sıkıştırma kalitesi"
-
-#~ msgid "Led control"
-#~ msgstr "Led kontrolü"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "En yeni resmi sabit dosya adına bağlayın"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr "Ringbuffer'daki son resmi sağlanan sabit isimli dosyaya bağlayın."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-yayıncısı"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Maks. tutulacak resim sayısı"
-
-#~ msgid "Off"
-#~ msgstr "Kapalı"
-
-#~ msgid "On"
-#~ msgstr "Açık"
-
-#~ msgid "Output plugin"
-#~ msgstr "Çıktı eklentisi"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Halka tampon boyutu"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Resimleri kaydetmek için klasör ayarlayın"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Aralığı milisaniye cinsinden ayarlayın"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Kaliteyi yüzde olarak ayarlayın. Bu ayar YUYV formatını etkinleştirir, "
-#~ "MJPEG'i devre dışı bırakır"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer, Linux-UVC uyumlu web kameraları için bir akış uygulamasıdır"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/uk/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/uk/ustreamer.po
@@ -3,7 +3,7 @@ msgstr ""
 "PO-Revision-Date: 2025-09-07 21:06+0000\n"
 "Last-Translator: Максим Горпиніч <gorpinicmaksim0@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/uk/>\n"
+"luciapplicationsustreamer/uk/>\n"
 "Language: uk\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -11,600 +11,585 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.14-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Запитувати імʼя та пароль користувача при підключенні"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Потрібна автентифікація"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Прив’язка до цього TCP-порту. За замовчуванням: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Пристрій"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Відпустіть кадри, менші за це обмеження"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Відпустіть кадри, менші за це обмеження. Корисно, якщо пристрій<br />"
+"створює невеликі кадри сміття. За замовчуванням: 128 байт"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Увімкнути µСтрімер"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Шлях до каталогу зі статичними файлами замість вбудованої кореневої "
+"сторінки індексу<br />"
+"Символічні посилання не підтримуються з міркувань безпеки. "
+"За замовчуванням: вимкнено"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Папка, яка містить веб-сторінки"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Кадров за секунду"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Загальне"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Надайте доступ UCI для luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "Вивід HTTP"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Легкий та швидкий MJPEG-HTTP стример"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Пароль"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Налаштування плагіна"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Роздільна здатність"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Встановіть мінімальний розмір, якщо веб-камера створює невеликі сміттєві "
-"кадри. Може статися в умовах слабкого освітлення"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Налаштування"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "Потік недоступний"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "TCP-порт для цього HTTP-сервера"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "УФ-вхід"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Ім'я користувача"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "папка WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Ім'я користувача"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "папка WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr ""
-#~ "Дозволити кільцевому буферу перевищити обмеження, встановивши це значення"
-
-#~ msgid "Auto"
-#~ msgstr "Авто"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Автоматичне відключення режиму MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Поморгайте"
-
-#~ msgid "Command to run"
-#~ msgstr "Команда на біг"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Не ініціалізуйте dynctrls драйвера Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Не ініціалізуйте dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Увімкнути MJPG-стрімер"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Увімкнути формат YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Перевищувати"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Виконайте команду після збереження зображення. Mjpg-streamer аналізує "
-#~ "назву файлу як перший параметр вашого сценарію."
-
-#~ msgid "File output"
-#~ msgstr "Вивід файлу"
-
-#~ msgid "Folder"
-#~ msgstr "Папка"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Надайте доступ UCI для luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Плагін введення"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Інтервал між збереженням картинок"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Якість стиснення JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "LED управління"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Пов’яжіть найновіше зображення з фіксованою назвою файлу"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Пов’яжіть останнє зображення в кільцевому буфері з наданим файлом із "
-#~ "фіксованою назвою."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-стрімер"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Макс. кількість фотографій для зберігання"
-
-#~ msgid "Off"
-#~ msgstr "Вимк."
-
-#~ msgid "On"
-#~ msgstr "Увімк"
-
-#~ msgid "Output plugin"
-#~ msgstr "Плагін виводу"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Розмір кільцевого буфера"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Встановити папку для збереження зображень"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Встановіть інтервал у мілісекундах"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Встановіть якість у відсотках. Цей параметр активує формат YUYV, вимикає "
-#~ "MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer — програма потокового передавання для веб-камер, сумісних "
-#~ "із Linux-UVC"
+msgid "µStreamer"
+msgstr "µСтрімер"

--- a/applications/luci-app-ustreamer/po/vi/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/vi/ustreamer.po
@@ -3,603 +3,592 @@ msgstr ""
 "PO-Revision-Date: 2025-08-05 09:41+0000\n"
 "Last-Translator: Vũ Minh Ngọc <vuminhngocpt@gmail.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/openwrt/"
-"luciapplicationsmjpg-streamer/vi/>\n"
+"luciapplicationsustreamer/vi/>\n"
 "Language: vi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "Yêu cầu tên người dùng và mật khẩu khi kết nối"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "Yêu cầu xác thực"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "Hãy lắng nghe trên cổng TCP này. Mặc định: 8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "Thiết bị"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "Thả khung hình nhỏ hơn giới hạn này"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"Thả khung hình nhỏ hơn giới hạn này. Hữu ích nếu thiết bị tạo ra<br />"
+"các khung dữ liệu rác có kích thước nhỏ. Mặc định: 128 byte"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "Bật µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "Kích Hoạt"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"Đường dẫn đến thư mục chứa các tệp tĩnh thay vì trang chỉ mục gốc được "
+"nhúng<br />"
+"Vì lý do bảo mật, liên kết tượng trưng (symlink) không được hỗ trợ. "
+"Mặc định: bị vô hiệu hóa"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "Thư mục chứa các trang web"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "Frames per second"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "Tổng quát"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr ""
+msgstr "Cấp quyền truy cập UCI cho luci-app-ustreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP output"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "Bộ phát trực tuyến MJPEG-HTTP nhẹ và nhanh"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "Cài đặt plugin"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "Cổng"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "Độ phân giải"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr ""
-"Đặt kích thước tối thiểu nếu webcam tạo ra các khung rác có kích thước nhỏ. "
-"Có thể xảy ra trong điều kiện ánh sáng yếu"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "Cài đặt"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "Cổng TCP cho máy chủ HTTP này"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "Đầu vào UVC"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
-msgid "Username"
-msgstr "Tên người dùng"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "WWW folder"
-msgstr "Thư mục WWW"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
-msgid "White balance"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
-msgid "Workers"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+msgid "UNIX socket remove old"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
+msgid "Username"
+msgstr "Tên người dùng"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
+msgid "WWW folder"
+msgstr "Thư mục WWW"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
+msgid "White balance"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
+msgid "Workers"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
 msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "Cho phép bộ đệm nhạc chuông vượt quá giới hạn theo số lượng này"
-
-#~ msgid "Auto"
-#~ msgstr "Tự động"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "Tự động tắt chế độ MJPEG"
-
-#~ msgid "Blink"
-#~ msgstr "Blink"
-
-#~ msgid "Command to run"
-#~ msgstr "Lệnh chạy"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "Không khởi tạo dynctrls của trình điều khiển Linux-UVC"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "Không khởi tạo dyntrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "Bật MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "Kích hoạt định dạng YUYV"
-
-#~ msgid "Exceed"
-#~ msgstr "Exceed"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr ""
-#~ "Thực hiện lệnh sau khi lưu ảnh. Mjpg-streamer phân tích cú pháp tên tệp "
-#~ "làm tham số đầu tiên cho tập lệnh của bạn."
-
-#~ msgid "File output"
-#~ msgstr "đầu ra tập tin"
-
-#~ msgid "Folder"
-#~ msgstr "Thư mục"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "Cấp quyền truy cập UCI cho luci-app-mjpg-streamer"
-
-#~ msgid "Input plugin"
-#~ msgstr "Input plugin"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "Khoảng thời gian giữa các lần lưu ảnh"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "Chất lượng nén JPEG"
-
-#~ msgid "Led control"
-#~ msgstr "điều khiển đèn led"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "Liên kết hình ảnh mới nhất với tên tệp cố định"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr ""
-#~ "Liên kết ảnh cuối cùng trong bộ đệm chuông với tệp có tên cố định được "
-#~ "cung cấp."
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "Tối đa số lượng hình ảnh để giữ"
-
-#~ msgid "Off"
-#~ msgstr "Tắt"
-
-#~ msgid "Output plugin"
-#~ msgstr "Output plugin"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "Ring buffer size"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "Đặt thư mục lưu ảnh"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "Đặt khoảng thời gian tính bằng mili giây"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr ""
-#~ "Đặt chất lượng theo phần trăm. Cài đặt này kích hoạt định dạng YUYV, tắt "
-#~ "MJPEG"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr ""
-#~ "mjpg streamer là một ứng dụng phát trực tuyến cho các webcam tương thích "
-#~ "với Linux-UVC"
+msgid "µStreamer"
+msgstr "µStreamer"

--- a/applications/luci-app-ustreamer/po/zh_Hans/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/zh_Hans/ustreamer.po
@@ -4,10 +4,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: luci-app-mjpg-streamer\n"
+"Project-Id-Version: luci-app-ustreamer\n"
 "POT-Creation-Date: 2015-06-11 21:11+0100\n"
-"PO-Revision-Date: 2026-02-11 13:57+0000\n"
-"Last-Translator: nKsyn <e.nksyn@gmail.com>\n"
+"PO-Revision-Date: 2025-12-25 20:02+0000\n"
+"Last-Translator: 大王叫我来巡山 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
 "projects/openwrt/luciapplicationsustreamer/zh_Hans/>\n"
 "Language: zh_Hans\n"
@@ -15,594 +16,589 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.16-dev\n"
+"X-Generator: Weblate 5.15.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr "允许 origin"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr "允许截短的帧"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "连接时询问用户名和密码"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "需要验证"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr "背景光补偿"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "速率"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "绑定到此 TCP 端口。默认值：8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "比特率（kbps）"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "亮度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr "缓冲"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr "客户端 TTL"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr "客户端 TTL。默认：10。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr "颜色效果"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "对比"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr "数字视频时序"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr "默认：10。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "调试"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
-msgstr "默认：2（CPU 核心数，不超过 4）。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
-msgstr "默认：3（CPU 核心数+1，不超过 4）。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "默认值：10 秒"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
-msgstr "默认：禁用。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
-msgstr "默认：可能的最大值。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "默认：禁用"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "设备"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr "设备错误延迟"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
-msgstr "发生超时不重新初始化设备。默认：禁用。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "丢弃小于该尺寸限制的帧"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr "发生超时不重新初始化设备。默认：禁用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"丢弃小于该尺寸限制的帧。如果设备生成小型垃圾帧，则此设置很有用。默认值：128 字节"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr "丢弃相同帧"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr "可用独立线程处理每一帧。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
-msgstr "启用数字视频时序查询和事件处理自动化分辨率更改。默认：禁用。"
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
+msgstr "启用数字视频时序查询和事件处理自动化分辨率更改。默认：禁用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr "开启 R-G-B 顺序互换：RGB 到 BGR，反之亦然。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "启用 µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "启用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
-msgstr "编码器"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
+msgstr "编码"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr "无客户端时退出"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
-msgstr "如果一直没有音视频流或接收端就退出程序"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
+msgstr ""
+"如果一直没有音视频流或接收端就退出程序、或最近 N 秒内的任何 HTTP 请求。默认值：0（禁用）"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr "伪造分辨率"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr "水平翻转"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr "垂直翻转"
 
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"指向包含静态文件的目录路径，而不是嵌入式根索引页<br />"
+"出于安全考虑，不支持符号链接。默认值：禁用"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr "Force TV 标准"
+
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr "包含该套接字的文件夹"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "包含网页的文件夹"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "格式"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr "格式：互换 RGB"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
 msgstr "帧每秒"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr "增益"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "伽马值"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "常规"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr "将 UCI 权限授予 ustreamer"
+msgstr "授予UCI访问luci-app-ustreamer的权限"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr "H264 GOP"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr "H264 M2M 设备"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr "Kbps 为单位的 H.264 比特率。默认：5000。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr "H264 优化"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr "H264 sink"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
-msgstr "H264 sink 模式"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP 输出"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr "主机"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr "色调"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr "IO 方式"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "图像控制"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
-msgstr "提升 PiKVM V4 开发板上的编码器性能。默认：禁用。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr "提升 PiKVM V4 开发板上的编码器性能。默认：禁用"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "信息"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr "输入"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "实例 ID"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr "关键帧间隔。默认：30。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr "JPEG sink"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
-msgstr "JPEG sink 模式"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
-msgstr "JPEG sink 超时"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "轻量级、快速的 MJPEG-HTTP 流媒体播放器"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "日志级别"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr "M2M 设备"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "密码"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
-msgstr "V4L2 M2M 编码器设备路径。默认：自动选择。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr "V4L2 M2M 编码器设备路径。默认：自动选择"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "性能"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr "持久"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "插件设置"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "端口"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "画质"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
-msgstr "RAW sink"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
-msgstr "RAW sink 客户端 TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
-msgstr "RAW sink 模式"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
-msgstr "RAW sink 超时"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
+msgstr "停止时删除共享内存。默认：禁用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr "删除"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
-msgstr "删除 JPEG sink"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr "退出时删除 JPEG sink 文件"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr "删除 RAW sink"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr "停止时删除共享内存。默认：禁用。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "分辨率"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr "旋转"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr "饱和度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr "服务器超时"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
-msgstr "设置 H264 权限（如 777）。默认：660。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr "设置 JPEG sink 权限（如 777）。默认：660。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr "设置 RAW sink 权限（如 777）。默认：660。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr "当光照不足时可能会产生无用帧，可在此设置帧的最小尺寸以过滤它"
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
-msgstr "设置百分比表示的画质。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "设置"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "锐利度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
-msgstr "Sink 客户端 TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
-msgstr "Sink 超时"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "套接字"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr "套接字权限"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "流不可用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
-msgstr "这台 HTTP 服务器的 TCP 主机"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "HTTP 服务监听的 TCP 端口"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
+msgstr ""
+"从设备接收数据的缓冲数。每个缓冲区都可以使用独立的线程进行处理。"
+"默认：3（CPU 核心数+1，不超过 4）。"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
-msgstr "TV 标准"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
+msgstr "worker 线程数，不能超过缓冲数。默认：2（CPU 核心数，不超过 4）。"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
-msgstr "名称应以 \".h264\" 后缀结束"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
-msgstr "名称应当以 \".jpeg\" 后缀结束。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
-msgstr "名称应以 \".raw\" 后缀结束。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
+msgstr "锁定超时"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
-msgstr "从设备接收数据的缓冲数。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
-msgstr "worker 线程数，不能超过缓冲数。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "超时"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
-msgstr "锁定超时。默认：1."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC 输入"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr "使用设备默认值"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr "使用共享内存接收 H264 帧。默认：禁用。名称应以 \".h264\" 后缀结束"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
-msgstr "使用共享内存接收 H264 帧。默认：禁用。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+"使用共享内存接收 JPEG 帧。默认：禁用。名称应当以 \".jpg\" 或 \".jpeg\" 后缀结束"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
-msgstr "使用共享内存接收 JPEG 帧。默认：禁用。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr "使用共享内存接收 RAW 帧。默认：禁用。名称应以 \".raw\" 后缀结束"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
-msgstr "使用共享内存接收 RAW 帧。默认：禁用。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "用户名"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "详细"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "WWW 文件夹"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr "白平衡"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr "Workers"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "调试"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
+msgstr "默认"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "信息"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
-msgstr "或最后 N 秒内的任意 HTTP 请求。默认：0（禁用）。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "性能"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
-msgstr "单位：秒"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
+msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr "ustreamer"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "详细"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-"µStreamer 是轻量级和非常快速的服务器，用于将 MJPEG 视频从任意 V4L2 设备串流到"
-"网络。"
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "允许环形缓冲区超过这个值的限制"
-
-#~ msgid "Auto"
-#~ msgstr "自动"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "自动禁用 MJPEG 模式"
-
-#~ msgid "Blink"
-#~ msgstr "闪烁"
-
-#~ msgid "Command to run"
-#~ msgstr "运行的命令"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "不要初始化 Linux-UVC 驱动的 dynctrls"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "不要初始化 dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "启用 MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "启用 YUYV 格式"
-
-#~ msgid "Exceed"
-#~ msgstr "超出"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr "保存图片后执行命令。文件名将作为第一个参数传递给命令。"
-
-#~ msgid "File output"
-#~ msgstr "文件输出"
-
-#~ msgid "Folder"
-#~ msgstr "文件夹"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "授予UCI访问luci-app-mjpg-streamer的权限"
-
-#~ msgid "Input plugin"
-#~ msgstr "输入插件"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "图片保存时间间隔"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG 压缩品质"
-
-#~ msgid "Led control"
-#~ msgstr "LED 控制"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "将最新的图片链接到固定文件名"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr "将环缓冲区中的最后一张图片链接到提供的固定命名文件。"
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer(网络摄像机串流)"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "保存的图片数量上限"
-
-#~ msgid "Off"
-#~ msgstr "关"
-
-#~ msgid "On"
-#~ msgstr "开"
-
-#~ msgid "Output plugin"
-#~ msgstr "输出插件"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "环形缓冲区大小"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "图片保存位置"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "设置时间间隔（毫秒）"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr "设置品质（百分比）。此设置会开启 YUYV 格式输出，关闭 MJPEG 输出"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr "mjpg streamer 是一个视频流程序，用于 Linux-UVC 兼容的摄像头"
+msgid "µStreamer"
+msgstr "µStreamer(网络摄像机串流)"

--- a/applications/luci-app-ustreamer/po/zh_Hant/ustreamer.po
+++ b/applications/luci-app-ustreamer/po/zh_Hant/ustreamer.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: luci-app-mjpg-streamer\n"
+"Project-Id-Version: luci-app-ustreamer\n"
 "POT-Creation-Date: 2015-06-11 21:11+0100\n"
-"PO-Revision-Date: 2026-02-13 16:02+0000\n"
-"Last-Translator: EESF-2 <eesf-2@users.noreply.hosted.weblate.org>\n"
+"PO-Revision-Date: 2025-06-19 08:25+0000\n"
+"Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
 "projects/openwrt/luciapplicationsustreamer/zh_Hant/>\n"
 "Language: zh_Hant\n"
@@ -15,592 +15,585 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.16-dev\n"
+"X-Generator: Weblate 5.12.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:247
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:518
+msgid ""
+"A short string identifier to be displayed in the /state handle.<br />"
+"It must satisfy regexp ^[a-zA-Z0-9\./+_-]*$. Default: an empty string"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:509
 msgid "Allow origin"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:132
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:335
 msgid "Allow truncated frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Ask for username and password on connect"
-msgstr "連線時詢問使用者名稱和密碼"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:336
+msgid ""
+"Allows to handle truncated frames. Default: disabled<br />"
+"Useful if the device produces incorrect but still acceptable frames"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:213
-msgid "Authentication required"
-msgstr "需要驗證"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:850
 msgid "Backlight compensation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:437
-msgid "Bitrate"
-msgstr "位元速率"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:458
+msgid "Bind to UNIX domain socket. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:302
+msgid "Bind to this TCP port. Default: 8080"
+msgstr "綁定到此 TCP 連接埠。預設值：8080"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:681
+msgid "Bitrate (kbps)"
+msgstr "位元速率（kbps）"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:768
 msgid "Brightness"
 msgstr "亮度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:158
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:381
 msgid "Buffers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:355
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
+msgid "Capture"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:370
+msgid ""
+"Changing this parameter may increase the performance. Or not.<br />"
+"See kernel documentation. Default: MMAP"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:559
 msgid "Client TTL"
 msgstr "用戶端 TTL"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:389
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
-msgid "Client TTL. Default: 10."
-msgstr "用戶端 TTL。預設: 10。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:512
-msgid "Color effect"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:831
+msgid "Colour effect"
 msgstr "顏色效果"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:480
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
 msgid "Contrast"
 msgstr "對比度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:143
-msgid "DV Timings"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:351
+msgid "DV-timings"
 msgstr "DV 時序"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:356
-msgid "Default: 10."
-msgstr "預設: 10。"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:730
+msgid "Debug"
+msgstr "除錯"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:168
-msgid "Default: 2 (the number of CPU cores (but not more than 4))."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:569
+msgid "Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:161
-msgid "Default: 3 (the number of CPU cores (but not more than 4) + 1)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:560
+msgid "Default: 10 seconds"
+msgstr "預設值：10 秒"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:691
+msgid "Default: 30"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:345
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:378
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:411
-msgid "Default: disabled."
-msgstr "預設: 已停用。"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:99
-msgid "Default: maximum possible."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:682
+msgid "Default: 5000 kbps"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:71
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Default: YUYV"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:358
+msgid "Default: disabled"
+msgstr "預設: 已停用"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:427
+msgid ""
+"Delay before trying to connect to the device again<br />"
+"after an error (timeout for example). Default: 1 second"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:232
+msgid "Desired FPS. Default: maximum possible"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:186
 msgid "Device"
 msgstr "裝置"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:193
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:426
 msgid "Device error delay"
 msgstr "裝置錯誤延遲"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:140
-msgid "Don't re-initialize device on timeout. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:197
+msgid "Device timeout"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
-msgid "Drop frames smaller than this limit"
-msgstr "丟棄小於該尺寸限制的影格"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:347
+msgid "Don't re-initialize device on timeout. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:239
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:486
+msgid ""
+"Don't send identical frames to clients, but no more than specified number."
+"<br />"
+"It can significantly reduce the outgoing traffic, but will increase<br />"
+"the CPU loading. Don't use this option with analog signal sources<br />"
+"or webcams, it's useless. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:417
+msgid ""
+"Drop frames smaller than this limit. Useful if the device<br />"
+"produces small-sized garbage frames. Default: 128 bytes"
+msgstr ""
+"丟棄小於該尺寸限制的影格。如果裝置產生小型垃圾幀，則此設定很有用。預設值：128 位元組"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:485
 msgid "Drop same frames"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:160
-msgid "Each buffer may processed using an independent thread."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:352
 msgid ""
-"Enable DV-timings querying and events processing to automatic resolution "
-"change. Default: disabled."
+"Enable DV-timings querying and events processing to automatic "
+"resolution change<br />Default: disable"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:136
-msgid "Enable R-G-B order swapping: RGB to BGR and vice versa."
-msgstr ""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
+msgid "Enable µStreamer"
+msgstr "啟用 µStreamer"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:45
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:182
 msgid "Enabled"
 msgstr "已啟用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:118
-msgid "Encoder"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:264
+msgid "Еncoder"
 msgstr "編碼器"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:464
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:734
 msgid "Exit on no clients"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:465
-msgid "Exit the program if there have been no stream or sink clients"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:735
+msgid ""
+"Exit the program if there have been no stream or sink clients<br />"
+"or any HTTP requests in the last N seconds. Default: 0 (disabled)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:242
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:472
+msgid "Expecting: file mode, e.g. 640 or 0640"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:757
+msgid "Expecting: number | default"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:764
+msgid "Expecting: number | default | auto"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:499
 msgid "Fake resolution"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:520
-msgid "Flip horizontally"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:859
+msgid "Flip horizontal"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:523
-msgid "Flip vertically"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:868
+msgid "Flip vertical"
 msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:448
+msgid ""
+"Path to dir with static files instead of embedded root index page<br />"
+"Symlinks are not supported for security reasons. Default: disabled"
+msgstr ""
+"指向包含靜態檔案的目錄路徑，而不是嵌入式根索引頁<br />"
+"出於安全考慮，不支援符號連結。預設值：停用"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:357
+msgid "Force TV standard"
+msgstr "Force TV 標準"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Folder that contains the socket"
-msgstr "包含 socket 的資料夾"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
-msgid "Folder that contains webpages"
-msgstr "包含網頁的資料夾"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:104
-msgid "Format"
-msgstr "格式"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:135
-msgid "Format: Swap RGB"
-msgstr "格式: 交換 RGB"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:98
 msgid "Frames per second"
-msgstr "影格每秒"
+msgstr "幀每秒"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:508
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:804
 msgid "Gain"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:492
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:795
 msgid "Gamma"
 msgstr "Gamma"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:41
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
 msgid "General"
 msgstr "一般"
 
 #: applications/luci-app-ustreamer/root/usr/share/rpcd/acl.d/luci-app-ustreamer.json:3
 msgid "Grant UCI access for luci-app-ustreamer"
-msgstr "授予 luci-app-ustreamer 存取 UCI 的權限"
+msgstr "授予luci-app-ustreamer存取UCI的權限"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:443
-msgid "H264 GOP"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:449
-msgid "H264 M2M device"
-msgstr "H264 M2M 裝置"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:438
-msgid "H264 bitrate in Kbps. Default: 5000."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:460
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:676
 msgid "H264 boost"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:60
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:408
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:172
 msgid "H264 sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:415
-msgid "H264 sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:320
+msgid "HTTP basic auth passwd. Default: empty"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:61
-msgid "HTTP output"
-msgstr "HTTP 輸出"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:311
+msgid "HTTP basic auth user. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:169
+msgid "HTTP server"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:292
 msgid "Host"
 msgstr "主機"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:488
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:813
 msgid "Hue"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:153
-msgid "IO method"
-msgstr "IO 方式"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:62
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:174
 msgid "Image control"
 msgstr "影像控制"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:461
-msgid "Increase encoder performance on PiKVM V4. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:749
+msgid "Image default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:82
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:246
+msgid "Image format"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:677
+msgid "Increase encoder performance on PiKVM V4. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:727
+msgid "Info"
+msgstr "資訊"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:215
+msgid "Initial image resolution. Default: 640x480"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
 msgid "Input"
 msgstr "傳入"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:250
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:206
+msgid "Input channel. Default: 0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:517
 msgid "Instance ID"
 msgstr "實例 ID"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:444
-msgid "Interval between keyframes. Default: 30."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:63
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:170
 msgid "JPEG sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:349
-msgid "JPEG sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:690
+msgid "Keyframe interval"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:361
-msgid "JPEG sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:36
+msgid "Lightweight and fast MJPEG-HTTP streamer"
+msgstr "輕量級、快速的 MJPEG-HTTP 串流播放器"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:293
+msgid "Listen on Hostname or IP. Default: 127.0.0.1"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:47
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:718
 msgid "Log level"
 msgstr "日誌等級"
 
 #: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:173
+msgid "Logging"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:402
 msgid "M2M device"
 msgstr "M2M 裝置"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:220
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
+msgid "Min frame size"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:500
+msgid "Override image resolution for the /state. Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:319
 msgid "Password"
 msgstr "密碼"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:450
-msgid "Path to V4L2 M2M encoder device. Default: auto select."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:403
+msgid "Path to V4L2 M2M encoder device. Default: auto select"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:139
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:187
+msgid "Path to V4L2 device. Default: /dev/video0"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:728
+msgid "Performance"
+msgstr "效能"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:346
 msgid "Persistent"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:56
-msgid "Plugin settings"
-msgstr "外掛設定"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:301
 msgid "Port"
 msgstr "連接埠"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:126
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:73
+msgid "Preview"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:280
 msgid "Quality"
 msgstr "品質"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:64
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:375
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:341
+msgid "R-G-B order swap"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:171
 msgid "RAW sink"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:388
-msgid "RAW sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:342
+msgid "RGB to BGR and vice versa. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
-msgid "RAW sink mode"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:577
+msgid "Remove on stop"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:394
-msgid "RAW sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:578
+msgid "Remove shared memory on stop. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:421
-msgid "Remove"
-msgstr "刪除"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:367
-msgid "Remove JPEG sink"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:750
+msgid "Reset all image settings below to default. Unchecked: no change"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:368
-msgid "Remove JPEG sink file on exit"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:400
-msgid "Remove RAW sink"
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:401
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:422
-msgid "Remove shared memory on stop. Default: disabled."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:85
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:214
 msgid "Resolution"
 msgstr "解析度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:516
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:898
 msgid "Rotate"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:484
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:786
 msgid "Saturation"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:252
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:526
 msgid "Server timeout"
 msgstr "伺服器逾時"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:416
-msgid "Set H264 sink permissions (like 777). Default: 660."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:510
+msgid "Set Access-Control-Allow-Origin header. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:350
-msgid "Set JPEG sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:383
-msgid "Set RAW sink permissions (like 777). Default: 660."
-msgstr ""
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:188
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:442
 msgid ""
-"Set the minimum size if the webcam produces small-sized garbage frames. May "
-"happen under low light conditions"
-msgstr "設定無用影格的最小尺寸。光照不足時可能出現"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:127
-msgid "Set the quality in percent."
+"Set TCP_NODELAY flag to the client /stream socket. Only for TCP "
+"socket<br />Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:496
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:477
+msgid "Set UNIX socket file permissions (like 777). Default: disabled"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:551
+msgid "Set sink file permissions. Default: 660"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:281
+msgid ""
+"Set the quality of JPEG encoding: 1 to 100 (best). Default: 80<br />"
+"If HW encoding is used (JPEG source format), attempts to configure<br />"
+"the camera or capture device hardware's internal encoder.<br />"
+"MJPEG will not be recoded to MJPEG to change the quality"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:163
+msgid "Settings"
+msgstr "設定"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:822
 msgid "Sharpness"
 msgstr "銳利度"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:425
-msgid "Sink client TTL"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:550
+msgid "Sink permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:431
-msgid "Sink timeout"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:240
+msgid "Slowdown"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:231
-msgid "Socket"
-msgstr "Socket"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:241
+msgid ""
+"Slowdown capturing to 1 FPS or less when no stream or sink clients are "
+"connected.<br />Useful to reduce CPU consumption. Default: disabled"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:235
-msgid "Socket Permissions"
-msgstr "Socket 權限"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:323
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:144
 msgid "Stream unavailable"
 msgstr "串流不可用"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:202
-msgid "TCP host for this HTTP server"
-msgstr "此 HTTP 伺服器的 TCP 主機"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:208
-msgid "TCP port for this HTTP server"
-msgstr "此 HTTP 伺服器的 TCP 連接埠"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:147
-msgid "TV standard"
-msgstr "TV 標準"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:410
-msgid "The name should end with a suffix \".h264\""
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:441
+msgid "TCP no delay"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:344
-msgid "The name should end with a suffix \".jpeg\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:382
+msgid ""
+"The number of buffers to receive data from the device.<br />"
+"Each buffer may be processed using an independent thread.<br />"
+"Default: 3 (the number of CPU cores (but not more than 4) + 1)"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:377
-msgid "The name should end with a suffix \".raw\"."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:393
+msgid ""
+"The number of worker threads but not more than buffers.<br />"
+"Default: 2 (the number of CPU cores (but not more than 4))"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:159
-msgid "The number of buffers to receive data from the device."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:527
+msgid "Timeout for client connections. Default: 10 seconds"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:167
-msgid "The number of worker threads but not more than buffers."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:198
+msgid "Timeout for device querying. Default: 1 second"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "Timeout"
-msgstr "逾時"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:395
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:432
-msgid "Timeout for lock. Default: 1."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:568
+msgid "Timeout for lock"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:65
-msgid "UVC input"
-msgstr "UVC 輸入"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:473
-msgid "Use device defaults"
-msgstr "使用裝置預設"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:409
-msgid "Use the shared memory to sink H264 frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:467
+msgid "Try to remove old UNIX socket file before binding. Default: disabled"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:343
-msgid "Use the shared memory to sink JPEG frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:457
+msgid "UNIX socket"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:376
-msgid "Use the shared memory to sink RAW frames. Default: disabled."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:476
+msgid "UNIX socket permissions"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:216
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
+msgid "UNIX socket remove old"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:265
+msgid ""
+"Use specified encoder. It may affect the number of workers<br />"
+"<li><kbd>CPU  ──────── </kbd>Software MJPEG encoding (default)</li>"
+"<li><kbd>HW  ───────── </kbd>Use pre-encoded MJPEG frames directly from camera hardware</li>"
+"<li><kbd>M2M-VIDEO  ── </kbd>GPU-accelerated MJPEG encoding using V4L2 M2M video interface</li>"
+"<li><kbd>M2M-IMAGE  ── </kbd>GPU-accelerated JPEG encoding using V4L2 M2M image interface</li>"
+msgstr ""
+""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:635
+msgid ""
+"Use the shared memory to sink H264 frames. Default: disabled<br />"
+"The name should end with a suffix .h264"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:541
+msgid ""
+"Use the shared memory to sink JPEG frames. Default: disabled<br />"
+"The name should end with a suffix .jpg or .jpeg"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:588
+msgid ""
+"Use the shared memory to sink RAW frames. Default: disabled<br />"
+"The name should end with a suffix .raw"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:310
 msgid "Username"
 msgstr "使用者名稱"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:226
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:369
+msgid "V4L2 IO method"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:729
+msgid "Verbose"
+msgstr "詳細"
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:719
+msgid ""
+"Verbosity level of messages from 0 (info) to 3 (debug)<br />"
+"Enabling debugging messages can slow down the program<br />"
+"Default: 0 (info)"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:447
 msgid "WWW folder"
 msgstr "WWW 資料夾"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:504
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:840
 msgid "White balance"
 msgstr "白平衡"
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:166
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:392
 msgid "Workers"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:52
-msgid "debug"
-msgstr "除錯"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:48
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:49
-msgid "info"
-msgstr "資訊"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:466
-msgid "or any HTTP requests in the last N seconds. Default: 0 (disabled)."
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:362
+msgid "default"
 msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:50
-msgid "performance"
-msgstr "效能"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:818
+msgid "number | default | auto"
+msgstr ""
 
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:78
-msgid "units: seconds"
-msgstr "單位: 秒"
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:769
+msgid "number | default | auto. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:778
+msgid "number | default. Blank: no change"
+msgstr ""
+
+#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:841
+msgid "temperature | default | auto. Blank: no change"
+msgstr ""
 
 #: applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json:3
-msgid "ustreamer"
-msgstr "ustreamer"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:51
-msgid "verbose"
-msgstr "詳細"
-
-#: applications/luci-app-ustreamer/htdocs/luci-static/resources/view/ustreamer/ustreamer.js:37
-msgid ""
-"µStreamer is a lightweight and very quick server to stream MJPEG video from "
-"any V4L2 device to the net."
-msgstr ""
-
-#~ msgid "Allow ringbuffer to exceed limit by this amount"
-#~ msgstr "允許環形緩衝區超過這個值的限制"
-
-#~ msgid "Auto"
-#~ msgstr "自動"
-
-#~ msgid "Automatic disabling of MJPEG mode"
-#~ msgstr "自動禁用 MJPEG 模式"
-
-#~ msgid "Blink"
-#~ msgstr "閃爍"
-
-#~ msgid "Command to run"
-#~ msgstr "執行的指令"
-
-#~ msgid "Do not initialize dynctrls of Linux-UVC driver"
-#~ msgstr "不要初始化 Linux-UVC 驅動的 dynctrls"
-
-#~ msgid "Don't initialize dynctrls"
-#~ msgstr "不要初始化 dynctrls"
-
-#~ msgid "Enable MJPG-streamer"
-#~ msgstr "啟用 MJPG-streamer"
-
-#~ msgid "Enable YUYV format"
-#~ msgstr "啟用 YUYV 格式"
-
-#~ msgid "Exceed"
-#~ msgstr "超出"
-
-#~ msgid ""
-#~ "Execute command after saving picture. Mjpg-streamer parses the filename "
-#~ "as first parameter to your script."
-#~ msgstr "儲存圖片後執行指令。檔名將作為第一個參數傳遞給指令。"
-
-#~ msgid "File output"
-#~ msgstr "檔案輸出"
-
-#~ msgid "Folder"
-#~ msgstr "資料夾"
-
-#~ msgid "Grant UCI access for luci-app-mjpg-streamer"
-#~ msgstr "授予 luci-app-mjpg-streamer 存取 UCI 的權限"
-
-#~ msgid "Input plugin"
-#~ msgstr "輸入外掛"
-
-#~ msgid "Interval between saving pictures"
-#~ msgstr "圖片儲存時間間隔"
-
-#~ msgid "JPEG compression quality"
-#~ msgstr "JPEG 壓縮品質"
-
-#~ msgid "Led control"
-#~ msgstr "Led 控制"
-
-#~ msgid "Link newest picture to fixed file name"
-#~ msgstr "將最新的圖片連結到固定的檔案名稱"
-
-#~ msgid "Link the last picture in ringbuffer to fixed named file provided."
-#~ msgstr "將環形緩衝區中的最後一張圖片連結到自訂的固定檔案名稱。"
-
-#~ msgid "MJPG-streamer"
-#~ msgstr "MJPG-streamer"
-
-#~ msgid "Max. number of pictures to hold"
-#~ msgstr "儲存的圖片數量上限"
-
-#~ msgid "Off"
-#~ msgstr "關閉"
-
-#~ msgid "On"
-#~ msgstr "開啟"
-
-#~ msgid "Output plugin"
-#~ msgstr "輸出外掛"
-
-#~ msgid "Ring buffer size"
-#~ msgstr "環形緩衝區大小"
-
-#~ msgid "Set folder to save pictures"
-#~ msgstr "圖片儲存位置"
-
-#~ msgid "Set the interval in millisecond"
-#~ msgstr "設定時間間隔 (毫秒)"
-
-#~ msgid ""
-#~ "Set the quality in percent. This setting activates YUYV format, disables "
-#~ "MJPEG"
-#~ msgstr "設定品質 (百分比) 。此設定會開啟 YUYV 格式輸出，關閉 MJPEG 輸出"
-
-#~ msgid ""
-#~ "mjpg streamer is a streaming application for Linux-UVC compatible webcams"
-#~ msgstr "mjpg streamer 是一個串流應用程式，用於 Linux-UVC 相容的攝像頭"
+msgid "µStreamer"
+msgstr "µStreamer(網路攝影機串流)"

--- a/applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json
+++ b/applications/luci-app-ustreamer/root/usr/share/luci/menu.d/luci-app-ustreamer.json
@@ -1,6 +1,6 @@
 {
 	"admin/services/ustreamer": {
-		"title": "ustreamer",
+		"title": "µStreamer",
 		"action": {
 			"type": "view",
 			"path": "ustreamer/ustreamer"


### PR DESCRIPTION
New features:
- Implement all supported ustreamer features
- Detailed UI text and description based on the program help
- Input validation for all parameters
- Stream preview with link to the stream page
- Dark theme colours for the stream preview
- Bulgarian translation (complete)

Bug fixes:
- Use of `poll.add` inside the `render` function results in a fork bomb
- Repeated use if `setTimeout` results in a fork bomb when the stream is not available (old bug from `luci-app-mjpg-streamer`)

Merge:
- I tried to keep existing translations as much as possible
- All existing features, except `[video_devs]`

Removed:
- `[video_devs]` parameters, this or a similar feature will be implemented once I fully test it, and choose an optimal strategy, with support for multiple video input devices. In order to comlpete work on this feature, I need programatic access to the `configuration name` for each instance:

``` bash
config ustreamer 'configuration_name'
```

Formatting:
- Format code for readability and to fit 80 column where possible

TODO:
Ask the `ustreamer` author whether we should use `0-255` limits for some of the image control parameters. Note: My camera expects `0-255`, while the source code internally accepts int range, but warns when a value is outside the range I have defined. These limits could be standard, in which case we should keep them or dependent on the camera used, in which case we should remove the limits and accept any int value.

Edit: The values for image control varies between camera models, therefore the range is unrestricted.

Note:
Due to a race condition, two instances of the package got created. I put a lot of effort and testing in every single detail, and the other implementation got merged first. All features and translations are merged here, except for `[video_devs]`, which will be reworked later.

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.


-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (mvebu/cortexa9 WRT3200ACM, openwrt main r32847+5-bc8424ab89, Safari 26.2) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:

@systemcrash @hnyman @GeorgeSapkin @mdevaev

![01-Preview](https://github.com/user-attachments/assets/8ee366a4-2d29-499e-aa2b-00be6ede5424)
<img width="720" height="1084" alt="02-General" src="https://github.com/user-attachments/assets/06c02488-0a15-4eb1-9f89-fab5d53ec2eb" />
<img width="704" height="980" alt="03-Capture" src="https://github.com/user-attachments/assets/11942adb-1d35-4d2d-bcbc-6daeab2e0545" />
<img width="704" height="868" alt="04-HTTP-server" src="https://github.com/user-attachments/assets/ab15ab6c-b409-4758-81ef-f5af5f8e1508" />
<img width="612" height="424" alt="05-JPEG-sink" src="https://github.com/user-attachments/assets/8519d6b2-cce7-4cf9-81a1-cf76d45e7909" />
<img width="612" height="424" alt="06-RAW-sink" src="https://github.com/user-attachments/assets/399ad169-c5c1-498f-9307-d8514b01c9f1" />
<img width="612" height="704" alt="07-H264-sink" src="https://github.com/user-attachments/assets/6b874074-825a-4b35-8d09-a2e6fe83ef51" />
![08-Logging](https://github.com/user-attachments/assets/ca5a59c0-d01a-438d-9112-7428025f379b)
<img width="612" height="1032" alt="09-Image-control" src="https://github.com/user-attachments/assets/b6f92841-db37-435c-898f-78fe4e064582" />
