### PR TITLE
luci-base: reimplement the add method of CBIJSONConfig

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -154,25 +154,24 @@ const CBIJSONConfig = baseclass.extend({
 	},
 
 	add(config, sectiontype, sectionname) {
-		let num_sections_type = 0;
-		let next_index = 0;
-
+		let max_index = 0;
+	
 		for (const name in this.data) {
-			num_sections_type += (this.data[name]['.type'] == sectiontype);
-			next_index = Math.max(next_index, this.data[name]['.index']);
+			max_index = Math.max(max_index, this.data[name]['.index']);
 		}
-
-		const section_id = sectionname ?? (sectiontype + num_sections_type);
-
+	
+		const next_index = max_index + 1;
+		const section_id = sectionname ?? (sectiontype + next_index);
+	
 		if (!this.data.hasOwnProperty(section_id)) {
 			this.data[section_id] = {
-				'.name': section_id,
-				'.type': sectiontype,
-				'.anonymous': (sectionname == null),
-				'.index': next_index + 1
+			'.name': section_id,
+			'.type': sectiontype,
+			'.anonymous': (sectionname == null),
+			'.index': next_index
 			};
 		}
-
+	
 		return section_id;
 	},
 


### PR DESCRIPTION
This PR fixes a bug in the calculation of `section_id` in the `add` method of `CBIJSONConfig` when using nested sections (subsections).

When using the [JSONMap](https://openwrt.github.io/luci/jsapi/LuCI.form.JSONMap.html), data are retrieved via a JSON file or a custom JS object. Internally, the object is converted into a UCI-like format. Its top-level keys are treated as UCI section types, while the object or array-of-object values are treated as section content.

```
const data = {
  "first_section": [
    {
      "title": "my first section first item"
    },
    {
      "title": "my first section second item"
    },
  ],
  "second_section2": [
    {
      "title": "my second section first item"
    }
  ]
};
```

Section types are stored in the main `data` object with `key:value` pairs (just plain JS object). Keys are generated during [init](https://github.com/openwrt/luci/blob/d2b850b69c8835428828fc8b5c801556763a8d44/modules/luci-base/htdocs/luci-static/resources/form.js#L46) method and stored in a flat structure. Indexing increments globally, regardless of the section type.
```
{
  "first_section0": {
    "title": "my first section first item",
    ".name": "first_section0",
    ".type": "first_section",
    ".anonymous": true,
    ".index": 0
  },
  "first_section1": {
    "title": "my first section second item",
    ".name": "first_section1",
    ".type": "first_section",
    ".anonymous": true,
    ".index": 1
  },
  "second_section2": {
    "title": "my second section first item",
    ".name": "second_section2",
    ".type": "second_section",
    ".anonymous": true,
    ".index": 2
  }
}
```

The problem in the original code occurred when using nested sections, e.g., a `GridSection` inside another `GridSection`. In this case, adding a new section (via the UI "add" button) would compute the wrong `section_id`, causing it to always return the last section instead of creating a new blank one.

```
const formMap = new form.JSONMap(data);
const section = formMap.section(form.GridSection, 'first_section');

section.tab('tab1', _('Tab 1'));
section.tab('tab2', _('Tab 2'));

option = section.taboption('tab1', form.Value, 'title', _('Title in parent Grid'));
option = section.taboption('tab2', form.SectionValue, '_title', form.GridSection, 'second_section');

const subsection = option.subsection;

option = subsection.option(form.Value, 'title', _('Title in nested Grid'));
```

Changes in this PR fixes this problem:

- renamed `next_index` to `max_index` to make its purpose clearer
- `next_index` is now computed by incrementing the `max_index` found in data, regardless of section type
- removed `num_sections_type` as it is no longer used
- the` next_index` value is now used both for creating the `section_id` and as the value of `.index`, ensuring uniqueness
