### PR TITLE
luci-app-pbr: update to 1.2.2-r10

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=8
+PKG_RELEASE:=10
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/

--- a/applications/luci-app-pbr/po/templates/pbr.pot
+++ b/applications/luci-app-pbr/po/templates/pbr.pot
@@ -642,8 +642,8 @@ msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:422
 msgid ""
-"The %s interface not found, you need to set the "
-"'pbr.config.uplink_interface' option"
+"The %s interface not found, you need to set the 'pbr.config."
+"uplink_interface' option"
 msgstr ""
 
 #: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:97


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0-rc4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0-rc4

Description:
* version bump to match principal package

Signed-off-by: Stan Grishin <stangri@melmac.ca>