### PR TITLE
luci-base: implement the move method for CBIJSONConfig

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -186,7 +186,19 @@ const CBIJSONConfig = baseclass.extend({
 	},
 
 	move(config, section_id1, section_id2, after) {
-		return uci.move.apply(this, [config, section_id1, section_id2, after]);
+		const dataArray = Object.values(this.data).sort((a, b) => a['.index'] - b['.index']);
+		
+		const fromIndex = dataArray.findIndex(section => section['.name'] === section_id1);
+		const toIndex = dataArray.findIndex(section => section['.name'] === section_id2);
+		
+		const [itemToMove] = dataArray.splice(fromIndex, 1);
+		dataArray.splice(toIndex, 0, itemToMove);
+		
+		dataArray.forEach((item, index) => {
+			item['.index'] = index;
+		});
+
+		this.data = Object.fromEntries(dataArray.map(item => [item['.name'], item]));
 	}
 });
 


### PR DESCRIPTION
As the title says, the original implementation was missing. Here is the actual implementation. It works correctly with `GridSection` (including nested ones) and handles moving items internally, which is useful when you need to save the data as `JSON` file, not just visualize it via the UI. 

The logic is as follows:

- convert the `data` object into an array
- find the indices for `section_id1` and `section_id2` 
- move the `section_id1` item to the correct position
- recalculate the indices for the entire data object
- convert the array back into an object