### PR TITLE
luci-base: network.js: de-dup ifc IPv6 addresses

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -2322,21 +2322,21 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 */
 	getIP6Addrs() {
 		let addrs = this._ubus('ipv6-address');
-		const rv = [];
+		const rv = new Set();
 
 		if (Array.isArray(addrs))
 			for (let a of addrs)
 				if (L.isObject(a))
-					rv.push('%s/%d'.format(a.address, a.mask));
+					rv.add('%s/%d'.format(a.address, a.mask));
 
 		addrs = this._ubus('ipv6-prefix-assignment');
 
 		if (Array.isArray(addrs))
 			for (let a of addrs)
 				if (L.isObject(a) && L.isObject(a['local-address']))
-					rv.push('%s/%d'.format(a['local-address'].address, a['local-address'].mask));
+					rv.add('%s/%d'.format(a['local-address'].address, a['local-address'].mask));
 
-		return rv;
+		return Array.from(rv);
 	},
 
 	/**


### PR DESCRIPTION
De-dup IPv6 addresses before getIP6Addrs() returns an array from "ipv6-address" and "ipv6-prefix-assignment" ubus data.

This can happen when the local address derived from a delegated prefix matches an explicitly configured IPv6 address. Use a Set to ensure that duplicate entries are filtered out before returning the address list.

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Tested on: (ARMv7, OpenWrt 25.12.0, chrome/firefox) :white_check_mark:
- [X] Description: (describe the changes proposed in this PR)
