### PR TITLE
openfortivpn: add password2 parameter to proto

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -8728,6 +8728,7 @@ msgid "Password strength"
 msgstr "قوة كلمة المرور"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "كلمة المرور 2"
 

--- a/modules/luci-base/po/ast/base.po
+++ b/modules/luci-base/po/ast/base.po
@@ -8440,6 +8440,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -8496,6 +8496,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/bn/base.po
+++ b/modules/luci-base/po/bn/base.po
@@ -8431,6 +8431,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -8438,6 +8438,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -8555,6 +8555,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Contrasenya2"
 

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -8913,6 +8913,7 @@ msgid "Password strength"
 msgstr "Odolnost hesla"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Heslo2"
 

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -8732,6 +8732,7 @@ msgid "Password strength"
 msgstr "Adgangskodestyrke"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Adgangskode2"
 

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -8971,6 +8971,7 @@ msgid "Password strength"
 msgstr "Passwortstärke"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Passwort Bestätigung"
 

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -8529,6 +8529,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Password2"
 

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -8984,6 +8984,7 @@ msgid "Password strength"
 msgstr "Seguridad de la contraseña"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Contraseña2"
 

--- a/modules/luci-base/po/fa/base.po
+++ b/modules/luci-base/po/fa/base.po
@@ -8441,6 +8441,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "گذرواژهٔ ۲"
 

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -8590,6 +8590,7 @@ msgid "Password strength"
 msgstr "Salasanan vahvuus"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Salasana2"
 

--- a/modules/luci-base/po/fil/base.po
+++ b/modules/luci-base/po/fil/base.po
@@ -8505,6 +8505,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -8776,6 +8776,7 @@ msgid "Password strength"
 msgstr "Force du mot de passe"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Password2"
 

--- a/modules/luci-base/po/ga/base.po
+++ b/modules/luci-base/po/ga/base.po
@@ -8937,6 +8937,7 @@ msgid "Password strength"
 msgstr "Neart pasfhocal"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Pasfhocal2"
 

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -8459,6 +8459,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -8439,6 +8439,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -8990,6 +8990,7 @@ msgid "Password strength"
 msgstr "Jelszóerősség"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "2. jelszó"
 

--- a/modules/luci-base/po/id/base.po
+++ b/modules/luci-base/po/id/base.po
@@ -8437,6 +8437,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -8863,6 +8863,7 @@ msgid "Password strength"
 msgstr "Complessità della password"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Password2"
 

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -8642,6 +8642,7 @@ msgid "Password strength"
 msgstr "パスワード強度"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "パスワード2"
 

--- a/modules/luci-base/po/ka/base.po
+++ b/modules/luci-base/po/ka/base.po
@@ -8437,6 +8437,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -8599,6 +8599,7 @@ msgid "Password strength"
 msgstr "암호 강도"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "암호2"
 

--- a/modules/luci-base/po/lt/base.po
+++ b/modules/luci-base/po/lt/base.po
@@ -9056,6 +9056,7 @@ msgid "Password strength"
 msgstr "Slaptažodžio stiprumas"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Slaptažodis2"
 

--- a/modules/luci-base/po/lv/base.po
+++ b/modules/luci-base/po/lv/base.po
@@ -8455,6 +8455,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/ml/base.po
+++ b/modules/luci-base/po/ml/base.po
@@ -8431,6 +8431,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -8437,6 +8437,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -8453,6 +8453,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -8511,6 +8511,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -8765,6 +8765,7 @@ msgid "Password strength"
 msgstr "Wachtwoordsterkte"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Wachtwoord2"
 

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -8935,6 +8935,7 @@ msgid "Password strength"
 msgstr "Siła hasła"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Hasło2"
 

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -8918,6 +8918,7 @@ msgid "Password strength"
 msgstr "Força da palavra-passe"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Palavra-passe2"
 

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -8972,6 +8972,7 @@ msgid "Password strength"
 msgstr "Força da senha"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Senha2"
 

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -8845,6 +8845,7 @@ msgid "Password strength"
 msgstr "Puterea parolei"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Parola2"
 

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -9115,6 +9115,7 @@ msgid "Password strength"
 msgstr "Сложность пароля"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Пароль2"
 

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -8601,6 +8601,7 @@ msgid "Password strength"
 msgstr "Sila hesla"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -8471,6 +8471,7 @@ msgid "Password strength"
 msgstr "Lösenordets styrka"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Lösenord2"
 

--- a/modules/luci-base/po/ta/base.po
+++ b/modules/luci-base/po/ta/base.po
@@ -8828,6 +8828,7 @@ msgid "Password strength"
 msgstr "கடவுச்சொல் வலிமை"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "கடவுச்சொல் 2"
 

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -8428,6 +8428,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -8812,6 +8812,7 @@ msgid "Password strength"
 msgstr "Şifre güvenlik seviyesi"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Şifre2"
 

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -8969,6 +8969,7 @@ msgid "Password strength"
 msgstr "Надійність пароля"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Пароль2"
 

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -8437,6 +8437,7 @@ msgid "Password strength"
 msgstr ""
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr ""
 

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -8832,6 +8832,7 @@ msgid "Password strength"
 msgstr "Độ mạnh mật mã"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Mật mã 2"
 

--- a/modules/luci-base/po/yua/base.po
+++ b/modules/luci-base/po/yua/base.po
@@ -8868,6 +8868,7 @@ msgid "Password strength"
 msgstr "Seguridad de la contraseña"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "Contraseña2"
 

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -8662,6 +8662,7 @@ msgid "Password strength"
 msgstr "密码强度"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "密码 2"
 

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -8591,6 +8591,7 @@ msgid "Password strength"
 msgstr "密碼強度"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:149
+#: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openfortivpn.js:109
 msgid "Password2"
 msgstr "密碼 2"
 

--- a/protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js
+++ b/protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js
@@ -103,6 +103,9 @@ return network.registerProtocol('openfortivpn', {
 		o = s.taboption('general', form.Value, 'password', _('Password'));
 		o.password = true;
 
+		o = s.taboption('general', form.Value, 'password2', _('Password2'));
+		o.password = true;
+
 		o = s.taboption('general', form.TextValue, 'user_cert', _('User certificate (PEM encoded)'));
 		o.rows = 10;
 		o.monospace = true;


### PR DESCRIPTION
Introduce password2 new parameter in openfortivpn proto to enable introducing OTP or other DFA necessary for the VPN connection established.Password2 parameter name and coding has been copied from openconnect package.
