### PR TITLE
luci-app-firewall: fix custom rules page for fw4

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/custom.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/custom.js
@@ -23,7 +23,7 @@ return view.extend({
 	render(fwuser) {
 		return E([
 			E('h2', _('Firewall - Custom Rules')),
-			E('p', {}, _('Custom rules allow you to execute arbitrary iptables commands which are not otherwise covered by the firewall framework. The commands are executed after each firewall restart, right after the default ruleset has been loaded.')),
+			E('p', {}, _('Custom rules allow you to define custom firewall rules which are not otherwise covered by the firewall framework. On firewall4 systems, these rules must use nftables syntax.'))
 			E('p', {}, E('textarea', { 'style': 'width:100%', 'rows': 25 }, [ fwuser != null ? fwuser : '' ]))
 		]);
 	},

--- a/applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json
+++ b/applications/luci-app-firewall/root/usr/share/luci/menu.d/luci-app-firewall.json
@@ -65,8 +65,5 @@
 			"type": "view",
 			"path": "firewall/custom"
 		},
-		"depends": {
-			"fs": { "/usr/share/fw3/helpers.conf": "file" }
-		}
 	}
 }


### PR DESCRIPTION
This fixes the Custom Rules page on firewall4 systems.

The page is currently hidden by a dependency on
`/usr/share/fw3/helpers.conf`, which is fw3-specific and not needed for firewall4.

This change removes that dependency so the page is shown again on fw4,
and updates the page text to refer to nftables syntax instead of iptables.

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: ipq806x/generic, OpenWrt 24.10.5, Firefox
- [X] Description: This change removes the dependency on `/usr/share/fw3/helpers.conf`, which is fw3-specific and not needed for firewall4, so the page is shown again on fw4, and updates the page text to refer to nftables syntax instead of iptables.

Closes #7428