### PR TITLE
[DRAFT] luci-layer2: create a minimal collection for layer-2 devices

### DIFF
--- a/collections/luci-layer2/Makefile
+++ b/collections/luci-layer2/Makefile
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2008-2014 The LuCI Team <luci@lists.subsignal.org>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TYPE:=col
+LUCI_BASENAME:=layer2
+
+LUCI_TITLE:=LuCI interface for layer-2 devices, using Uhttpd (layer-2)
+LUCI_DESCRIPTION:=Layer-2 OpenWrt set including admin support and the default Bootstrap theme
+LUCI_DEPENDS:= \
+	+luci-mod-admin-full \
+	+luci-theme-bootstrap \
+	+rpcd-mod-rrdns \
+	+uhttpd \
+	+uhttpd-mod-ubus
+
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
The current luci-light collection includes many router (layer-3) specific package dependencies that are inappropriate for inclusion on switches and APs.  Let's create an even lighter top-level package to accommodate those devices as they rapidly are becoming more popular.

---
Testers strongly encouraged to grab this and test it out.  Some discussion at https://forum.openwrt.org/t/support-for-rtl838x-based-managed-switches/57875/4178