### PR TITLE
[25.12] luci-app-pbr: update to 1.2.2-r6

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -6,11 +6,11 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.2.1
-PKG_RELEASE:=87
+PKG_VERSION:=1.2.2
+PKG_RELEASE:=6
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
-LUCI_URL:=https://github.com/stangri/luci-app-pbr/
+LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/
 LUCI_DESCRIPTION:=Provides Web UI for Policy Based Routing Service.
 LUCI_DEPENDS:=+luci-base +jsonfilter +pbr
 

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
@@ -11,10 +11,10 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 24;
+		return 25;
 	},
 	get ReadmeCompat() {
-		return "1.2.1";
+		return "1.2.2";
 	},
 	get URL() {
 		return (
@@ -364,7 +364,7 @@ var status = baseclass.extend({
 					{ class: "cbi-value-title" },
 					_("Service Warnings"),
 				);
-				var text = "";
+				text = "";
 				reply.ubus.warnings.forEach((element) => {
 					if (element.code && warningTable[element.code]) {
 						text += pkg.formatMessage(element.info, warningTable[element.code]);
@@ -373,7 +373,7 @@ var status = baseclass.extend({
 					}
 				});
 				text += _("Warnings encountered, please check the %sREADME%s").format(
-					'<a href="' + pkg.URL + '#WarningMessagesDetails" target="_blank">',
+					'<a href="' + pkg.URL + '#warning-messages-details" target="_blank">',
 					"</a>!<br />",
 				);
 				var warningsText = E("div", { class: "cbi-value-description" }, text);
@@ -522,26 +522,13 @@ var status = baseclass.extend({
 					errorUplinkDown: _(
 						"Uplink/WAN interface is still down, increase value of 'procd_boot_trigger_delay' option",
 					),
-					errorUnexpectedExit: _(
-						"Unexpected exit or service termination: '%s'",
-					),
-					errorNoDownloadWithSecureReload: _(
-						"Policy '%s' refers to URL which can't be downloaded in 'secure_reload' mode",
-					),
-					errorIncompatibleUserFile: _(
-						"Incompatible custom user file detected '%s'",
-					),
-					errorTryFailed: _("Command failed: '%s'"),
-					errorMktempFileCreate: _(
-						"Failed to create temporary file with mktemp mask: '%s'",
-					),
 				};
 				var errorsTitle = E(
 					"label",
 					{ class: "cbi-value-title" },
 					_("Service Errors"),
 				);
-				var text = "";
+				text = "";
 				reply.ubus.errors.forEach((element) => {
 					if (element.code && errorTable[element.code]) {
 						text += pkg.formatMessage(element.info, errorTable[element.code]);
@@ -550,7 +537,7 @@ var status = baseclass.extend({
 					}
 				});
 				text += _("Errors encountered, please check the %sREADME%s").format(
-					'<a href="' + pkg.URL + '#ErrorMessagesDetails" target="_blank">',
+					'<a href="' + pkg.URL + '#error-messages-details" target="_blank">',
 					"</a>!<br />",
 				);
 				var errorsText = E("div", { class: "cbi-value-description" }, text);

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
@@ -6,6 +6,7 @@
 "require rpc";
 "require view";
 "require pbr.status as pbr";
+/* global pbr */
 
 var pkg = pbr.pkg;
 
@@ -52,7 +53,7 @@ return view.extend({
 				"</b>",
 				'<a href="' +
 					pkg.URL +
-					'#ServiceConfigurationSettings" target="_blank">',
+					'#service-configuration-settings" target="_blank">',
 				"</a>",
 				"<br/><br/>"
 			)
@@ -78,7 +79,7 @@ return view.extend({
 			"strict_enforcement",
 			_("Strict enforcement"),
 			_("See the %sREADME%s for details.").format(
-				'<a href="' + pkg.URL + '#StrictEnforcement" target="_blank">',
+				'<a href="' + pkg.URL + '#strict-enforcement" target="_blank">',
 				"</a>"
 			)
 		);
@@ -100,7 +101,7 @@ return view.extend({
 		text += _(
 			"Please check the %sREADME%s before changing this option."
 		).format(
-			'<a href="' + pkg.URL + '#UseResolversSetSupport" target="_blank">',
+			'<a href="' + pkg.URL + '#use-resolvers-set-support" target="_blank">',
 			"</a>"
 		);
 
@@ -144,7 +145,7 @@ return view.extend({
 					"Can be useful if your OpenVPN tunnels have dev option other than tun* or tap* or specific use cases " +
 					"of WireGuard servers. See the %sREADME%s for details."
 			).format(
-				'<a href="' + pkg.URL + '#WireGuardServerUseCases" target="_blank">',
+				'<a href="' + pkg.URL + '#wireguard-server-use-cases" target="_blank">',
 				"</a>"
 			)
 		);
@@ -161,7 +162,7 @@ return view.extend({
 					"have a listen_port defined, are handled automatically, do not add those here." +
 					"See the %sREADME%s for details."
 			).format(
-				'<a href="' + pkg.URL + '#WireGuardServerUseCases" target="_blank">',
+				'<a href="' + pkg.URL + '#wireguard-server-use-cases" target="_blank">',
 				"</a>"
 			)
 		);
@@ -250,7 +251,7 @@ return view.extend({
 			_(
 				"Adds 'ignore' to the list of interfaces for policies. See the %sREADME%s for details."
 			).format(
-				'<a href="' + pkg.URL + '#IgnoreTarget" target="_blank">',
+				'<a href="' + pkg.URL + '#ignore-target" target="_blank">',
 				"</a>"
 			)
 		);
@@ -277,7 +278,7 @@ return view.extend({
 					"addresses/devices/domains and ports can be space separated. Placeholders below represent just " +
 					"the format/syntax and will not be used if fields are left blank. For more information on options, check the %sREADME%s."
 			).format(
-				'<a href="' + pkg.URL + '#PolicyOptions" target="_blank">',
+				'<a href="' + pkg.URL + '#policy-options" target="_blank">',
 				"</a>"
 			)
 		);
@@ -355,7 +356,7 @@ return view.extend({
 				"Name, local address and remote DNS fields are required. Multiple local " +
 					"addresses/devices can be space separated. For more information on options, check the %sREADME%s."
 			).format(
-				'<a href="' + pkg.URL + '#DNSPolicyOptions" target="_blank">',
+				'<a href="' + pkg.URL + '#dns-policy-options" target="_blank">',
 				"</a>"
 			)
 		);
@@ -400,7 +401,7 @@ return view.extend({
 			_(
 				"Set DSCP tags (in range between 1 and 63) for specific interfaces. See the %sREADME%s for details."
 			).format(
-				'<a href="' + pkg.URL + "#DSCPTag-BasedPolicies" + '" target="_blank">',
+				'<a href="' + pkg.URL + "#dscp-tag-based-policies" + '" target="_blank">',
 				"</a>"
 			)
 		);
@@ -423,7 +424,7 @@ return view.extend({
 				"Run the following user files after setting up but before restarting DNSMASQ. " +
 					"See the %sREADME%s for details."
 			).format(
-				'<a href="' + pkg.URL + '#CustomUserFiles" target="_blank">',
+				'<a href="' + pkg.URL + '#custom-user-files" target="_blank">',
 				"</a>"
 			)
 		);

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js
@@ -3,6 +3,7 @@
 "require form";
 "require baseclass";
 "require pbr.status as pbr";
+/* global pbr */
 
 var pkg = pbr.pkg;
 
@@ -14,63 +15,56 @@ return baseclass.extend({
 	},
 
 	render: function (data) {
-		var reply;
-		if (data[0] && data[0][pkg.Name]) {
-			reply = data[0][pkg.Name];
-		} else {
-			reply = {
-				enabled: null,
-				running: null,
-				running_iptables: null,
-				running_nft: null,
-				running_nft_file: null,
-				version: null,
-				gateways: null,
-				errors: [],
-				warnings: [],
-			};
-		}
+		try {
+			var reply = (data[0] && data[0][pkg.Name]) || {};
 
-		var versionText,
-			statusText = "",
-			modeText = "";
-		if (reply.version) {
-			versionText = reply.version;
-			if (reply.running) {
-				statusText = _("Active");
-				if (reply.running_iptables) {
-					modeText = _("iptables mode");
-				} else if (reply.running_nft_file) {
-					modeText = _("fw4 nft file mode");
-				} else if (reply.running_nft) {
-					modeText = _("nft mode");
+			var versionText,
+				statusText = "",
+				modeText = "";
+			if (reply.version) {
+				versionText = reply.version;
+				if (reply.running) {
+					statusText = _("Active");
+					if (reply.running_iptables) {
+						modeText = _("iptables mode");
+					} else if (reply.running_nft_file) {
+						modeText = _("fw4 nft file mode");
+					} else if (reply.running_nft) {
+						modeText = _("nft mode");
+					} else {
+						modeText = _("unknown");
+					}
 				} else {
-					modeText = _("unknown");
+					if (reply.enabled) {
+						statusText = _("Inactive");
+					} else {
+						statusText = _("Inactive (Disabled)");
+					}
 				}
 			} else {
-				if (reply.enabled) {
-					statusText = _("Inactive");
-				} else {
-					statusText = _("Inactive (Disabled)");
-				}
+				versionText = _("Not installed or not found");
 			}
-		} else {
-			versionText = _("Not installed or not found");
+
+			var table = E("table", { class: "table", id: "pbr_status_table" }, [
+				E("tr", { class: "tr table-titles" }, [
+					E("th", { class: "th" }, _("Status")),
+					E("th", { class: "th" }, _("Version")),
+					E("th", { class: "th" }, _("Mode")),
+				]),
+				E("tr", { class: "tr" }, [
+					E("td", { class: "td" }, statusText),
+					E("td", { class: "td" }, versionText),
+					E("td", { class: "td" }, modeText),
+				]),
+			]);
+
+			return table;
+		} catch (e) {
+			return E(
+				"div",
+				{ class: "alert-message warning" },
+				_("Unable to retrieve %s status").format("PBR"),
+			);
 		}
-
-		var table = E("table", { class: "table", id: "pbr_status_table" }, [
-			E("tr", { class: "tr table-titles" }, [
-				E("th", { class: "th" }, _("Status")),
-				E("th", { class: "th" }, _("Version")),
-				E("th", { class: "th" }, _("Mode")),
-			]),
-			E("tr", { class: "tr" }, [
-				E("td", { class: "td" }, statusText),
-				E("td", { class: "td" }, versionText),
-				E("td", { class: "td" }, modeText),
-			]),
-		]);
-
-		return table;
 	},
 });

--- a/applications/luci-app-pbr/po/templates/pbr.pot
+++ b/applications/luci-app-pbr/po/templates/pbr.pot
@@ -10,40 +10,40 @@ msgstr ""
 msgid "%s binary cannot be found"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:48
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:49
 msgid ""
 "%sWARNING:%s Please make sure to check the %sREADME%s before changing "
 "anything in this section! Change any of the settings below with extreme "
 "caution!%s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:40
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:27
 msgid "Active"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:116
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:117
 msgid "AdGuardHome ipset"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:177
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:178
 msgid "Add"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:249
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:250
 msgid "Add Ignore Target"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:251
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:252
 msgid ""
 "Adds 'ignore' to the list of interfaces for policies. See the %sREADME%s for "
 "details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:46
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:47
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:143
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:144
 msgid ""
 "Allows to specify the list of interface names (in lower case) to be "
 "explicitly supported by the service. Can be useful if your OpenVPN tunnels "
@@ -51,7 +51,7 @@ msgid ""
 "servers. See the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:159
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:160
 msgid ""
 "Allows to specify the list of interface names (lower case) to be ignored by "
 "the service. Can be useful for an OpenVPN server running on OpenWrt device. "
@@ -59,20 +59,19 @@ msgid ""
 "automatically, do not add those here.See the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:43
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:44
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:336
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:337
 msgid "Chain"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:493
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:534
 msgid "Command failed: '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:71
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:72
 msgid "Condensed output"
 msgstr ""
 
@@ -80,11 +79,11 @@ msgstr ""
 msgid "Config (%s) validation failure"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:68
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:69
 msgid "Controls both system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:421
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:422
 msgid "Custom User File Includes"
 msgstr ""
 
@@ -92,19 +91,19 @@ msgstr ""
 msgid "Custom user file '%s' not found or empty"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:353
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:354
 msgid "DNS Policies"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:412
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:413
 msgid "DSCP Tag"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:399
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:400
 msgid "DSCP Tagging"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:185
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:186
 msgid "Default ICMP Interface"
 msgstr ""
 
@@ -116,21 +115,21 @@ msgstr ""
 msgid "Default fw4 table '%s' is missing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:663
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:650
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:114
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:134
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:257
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:115
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:135
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:258
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:657
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:644
 msgid "Disabling %s service"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:267
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:268
 msgid "Display these protocols in protocol column in Web UI."
 msgstr ""
 
@@ -140,35 +139,35 @@ msgid ""
 "confdir"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:120
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:121
 msgid "Dnsmasq ipset"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:124
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:125
 msgid "Dnsmasq nft set"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:85
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:86
 msgid "Do not enforce policies when their gateway is down"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:710
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:697
 msgid "Donate to the Project"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:644
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:631
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:135
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:258
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:289
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:367
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:434
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:136
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:259
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:290
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:368
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:435
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:638
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:625
 msgid "Enabling %s service"
 msgstr ""
 
@@ -180,18 +179,17 @@ msgstr ""
 msgid "Errors encountered, please check %s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:552
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:539
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:219
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:220
 msgid ""
 "FW Mask used by the service. High mask is used to avoid conflict with SQM/"
 "QoS. Change with caution together with"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:504
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:536
 msgid "Failed to create temporary file with mktemp mask: '%s'"
 msgstr ""
 
@@ -223,7 +221,7 @@ msgstr ""
 msgid "Failed to set up any gateway"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:186
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:187
 msgid "Force the ICMP protocol interface."
 msgstr ""
 
@@ -231,19 +229,19 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-pbr"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:132
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:133
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:157
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:158
 msgid "Ignored Interfaces"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:52
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:39
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:54
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:41
 msgid "Inactive (Disabled)"
 msgstr ""
 
@@ -252,7 +250,6 @@ msgid "Incompatible DHCP Option 6 for interface %s"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:495
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:532
 msgid "Incompatible custom user file detected '%s'"
 msgstr ""
 
@@ -262,7 +259,7 @@ msgid ""
 "support"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:178
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:179
 msgid "Insert"
 msgstr ""
 
@@ -278,7 +275,7 @@ msgstr ""
 msgid "Installed AdGuardHome (%s) doesn't support 'ipset_file' option."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:343
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:344
 msgid "Interface"
 msgstr ""
 
@@ -305,12 +302,12 @@ msgstr ""
 msgid "Invalid OpenVPN config for '%s' interface"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:295
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:374
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:296
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:375
 msgid "Local addresses / devices"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:301
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:302
 msgid "Local ports"
 msgstr ""
 
@@ -318,16 +315,16 @@ msgstr ""
 msgid "Mismatched IP family between in policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:65
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:52
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:293
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:371
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:294
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:372
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:276
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:277
 msgid ""
 "Name, interface and at least one other field are required. Multiple local "
 "and remote addresses/devices/domains and ports can be space separated. "
@@ -335,7 +332,7 @@ msgid ""
 "fields are left blank. For more information on options, check the %sREADME%s."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:355
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:356
 msgid ""
 "Name, local address and remote DNS fields are required. Multiple local "
 "addresses/devices can be space separated. For more information on options, "
@@ -366,29 +363,29 @@ msgstr ""
 msgid "Netifd setup: required option '%s' is missing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:188
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:189
 msgid "No Change"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:251
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:58
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:45
 msgid "Not installed or not found"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:67
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:68
 msgid "Output verbosity"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:439
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:440
 msgid "Path"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:279
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:718
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:705
 msgid "Please %sdonate%s to support development of this project."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:101
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:102
 msgid "Please check the %sREADME%s before changing this option."
 msgstr ""
 
@@ -413,7 +410,7 @@ msgstr ""
 msgid "Please unset 'src_addr', 'src_port' and 'dest_port' for policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:274
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:275
 msgid "Policies"
 msgstr ""
 
@@ -434,16 +431,15 @@ msgid "Policy '%s' has no source/destination parameters"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:484
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:529
 msgid ""
 "Policy '%s' refers to URL which can't be downloaded in 'secure_reload' mode"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:10
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:11
 msgid "Policy Based Routing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:40
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:41
 msgid "Policy Based Routing - Configuration"
 msgstr ""
 
@@ -455,7 +451,7 @@ msgstr ""
 msgid "Policy Routing"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:319
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:320
 msgid "Protocol"
 msgstr ""
 
@@ -467,19 +463,19 @@ msgstr ""
 msgid "Refer to %sREADME%s for details"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:381
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:382
 msgid "Remote DNS"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:389
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:390
 msgid "Remote DNS Port"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:307
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:308
 msgid "Remote addresses / domains"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:313
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:314
 msgid "Remote ports"
 msgstr ""
 
@@ -509,19 +505,19 @@ msgid ""
 "Resolver set support (%s) requires nftables, but nft binary cannot be found"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:606
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:593
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:600
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:587
 msgid "Restarting %s service"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:174
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:175
 msgid "Rule Create option"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:423
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:424
 msgid ""
 "Run the following user files after setting up but before restarting DNSMASQ. "
 "See the %sREADME%s for details."
@@ -531,24 +527,24 @@ msgstr ""
 msgid "Running"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:80
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:81
 msgid "See the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:175
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:176
 msgid "Select Add for -A/add and Insert for -I/Insert."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:689
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:676
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:542
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:529
 msgid "Service Errors"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:206
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:217
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:207
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:218
 msgid "Service FW Mask"
 msgstr ""
 
@@ -564,7 +560,7 @@ msgstr ""
 msgid "Service Warnings"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:401
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:402
 msgid ""
 "Set DSCP tags (in range between 1 and 63) for specific interfaces. See the "
 "%sREADME%s for details."
@@ -574,33 +570,33 @@ msgstr ""
 msgid "Skipping IPv6 policy '%s' as IPv6 support is disabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:587
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:574
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:581
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:568
 msgid "Starting %s service"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:202
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:203
 msgid ""
 "Starting (Uplink Interface) FW Mark for marks used by the service. High "
 "starting mark is used to avoid conflict with SQM/QoS. Change with caution "
 "together with"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:236
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:237
 msgid ""
 "Starting (Uplink/WAN) ip rules priority used by the pbr service. High "
 "starting priority is used to avoid conflict with other services, this can be "
 "changed by user."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:63
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:50
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:625
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:612
 msgid "Stop"
 msgstr ""
 
@@ -612,27 +608,27 @@ msgstr ""
 msgid "Stopped."
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:619
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:606
 msgid "Stopping %s service"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:79
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:80
 msgid "Strict enforcement"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:86
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:87
 msgid "Strictly enforce policies when their gateway is down"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:141
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:142
 msgid "Supported Interfaces"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:266
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:267
 msgid "Supported Protocols"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:70
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:71
 msgid "Suppress/No output"
 msgstr ""
 
@@ -646,11 +642,11 @@ msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:414
 msgid ""
-"The %s interface not found, you need to set the "
-"'pbr.config.uplink_interface' option"
+"The %s interface not found, you need to set the 'pbr.config."
+"uplink_interface' option"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:96
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:97
 msgid "The %s is not supported on this system."
 msgstr ""
 
@@ -662,7 +658,7 @@ msgstr ""
 msgid "The %s service is currently disabled"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:92
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:93
 msgid "The %s support is unknown."
 msgstr ""
 
@@ -686,8 +682,11 @@ msgstr ""
 msgid "The principal package (pbr) is outdated, please update it"
 msgstr ""
 
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:66
+msgid "Unable to retrieve %s status"
+msgstr ""
+
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:429
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:526
 msgid "Unexpected exit or service termination: '%s'"
 msgstr ""
 
@@ -699,7 +698,7 @@ msgstr ""
 msgid "Unknown entry in policy '%s'"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:549
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:536
 msgid "Unknown error"
 msgstr ""
 
@@ -719,11 +718,11 @@ msgstr ""
 msgid "Unknown warning"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:234
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:235
 msgid "Uplink IP Rules Priority"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:200
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:201
 msgid "Uplink Interface Table FW Mark"
 msgstr ""
 
@@ -743,15 +742,15 @@ msgid ""
 "installed"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:111
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:112
 msgid "Use resolver set support for domains"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:72
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:73
 msgid "Verbose output"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:64
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:51
 msgid "Version"
 msgstr ""
 
@@ -759,7 +758,7 @@ msgstr ""
 msgid "Version %s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:223
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:224
 msgid "WAN Table FW Mark"
 msgstr ""
 
@@ -771,29 +770,29 @@ msgstr ""
 msgid "Warnings encountered, please check the %sREADME%s"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:61
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:62
 msgid "Web UI Configuration"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:328
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:329
 msgid "all"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:237
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:44
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:31
 msgid "fw4 nft file mode"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:235
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:42
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:29
 msgid "iptables mode"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:239
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:46
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:33
 msgid "nft mode"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:48
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/status/include/72_pbr.js:35
 msgid "unknown"
 msgstr ""

--- a/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
+++ b/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
@@ -10,7 +10,7 @@
 # ubus -S call luci.pbr getPlatformSupport '{"name": "pbr" }'
 # ubus -S call luci.pbr getInterfaces '{"name": "pbr" }'
 
-readonly rpcdCompat='24'
+readonly rpcdCompat='25'
 readonly pbrFunctionsFile="${IPKG_INSTROOT}/etc/init.d/pbr"
 if [ -s "$pbrFunctionsFile" ]; then
 # shellcheck source=../../../../../pbr/files/etc/init.d/pbr
@@ -169,7 +169,13 @@ get_platform_support() {
 }
 
 get_supported_interfaces() {
-	_build_ifaces_supported() { is_supported_interface "$1" && ! str_contains "$ifacesSupported" "$1" && ifacesSupported="${ifacesSupported}${1} "; }
+	_build_ifaces_supported() { 
+		# Skip wan6 interface in split WAN scenarios as it shouldn't be a target for policies
+		if is_split_uplink && is_uplink6 "$1"; then
+			return
+		fi
+		is_supported_interface "$1" && ! str_contains "$ifacesSupported" "$1" && ifacesSupported="${ifacesSupported}${1} "
+	}
 	_find_firewall_wan_zone() { [ "$(uci_get 'firewall' "$1" 'name')" = 'wan' ] && firewallWanZone="$1"; }
 	local i
 	local firewallWanZone
@@ -178,6 +184,10 @@ get_supported_interfaces() {
 	config_load 'firewall'
 	config_foreach _find_firewall_wan_zone 'zone'
 	for i in $(uci_get 'firewall' "$firewallWanZone" 'network'); do
+		# Skip wan6 interface in split WAN scenarios as it shouldn't be a target for policies
+		if is_split_uplink && is_uplink6 "$i"; then
+			continue
+		fi
 		is_supported_interface "$i" && ! str_contains "$ifacesSupported" "$i" && ifacesSupported="${ifacesSupported}${i} "
 	done
 	config_load 'network'


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0-rc4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0-rc4

Description:
Update luci-app-pbr from 1.2.1-r87 to 1.2.2-r6.
This release bumps compat to 25, fixes split-uplink WAN6 interface filtering in the rpcd backend, adds error handling to the status overview widget,
normalizes all README anchor links to kebab-case,
and updates the translation template.



---

- **6 files changed**, +90 / -83 lines (net +7)
- **1 commit**: `cc43913` — `luci-app-pbr: update to 1.2.2-r6`

---

- Version bumped from `1.2.1-r87` to `1.2.2-r6`
- URL updated from `github.com/stangri/...` to `github.com/mossdef-org/...`
- No dependency changes

---

`rpcdCompat` bumped from `24` to `25`.

`get_supported_interfaces()` now filters out the
WAN6 interface in split-uplink configurations so
it does not appear as a policy target in the UI.

Two filter points added:

1. **`_build_ifaces_supported()` callback** — When iterating netifd interfaces, skips any interface where `is_split_uplink()` is true and `is_uplink6()` matches. Prevents WAN6 from being added to the supported list.

2. **Firewall zone enumeration loop** — Same check applied when iterating interfaces from the firewall WAN zone. Skips WAN6 via `continue` before the `is_supported_interface` check.

**Impact:** In split-uplink setups (separate
interfaces for IPv4 and IPv6 uplinks), the WAN6
interface no longer appears in the policy target
dropdown. Policies should target the WAN4
interface; IPv6 routing follows automatically.

---

**Compat bumps:**
- `LuciCompat`: `24` → `25`
- `ReadmeCompat`: `1.2.1` → `1.2.2`

**README anchor link fixes (2 locations):**
- `#WarningMessagesDetails` → `#warning-messages-details`
- `#ErrorMessagesDetails` → `#error-messages-details`

**README anchor link fixes (10 locations):**

| Old Anchor                    | New Anchor                    |
|-------------------------------|-------------------------------|
| `#ServiceConfigurationSettings` | `#service-configuration-settings` |
| `#StrictEnforcement`          | `#strict-enforcement`         |
| `#UseResolversSetSupport`     | `#use-resolvers-set-support`  |
| `#WireGuardServerUseCases` (×2) | `#wireguard-server-use-cases` |
| `#IgnoreTarget`               | `#ignore-target`              |
| `#PolicyOptions`              | `#policy-options`             |
| `#DNSPolicyOptions`           | `#dns-policy-options`         |
| `#DSCPTag-BasedPolicies`      | `#dscp-tag-based-policies`    |
| `#CustomUserFiles`            | `#custom-user-files`          |

All anchors converted from PascalCase to
kebab-case to match the current README heading
format.

**Error handling added:**
- Entire `render()` function body wrapped in `try/catch` block
- On exception, renders a yellow warning banner: `"Unable to retrieve PBR status"` instead of crashing the status page
- Prevents unhandled errors from breaking the LuCI overview when PBR data is malformed or unavailable

**Data access simplified:**
- Old: Verbose fallback object with explicit null fields (`enabled: null`, `running: null`, `version: null`, `gateways: null`, etc.)
- New: `var reply = (data[0] && data[0][pkg.Name])` `|| {};` — single-line fallback to empty object
- All downstream property access already handles undefined values, making the verbose defaults unnecessary

**No behavioral changes** to the status table
rendering logic itself (Active/Inactive/Disabled
states, iptables/nft/fw4 mode detection).

---

**1 new string added:**
- `"Unable to retrieve %s status"` — Error fallback message for the status overview widget

**0 strings removed, 0 strings reworded.**

All other changes are source line number updates
from the `72_pbr.js` refactoring. Existing
translations remain valid; translators only need
to handle the 1 new entry.

---

- `rpcdCompat` bumped from `24` to `25`
- `LuciCompat` bumped from `24` to `25`
- Requires companion `pbr` package >= 1.2.2 (for `is_split_uplink()` and `is_uplink6()` functions used by the rpcd backend)
- All existing RPC methods preserved; no new methods added
- All existing UI functionality preserved


(cherry picked from commit b910d04d1b084920596ebf3ab410dcc705f5beae)
