### PR TITLE
luci-mod-status: fix syslog page with syslog-ng

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/views.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/views.js
@@ -2,6 +2,7 @@
 'require poll';
 'require rpc';
 'require uci';
+'require fs';
 'require ui';
 'require view';
 
@@ -74,21 +75,34 @@ var CBILogreadBox = function(logtag, name) {
 				const tz = uci.get('system', '@system[0]', 'zonename')?.replaceAll(' ', '_');
 				const ts = uci.get('system', '@system[0]', 'clock_timestyle') || 0;
 				const hc = uci.get('system', '@system[0]', 'clock_hourcycle') || 0;
-				const logEntries = await callLogRead(this.fetchMaxRows, false, true);
-				const dateObj = new Intl.DateTimeFormat(undefined, {
-						dateStyle: 'medium',
-						timeStyle: (ts == 0) ? 'long' : 'full',
-						hourCycle: (hc == 0) ? undefined : hc,
-						timeZone: tz
-				});
+				let loglines = await callLogRead(this.fetchMaxRows, false, true)
+					.then((logEntries) => {
+						const dateObj = new Intl.DateTimeFormat(undefined, {
+								dateStyle: 'medium',
+								timeStyle: (ts == 0) ? 'long' : 'full',
+								hourCycle: (hc == 0) ? undefined : hc,
+								timeZone: tz
+						});
 
-				let loglines = logEntries.map(entry => {
-					const time = new Date(entry?.time);
-					const datestr = dateObj.format(time);
-					/* remember to add one since the 'any' entry occupies 1st position i.e. [0] */
-					const facility = this.facilities[Math.floor(entry?.priority / 8) + 1][1] ?? 'unknown';
-					const severity = this.severity[(entry?.priority % 8) + 1][1] ?? 'unknown';
-					return `[${datestr}] ${facility}.${severity}: ${entry?.msg}`;
+						return logEntries.map(entry => {
+							const time = new Date(entry?.time);
+							const datestr = dateObj.format(time);
+							/* remember to add one since the 'any' entry occupies 1st position i.e. [0] */
+							const facility = this.facilities[Math.floor(entry?.priority / 8) + 1][1] ?? 'unknown';
+							const severity = this.severity[(entry?.priority % 8) + 1][1] ?? 'unknown';
+							return `[${datestr}] ${facility}.${severity}: ${entry?.msg}`;
+						});
+					})		
+				.catch(function (){
+					return Promise.all([
+						L.resolveDefault(fs.stat('/usr/libexec/syslog-wrapper'), null),
+					]).then((stat) => {
+						const logger = stat[0]?.path;
+						return fs.exec_direct(logger)
+							.then(logdata => {
+								return logdata.trim().split(/\n/);
+						});
+					});
 				});
 
 				loglines = loglines.filter(line => {

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -35,10 +35,12 @@
 		"read": {
 			"cgi-io": [ "exec" ],
 			"file": {
-				"/bin/dmesg -r": [ "exec" ]
+				"/bin/dmesg -r": [ "exec" ],
+				"/usr/libexec/syslog-wrapper": [ "exec" ]
 			},
 			"ubus": {
-				"log": [ "read" ]
+				"log": [ "read" ],
+				"file": [ "stat" ]
 			}
 		}
 	},


### PR DESCRIPTION
If you have syslog-ng installed instead of logd then syslog page displays errors.
This commit fixes that.

P.S. Every 5 seconds an error is added to the page via ui.addNotification, not sure if we want to fix that in addition? It does not look very elegant... We could just replace the error box with an error message in the log file box?