### PR TITLE
luci-theme-*: Remove LuCI from title, material changes

### DIFF
--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -18,7 +18,7 @@
 <html lang="{{ dispatcher.lang }}" {{ darkpref ? `data-darkmode="${darkpref}"` : '' }}>
 	<head>
 		<meta charset="utf-8">
-		<title>{{ striptags(`${boardinfo.hostname + ' | ' ?? '?'}${dispatched?.title ? `${_(dispatched.title)} | ` : ''}`) }} LuCI</title>
+		<title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>
 		{% if (!darkpref): %}
 			<script>
 				var mediaQuery = window.matchMedia('(prefers-color-scheme: dark)'),
@@ -29,7 +29,7 @@
 				setDarkMode(mediaQuery);
 			</script>
 		{% endif %}
-		<meta name="viewport" content="initial-scale=1.0">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="darkreader-lock">
 		<link rel="stylesheet" href="{{ media }}/cascade.css">
 		<link rel="stylesheet" media="only screen and (max-device-width: 854px)" href="{{ media }}/mobile.css" />

--- a/themes/luci-theme-material/ucode/template/themes/material/header.ut
+++ b/themes/luci-theme-material/ucode/template/themes/material/header.ut
@@ -30,14 +30,7 @@
 <html lang="{{ dispatcher.lang }}">
 <head>
 <meta charset="utf-8">
-<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport"/>
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="mobile-web-app-capable" content="yes">
-<meta name="theme-color" content="#09c">
-<meta name="msapplication-tap-highlight" content="no">
-<meta name="msapplication-TileColor" content="#09c">
-<meta name="application-name" content="{{ striptags(`${dispatched ? `${dispatched.title} | ` : ''}${boardinfo.hostname ?? '?'}`) }} | LuCI">
-<meta name="apple-mobile-web-app-title" content="{{ striptags(`${dispatched ? `${dispatched.title} | ` : ''}${boardinfo.hostname ?? '?'}`) }} | LuCI">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="{{ media }}/cascade.css">
 <link rel="icon" href="{{ media }}/logo_48.png" sizes="48x48">
 <link rel="icon" href="{{ media }}/logo.svg" sizes="any">
@@ -46,7 +39,7 @@
 {% endif %}
 <script src="{{ dispatcher.build_url('admin/translations', dispatcher.lang) }}"></script>
 <script src="{{ resource }}/cbi.js"></script>
-<title>{{ striptags(`${boardinfo.hostname + ' | ' ?? '?'}${dispatched?.title ? `${_(dispatched.title)} | ` : ''}`) }} LuCI</title>
+<title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>
 {% if (css): %}
 <style title="text/css">{{ css }}</style>
 {% endif %}

--- a/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut
+++ b/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut
@@ -16,13 +16,12 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="apple-mobile-web-app-capable" content="yes" />
 <link rel="stylesheet" media="screen" href="{{ media }}/cascade.css" />
 <link rel="icon" href="{{ media }}/logo.png" sizes="180x180">
 <link rel="icon" href="{{ media }}/logo.svg" sizes="any">
 <script src="{{ dispatcher.build_url('admin/translations', dispatcher.lang) }}"></script>
 <script src="{{ resource }}/cbi.js"></script>
-<title>{{ striptags(`${boardinfo.hostname + ' | ' ?? '?'}${dispatched?.title ? `${_(dispatched.title)} | ` : ''}`) }} LuCI</title>
+<title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>
 {% if (css): %}
 <style title="text/css">{{ css }}</style>
 {% endif %}

--- a/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
+++ b/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
@@ -28,7 +28,7 @@
 <script src="{{ dispatcher.build_url('admin/translations', dispatcher.lang) }}"></script>
 <script src="{{ resource }}/cbi.js"></script>
 
-<title>{{ striptags(`${boardinfo.hostname + ' | ' ?? '?'}${dispatched?.title ? `${_(dispatched.title)} | ` : ''}`) }} LuCI</title>
+<title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>
 </head>
 <body class="lang_{{ dispatcher.lang }}" data-page="{{ entityencode(join('-', ctx.request_path), true) }}">
 


### PR DESCRIPTION
- Remove `| LuCI` suffix from title tag
- Make material theme zoomable and remove legacy meta tags
- Unify viewport