### PR TITLE
luci-app-upnp: Revision, new access control and UCI options…

### DIFF
--- a/applications/luci-app-upnp/Makefile
+++ b/applications/luci-app-upnp/Makefile
@@ -6,7 +6,7 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=UPnP IGD & PCP/NAT-PMP configuration module | Universal Plug and Play
+LUCI_TITLE:=LuCI support for UPnP IGD & PCP/NAT-PMP service | originally: Universal Plug and Play
 LUCI_DEPENDS:=+luci-base +miniupnpd +rpcd-mod-ucode
 
 PKG_LICENSE:=Apache-2.0

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -70,15 +70,19 @@ return baseclass.extend({
 				rule.proto,
 				expires_str,
 				'%h'.format(rule.descr),
-				E('button', {
+				rule.num != '0' ? E('button', {
 					'class': 'btn cbi-button-remove',
 					'click': L.bind(handleDelRule, this, rule.num),
 					'title': _('Delete')
+				}, [_('Delete')]) : E('button', {
+					'class': 'btn cbi-button-remove',
+					'title': _('Not yet deletable; UPnP IGDv2 IPv6 port maps expire sooner, have no description'),
+					'style': 'cursor: not-allowed'
 				}, [_('Delete')])
 			];
 		});
 
-		cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
+		cbi_update_table(table, rows, E('em', _('There are no active IPv4/IPv6 port maps')));
 
 		return table;
 	}

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -7,14 +7,14 @@
 const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',
-	expect: {  }
+	expect: {}
 });
 
 const callUpnpDeleteRule = rpc.declare({
 	object: 'luci.upnp',
 	method: 'delete_rule',
-	params: [ 'token' ],
-	expect: { result : "OK" },
+	params: ['token'],
+	expect: { result: 'OK' },
 });
 
 function handleDelRule(num, ev) {
@@ -35,23 +35,23 @@ return baseclass.extend({
 	},
 
 	render: function(data) {
-		var table = E('table', { 'class': 'table', 'id': 'upnp_status_table' }, [
+		const table = E('table', { 'class': 'table', 'id': 'upnp_status_table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
-				E('th', { 'class': 'th' }, _('Client Name')),
-				E('th', { 'class': 'th' }, _('Client Address')),
-				E('th', { 'class': 'th' }, _('Client Port')),
-				E('th', { 'class': 'th' }, _('External Port')),
+				E('th', { 'class': 'th' }, _('Hostname')),
+				E('th', { 'class': 'th' }, _('IP address')),
+				E('th', { 'class': 'th' }, _('Port')),
+				E('th', { 'class': 'th' }, _('External port')),
 				E('th', { 'class': 'th' }, _('Protocol')),
 				E('th', { 'class': 'th right' }, _('Expires')),
-				E('th', { 'class': 'th' }, _('Description')),
+				E('th', { 'class': 'th' }, _('Added via / description')),
 				E('th', { 'class': 'th cbi-section-actions' }, '')
 			])
 		]);
 
-		var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
+		const rules = Array.isArray(data[0].rules) ? data[0].rules : [];
 
-		var rows = rules.map(function(rule) {
-			const padnum = (num, length) => num.toString().padStart(length, "0");
+		const rows = rules.map(function(rule) {
+			const padnum = (num, length) => num.toString().padStart(length, '0');
 			const expires_sec = rule?.expires || 0;
 			const hour = Math.floor(expires_sec / 3600);
 			const minute = Math.floor((expires_sec % 3600) / 60);
@@ -72,8 +72,9 @@ return baseclass.extend({
 				'%h'.format(rule.descr),
 				E('button', {
 					'class': 'btn cbi-button-remove',
-					'click': L.bind(handleDelRule, this, rule.num)
-				}, [ _('Delete') ])
+					'click': L.bind(handleDelRule, this, rule.num),
+					'title': _('Delete')
+				}, [_('Delete')])
 			];
 		});
 

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -147,6 +147,7 @@ return view.extend({
 		s = m.section(form.NamedSection, 'settings', 'upnpd', _('Service Settings'));
 		s.addremove = false;
 		s.tab('setup', _('Service Setup'));
+		s.tab('access_control', _('Access Control'));
 		s.tab('advanced', _('Advanced Settings'));
 		s.tab('igd', _('UPnP IGD Adjustments'));
 
@@ -161,6 +162,18 @@ return view.extend({
 		o.default = 'all';
 		o.widget = 'radio';
 
+		o = s.taboption('setup', widgets.NetworkSelect, 'internal_iface', _('Enable networks'),
+			_('Select local/internal (LAN) network interfaces to enable the service for'));
+		o.nocreate = true;
+		o.multiple = true;
+		o.rmempty = false;
+		o.filter = function(section_id, value) {
+			return (value == 'wan' || value == 'wan6') ? '' : value;
+		};
+		o.write = function(section_id, formvalue) {
+			uci.set('upnpd', section_id, 'internal_iface', Array.isArray(formvalue) ? formvalue.join(' ') : formvalue);
+		};
+
 		o = s.taboption('setup', form.ListValue, 'upnp_igd_compat', _('UPnP IGD compatibility'),
 			_('Set compatibility mode (act as device) to workaround IGDv2-incompatible clients; %s are known to only work with %s (or) <br />Emulate/report a specific/different device to workaround/support/handle/bypass/assist/mitigate... (Alternative text welcome)').format('Sony PS, Activision CoD…', 'IGDv1'));
 		o.value('igdv1', _('IGDv1 (IPv4 only)'));
@@ -168,6 +181,35 @@ return view.extend({
 		o.depends('enable_protocols', 'upnp-igd');
 		o.depends('enable_protocols', 'all');
 		o.retain = true;
+
+		o = s.taboption('access_control', form.ListValue, 'access_defaults', _('Access defaults'),
+			_('Set access control defaults for ports that all devices can map'));
+		o.value('', _('None / accept extra ports only'));
+		o.value('accept-high-ports', _('Accept ports >= 1024'));
+		o.value('accept-web+high-ports', _('Accept HTTP/HTTPS + ports >= 1024'));
+		o.value('accept-web-ports', _('Accept HTTP/HTTPS ports'));
+		o.value('accept-all-ports', _('Accept all ports'));
+
+		o = s.taboption('access_control', form.Value, 'accept_ports', _('Accept extra ports'));
+		o.datatype = 'list(portrange)';
+
+		o = s.taboption('access_control', form.Value, 'reject_ports', _('Reject ports'),
+			_('Reject unsafe/insecure/risky FTP/Telnet/DCE/NetBIOS/SMB/RDP ports by default; overrides other settings; use %s for none').format('<code>0</code>'));
+		o.datatype = 'list(portrange)';
+		o.placeholder = '21 23 135 137-139 445 3389';
+		o.modalonly = true;
+
+		o = s.taboption('access_control', form.Flag, 'check_acl', _('Check ACL'),
+			_('Extend or override access defaults by device-specific permissions using the access control list (ACL)') + '<br />' +
+			_('Sequence:') + ' 1. ' + _('Reject ports') + ', 2. ' + _('ACL entries (if checked)') + ', 3. ' + _('Access defaults') + ', 4. ' + _('Accept extra ports'));
+		o.default = '1';
+		o.onchange = function(ev, section_id, value) {
+			let acl = document.getElementById('cbi-upnpd-acl_entry');
+			value == 0 ? acl.style.display = 'none' : acl.style.display = 'block';
+		};
+
+		s.taboption('access_control', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'),
+			_('IPv6 is currently always accepted unless disabled'));
 
 		o = s.taboption('advanced', form.RichListValue, 'allow_cgnat', _('Allow %s/%s', 'Allow %s/%s (%s = CGNAT, %s = STUN)')
 			.format('<a href="https://en.wikipedia.org/wiki/Carrier-grade_NAT" target="_blank" rel="noreferrer"><abbr title="Carrier-grade NAT">CGNAT</abbr></a>',
@@ -198,8 +240,6 @@ return view.extend({
 		o.value('1', _('Enabled'));
 		o.value('upnp-igd', _('Enabled') + ' (' + _('UPnP IGD only') + ')');
 		o.value('pcp', _('Enabled') + ' (' + _('PCP only') + ')');
-
-		s.taboption('advanced', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'));
 
 		o = s.taboption('advanced', form.Flag, 'system_uptime', _('Report system instead of service uptime'));
 		o.default = '1';
@@ -281,72 +321,16 @@ return view.extend({
 		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
-		s = m.section(form.GridSection, 'internal_network', '<h5>' + _('Enable Networks / Access Control') + '</h5>',
-			_('Select local/internal (LAN) network interfaces to enable the service for.') + ' ' +
-			_('Set access control defaults for ports that all devices on a network can map.') + ' ' +
-			_('IPv6 is currently always accepted unless disabled. (Alternative text welcome)'));
-		s.anonymous = true;
-		s.addremove = true;
-		s.cloneable = true;
-		s.sortable = true;
-		s.nodescriptions = true;
-		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit Network Access Control Settings');
-
-		o = s.option(widgets.NetworkSelect, 'interface', _('Internal network'),
-			_('Select the local/internal (LAN) network interface to enable the service for'));
-		o.nocreate = true;
-		o.editable = true;
-		o.rmempty = false;
-		o.retain = true;
-		o.filter = function(section_id, value) {
-			return (value == 'wan' || value == 'wan6') ? '' : value;
-		};
-
-		o = s.option(form.ListValue, 'access_defaults', _('Access defaults'),
-			_('Set access control defaults for ports that all devices on the network can map'));
-		o.value('', _('None / accept extra ports only'));
-		o.value('accept-high-ports', _('Accept ports >= 1024'));
-		o.value('accept-web+high-ports', _('Accept HTTP/HTTPS + ports >= 1024'));
-		o.value('accept-web-ports', _('Accept HTTP/HTTPS ports'));
-		o.value('accept-all-ports', _('Accept all ports'));
-		o.editable = true;
-		o.retain = true;
-
-		o = s.option(form.Value, 'accept_ports', _('Accept extra ports'));
-		o.datatype = 'list(portrange)';
-		o.retain = true;
-
-		o = s.option(form.Value, 'reject_ports', _('Reject ports'),
-			_('Reject unsafe/insecure/risky FTP/Telnet/DCE/NetBIOS/SMB/RDP ports on the network by default; overrides other settings; use %s for none').format('<code>0</code>'));
-		o.datatype = 'list(portrange)';
-		o.placeholder = '21 23 135 137-139 445 3389';
-		o.modalonly = true;
-		o.retain = true;
-
-		o = s.option(form.Flag, 'check_acl', _('Check ACL'),
-			_('Extend or override access defaults by device-specific permissions using the access control list (ACL)') + '<br />' +
-			_('Sequence:') + ' 1. ' + _('Reject ports') + ', 2. ' + _('ACL entries (if checked)') + ', 3. ' + _('Access defaults') + ', 4. ' + _('Accept extra ports'));
-		o.default = '1';
-		o.editable = true;
-		o.retain = true;
-
 		s = m.section(form.GridSection, 'acl_entry', '<h5>' + _('Access Control List') + '</h5>',
 			_('The access control list (ACL) specifies which IP addresses and ports can be mapped.') + ' ' +
-			_('ACL entries are checked in order, then rejected if not matched and not accepted by access defaults. (should be part of extra tab)'));
+			_('ACL entries are checked in order, then rejected if not matched and not accepted by access defaults. (To do: should be part of access control tab)'));
 		s.anonymous = true;
 		s.addremove = true;
 		s.cloneable = true;
 		s.sortable = true;
 		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit ACL Entry');
-		// To do: ACL part of extra tab with dependency on option as immediately, and network section part of service setup tab
-		let acl_used = false;
-		for (let ifnr = 0; uci.get('upnpd', `@internal_network[${ifnr}]`, 'interface'); ifnr++) {
-			if (uci.get('upnpd', `@internal_network[${ifnr}]`, 'check_acl') != '0') {
-				acl_used = true;
-				break;
-			}
-		}
-		s.disable = !acl_used;
+		// To do: ACL part of access control tab and hide (or dependency on option) instead of disable as immediately, and to not break onchange function
+		s.disable = uci.get('upnpd', 'settings', 'check_acl') == '0';
 
 		o = s.option(form.Value, 'comment', _('Comment'));
 		o.default = _('unspecified');

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -322,11 +322,14 @@ return view.extend({
 		o.editable = true;
 		o.retain = true;
 
-		s = m.section(form.GridSection, 'perm_rule', _('Service Access Control List'),
-			_('ACL specify which client addresses and ports can be mapped, IPv6 always allowed.'));
+		s = m.section(form.GridSection, 'acl_entry', '<h5>' + _('Access Control List') + '</h5>',
+			_('The access control list (ACL) specifies which IP addresses and ports can be mapped.') + ' ' +
+			_('ACL entries are checked in order, then rejected if not matched and not accepted by access defaults. (should be part of extra tab)'));
 		s.anonymous = true;
 		s.addremove = true;
+		s.cloneable = true;
 		s.sortable = true;
+		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit ACL Entry');
 		// To do: ACL part of extra tab with dependency on option as immediately, and network section part of service setup tab
 		let acl_used = false;
 		for (let ifnr = 0; uci.get('upnpd', `@internal_network[${ifnr}]`, 'interface'); ifnr++) {
@@ -337,23 +340,46 @@ return view.extend({
 		}
 		s.disable = !acl_used;
 
-		s.option(form.Value, 'comment', _('Comment'));
+		o = s.option(form.Value, 'comment', _('Comment'));
+		o.default = _('unspecified');
 
 		o = s.option(form.Value, 'int_addr', _('IP address'));
 		o.datatype = 'ip4addr';
-		o.placeholder = '0.0.0.0/0';
+		o.rmempty = false;
+		o.editable = true;
+		o.retain = true;
+		o.modalonly = false;
 
-		o = s.option(form.Value, 'int_ports', _('Port'));
-		o.datatype = 'portrange';
-		o.placeholder = '1-65535';
+		o = s.option(form.Value, 'int_addr', _('IP address'),
+			_('Enter device\'s IPv4 address, or an address and netmask'));
+		o.datatype = 'ip4addr';
+		o.rmempty = false;
+		o.retain = true;
+		o.modalonly = true;
 
-		o = s.option(form.Value, 'ext_ports', _('External port'));
+		o = s.option(form.Value, 'int_port', _('Port'));
 		o.datatype = 'portrange';
-		o.placeholder = '1-65535';
+		o.placeholder = '1-65535 (' + _('any port') + ')';
+		o.editable = true;
+		o.retain = true;
+
+		o = s.option(form.Value, 'ext_port', _('External port'));
+		o.datatype = 'portrange';
+		o.placeholder = '1-65535 (' + _('any port') + ')';
+		o.editable = true;
+		o.retain = true;
+
+		o = s.option(form.Value, 'descr_filter', _('Description filter'),
+			_('Regular expression to check description of UPnP IGD IPv4 port maps'));
+		o.placeholder = '.* (' + _('any description') + ')';
+		o.modalonly = true;
 
 		o = s.option(form.ListValue, 'action', _('Action'));
-		o.value('allow', _('Allow'));
-		o.value('deny', _('Deny'));
+		o.value('accept', _('Accept'));
+		o.value('reject', _('Reject'));
+		o.value('disabled', _('Disabled'));
+		o.editable = true;
+		o.retain = true;
 
 		return m.render().then(L.bind(function(m, nodes) {
 			if (uci.get('upnpd', 'settings', 'enabled') != '0') {

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -85,16 +85,16 @@ return view.extend({
 				'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols/service enable permitted devices on local networks to autonomously set up IPv4/IPv6 port maps/forwards on this router.')
 			.format(protocols)
 		);
-		if (!uci.get('upnpd', 'config')) {
+		if (!uci.get('upnpd', 'settings')) {
 			ui.addNotification(null, E('div', '<h4>' + _('No suitable configuration was found!') + '</h4><p>' +
-				_('No suitable config (LuCI app %s) found in %s. A related package update (daemon or LuCI app) may be missing.').format('v1.0', '<code>/etc/config/upnpd</code>') + '<br />' +
+				_('No suitable config (LuCI app %s) found in %s. A related package update (daemon or LuCI app) may be missing.').format('v2.0', '<code>/etc/config/upnpd</code>') + '<br />' +
 				_('Use the software package manager, update lists, and install the related update. Config is migrated with the daemon package update.') + '</p>' +
 				'<a class="btn" href="/cgi-bin/luci/admin/system/package-manager?query=UPnP%20IGD%20&amp;%20PCP/NAT-PMP">' + _('Go to package manager…') + '</a>'), 'warning');
 			m.readonly = true;
 		}
 
 		s = m.section(form.GridSection, '_active_rules');
-		s.disable = uci.get('upnpd', 'config', 'enabled') == '0';
+		s.disable = uci.get('upnpd', 'settings', 'enabled') == '0';
 
 		s.render = L.bind(function(view, section_id) {
 			const table = E('table', { 'class': 'table cbi-section-table', 'id': 'upnp_status_table' }, [
@@ -136,7 +136,7 @@ return view.extend({
 			]);
 		}, o, this);
 
-		s = m.section(form.NamedSection, 'config', 'upnpd', _('Service Settings'));
+		s = m.section(form.NamedSection, 'settings', 'upnpd', _('Service Settings'));
 		s.addremove = false;
 		s.tab('setup', _('Service Setup'));
 		s.tab('advanced', _('Advanced Settings'));
@@ -356,7 +356,7 @@ return view.extend({
 		o.value('deny', _('Deny'));
 
 		return m.render().then(L.bind(function(m, nodes) {
-			if (uci.get('upnpd', 'config', 'enabled') != '0') {
+			if (uci.get('upnpd', 'settings', 'enabled') != '0') {
 				poll.add(L.bind(function() {
 					return Promise.all([
 						callUpnpGetStatus()

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -138,6 +138,7 @@ return view.extend({
 		s.addremove = false;
 		s.tab('setup', _('Service Setup'));
 		s.tab('advanced', _('Advanced Settings'));
+		s.tab('igd', _('UPnP IGD Adjustments'));
 
 		o = s.taboption('setup', form.Flag, 'enabled', _('Enable service'),
 			_('Enable the autonomous port mapping service'));
@@ -149,23 +150,13 @@ return view.extend({
 		o = s.taboption('setup', form.Flag, 'enable_natpmp', _('Enable PCP/NAT-PMP protocols'));
 		o.default = '1';
 
-		s.taboption('setup', form.Flag, 'ext_allow_private_ipv4', _('Allow private IPv4'),
+		s.taboption('advanced', form.Flag, 'ext_allow_private_ipv4', _('Allow private IPv4'),
 			_('Enable forwarding for private/reserved IPv4 address'));
 
 		o = s.taboption('setup', form.Flag, 'igdv1', _('UPnP IGDv1 compatibility mode'),
 			_('Advertise as IGDv1 (IPv4 only) device instead of IGDv2'));
 		o.default = '1';
 		o.rmempty = false;
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
-		o = s.taboption('setup', form.Value, 'download', _('Download speed'),
-			_('Report maximum download speed in kByte/s'));
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
-		o = s.taboption('setup', form.Value, 'upload', _('Upload speed'),
-			_('Report maximum upload speed in kByte/s'));
 		o.depends('enable_upnp', '1');
 		o.retain = true;
 
@@ -192,40 +183,6 @@ return view.extend({
 
 		s.taboption('advanced', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'));
 
-		o = s.taboption('advanced', form.Value, 'notify_interval', _('Notify interval'),
-			_('A 900 s interval sends %s announcements with the minimum %s header',
-				'A 900 s interval sends %s (%s = SSDP) announcements with the minimum %s (%s = Cache-Control: max-age=1800) header')
-			.format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>', '<code>Cache-Control: max-age=1800</code>'));
-		o.datatype = 'min(900)';
-		o.placeholder = '900';
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
-		o = s.taboption('advanced', form.Value, 'port', _('SOAP/HTTP port'));
-		o.datatype = 'port';
-		o.placeholder = '5000';
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
-		o = s.taboption('advanced', form.Value, 'presentation_url', _('Router/presentation URL'),
-			_('Report custom router web interface URL'));
-		o.placeholder = 'http://192.168.1.1/';
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
-		o = s.taboption('advanced', form.Value, 'uuid', _('Device UUID'));
-		// o.depends('enable_upnp', '1');
-		o.depends('keep-translation', 'to-disable-as-rare-use');
-		o.retain = true;
-
-		o = s.taboption('advanced', form.Value, 'model_number', _('Announced model number'));
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
-		o = s.taboption('advanced', form.Value, 'serial_number', _('Announced serial number'));
-		o.depends('enable_upnp', '1');
-		o.retain = true;
-
 		o = s.taboption('advanced', form.Flag, 'system_uptime', _('Report system instead of service uptime'));
 		o.default = '1';
 		o.depends('keep-translation', 'to-disable-as-rare-use');
@@ -236,6 +193,50 @@ return view.extend({
 
 		o = s.taboption('advanced', form.Value, 'upnp_lease_file', _('Service lease file'));
 		o.depends('keep-translation', 'to-disable-as-rare-use');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'download', _('Download speed'),
+			_('Report maximum download speed in kByte/s'));
+		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'upload', _('Upload speed'),
+			_('Report maximum upload speed in kByte/s'));
+		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'model_number', _('Announced model number'));
+		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'serial_number', _('Announced serial number'));
+		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'presentation_url', _('Router/presentation URL'),
+			_('Report custom router web interface URL'));
+		o.placeholder = 'http://192.168.1.1/';
+		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'uuid', _('Device UUID'));
+		// o.depends('enable_upnp', '1');
+		o.depends('keep-translation', 'to-disable-as-rare-use');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'port', _('SOAP/HTTP port'));
+		o.datatype = 'port';
+		o.placeholder = '5000';
+		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'notify_interval', _('Notify interval'),
+			_('A 900 s interval sends %s announcements with the minimum %s header',
+				'A 900 s interval sends %s (%s = SSDP) announcements with the minimum %s (%s = Cache-Control: max-age=1800) header')
+			.format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>', '<code>Cache-Control: max-age=1800</code>'));
+		o.datatype = 'min(900)';
+		o.placeholder = '900';
+		o.depends('enable_upnp', '1');
 		o.retain = true;
 
 		s = m.section(form.GridSection, 'perm_rule', _('Service Access Control List'),

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -3,20 +3,21 @@
 'require dom';
 'require poll';
 'require uci';
+'require ui';
 'require rpc';
 'require form';
 
 const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',
-	expect: {  }
+	expect: {}
 });
 
 const callUpnpDeleteRule = rpc.declare({
 	object: 'luci.upnp',
 	method: 'delete_rule',
-	params: [ 'token' ],
-	expect: { result : "OK" },
+	params: ['token'],
+	expect: { result: 'OK' },
 });
 
 function handleDelRule(num, ev) {
@@ -37,10 +38,10 @@ return view.extend({
 
 	poll_status: function(nodes, data) {
 
-		var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
+		const rules = Array.isArray(data[0].rules) ? data[0].rules : [];
 
-		var rows = rules.map(function(rule) {
-			const padnum = (num, length) => num.toString().padStart(length, "0");
+		const rows = rules.map(function(rule) {
+			const padnum = (num, length) => num.toString().padStart(length, '0');
 			const expires_sec = rule?.expires || 0;
 			const hour = Math.floor(expires_sec / 3600);
 			const minute = Math.floor((expires_sec % 3600) / 60);
@@ -61,8 +62,9 @@ return view.extend({
 				'%h'.format(rule.descr),
 				E('button', {
 					'class': 'btn cbi-button-remove',
-					'click': L.bind(handleDelRule, this, rule.num)
-				}, [ _('Delete') ])
+					'click': L.bind(handleDelRule, this, rule.num),
+					'title': _('Delete')
+				}, [_('Delete')])
 			];
 		});
 
@@ -73,53 +75,63 @@ return view.extend({
 
 		let m, s, o;
 
-		var protocols = '%s & %s/%s'.format(
+		const protocols = _('%s & %s/%s', '%s & %s/%s (%s = UPnP IGD, %s = PCP, %s = NAT-PMP)').format(
 			'<a href="https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol" target="_blank" rel="noreferrer"><abbr title="UPnP Internet Gateway Device (Control Protocol)">UPnP IGD</abbr></a>',
 			'<a href="https://en.wikipedia.org/wiki/Port_Control_Protocol" target="_blank" rel="noreferrer"><abbr title="Port Control Protocol">PCP</abbr></a>',
 			'<a href="https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol" target="_blank" rel="noreferrer"><abbr title="NAT Port Mapping Protocol">NAT-PMP</abbr></a>');
-		m = new form.Map('upnpd', [_('UPnP IGD & PCP/NAT-PMP Service')],
+		m = new form.Map('upnpd', _('UPnP IGD & PCP/NAT-PMP Service'),
 			_('The %s protocols allow clients on the local network to configure port maps/forwards on the router autonomously.',
 				'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local network to configure port maps/forwards on the router autonomously.')
-				.format(protocols)
+			.format(protocols)
 		);
+		if (!uci.get('upnpd', 'config')) {
+			ui.addNotification(null, E('div', '<h4>' + _('No suitable configuration was found!') + '</h4><p>' +
+				_('No suitable config (LuCI app %s) found in %s. A related package update (daemon or LuCI app) may be missing.').format('v1.0', '<code>/etc/config/upnpd</code>') + '<br />' +
+				_('Use the software package manager, update lists, and install the related update. Config is migrated with the daemon package update.') + '</p>' +
+				'<a class="btn" href="/cgi-bin/luci/admin/system/package-manager?query=UPnP%20IGD%20&amp;%20PCP/NAT-PMP">' + _('Go to package manager…') + '</a>'), 'warning');
+			m.readonly = true;
+		}
 
 		s = m.section(form.GridSection, '_active_rules');
 
 		s.render = L.bind(function(view, section_id) {
-			var table = E('table', { 'class': 'table cbi-section-table', 'id': 'upnp_status_table' }, [
+			const table = E('table', { 'class': 'table cbi-section-table', 'id': 'upnp_status_table' }, [
 				E('tr', { 'class': 'tr table-titles' }, [
-					E('th', { 'class': 'th' }, _('Client Name')),
-					E('th', { 'class': 'th' }, _('Client Address')),
-					E('th', { 'class': 'th' }, _('Client Port')),
-					E('th', { 'class': 'th' }, _('External Port')),
+					E('th', { 'class': 'th' }, _('Hostname')),
+					E('th', { 'class': 'th' }, _('IP address')),
+					E('th', { 'class': 'th' }, _('Port')),
+					E('th', { 'class': 'th' }, _('External port')),
 					E('th', { 'class': 'th' }, _('Protocol')),
 					E('th', { 'class': 'th right' }, _('Expires')),
-					E('th', { 'class': 'th' }, _('Description')),
+					E('th', { 'class': 'th' }, _('Added via / description')),
 					E('th', { 'class': 'th cbi-section-actions' }, '')
 				])
 			]);
 
-			var rules = Array.isArray(data[0].rules) ? data[0].rules : [];
+			const rules = Array.isArray(data[0].rules) ? data[0].rules : [];
 
-			var rows = rules.map(function(rule) {
+			const rows = rules.map(function(rule) {
 				return [
 					rule.host_hint || _('Unknown'),
 					rule.intaddr,
 					rule.intport,
 					rule.extport,
 					rule.proto,
-					rule.descr,
+					'', // expires
+					'%h'.format(rule.descr),
 					E('button', {
 						'class': 'btn cbi-button-remove',
-						'click': L.bind(handleDelRule, this, rule.num)
-					}, [ _('Delete') ])
+						'click': L.bind(handleDelRule, this, rule.num),
+						'title': _('Delete')
+					}, [_('Delete')])
 				];
 			});
 
 			cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
 
 			return E('div', { 'class': 'cbi-section cbi-tblsection' }, [
-					E('h3', _('Active Service Port Maps')), table ]);
+				E('h3', _('Active Port Maps')), table
+			]);
 		}, o, this);
 
 		s = m.section(form.NamedSection, 'config', 'upnpd', _('Service Settings'));
@@ -127,8 +139,8 @@ return view.extend({
 		s.tab('setup', _('Service Setup'));
 		s.tab('advanced', _('Advanced Settings'));
 
-		o = s.taboption('setup', form.Flag, 'enabled', _('Start service'),
-			_('Start autonomous port mapping service'));
+		o = s.taboption('setup', form.Flag, 'enabled', _('Enable service'),
+			_('Enable the autonomous port mapping service'));
 		o.rmempty = false;
 
 		o = s.taboption('setup', form.Flag, 'enable_upnp', _('Enable UPnP IGD protocol'));
@@ -145,86 +157,104 @@ return view.extend({
 		o.default = '1';
 		o.rmempty = false;
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		o = s.taboption('setup', form.Value, 'download', _('Download speed'),
 			_('Report maximum download speed in kByte/s'));
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		o = s.taboption('setup', form.Value, 'upload', _('Upload speed'),
 			_('Report maximum upload speed in kByte/s'));
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		s.taboption('advanced', form.Flag, 'use_stun', _('Use %s', 'Use %s (%s = STUN)')
-				.format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
+			.format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
 			_('To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs'));
 
 		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN host'));
-		o.depends('use_stun', '1');
 		o.datatype = 'host';
+		o.depends('use_stun', '1');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Value, 'stun_port', _('STUN port'));
-		o.depends('use_stun', '1');
 		o.datatype = 'port';
 		o.placeholder = '3478';
+		o.depends('use_stun', '1');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Flag, 'secure_mode', _('Enable secure mode'),
 			_('Allow adding port maps for requesting IP addresses only'));
 		o.default = '1';
 		o.depends('enable_upnp', '1');
+		o.retain = true;
+
+		s.taboption('advanced', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'));
 
 		o = s.taboption('advanced', form.Value, 'notify_interval', _('Notify interval'),
-			_('A 900s interval will result in %s notifications with the minimum max-age of 1800s', 'A 900s interval will result in %s (%s = SSDP) notifications with the minimum max-age of 1800s')
-				.format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>'));
-		o.datatype = 'uinteger';
+			_('A 900 s interval sends %s announcements with the minimum %s header',
+				'A 900 s interval sends %s (%s = SSDP) announcements with the minimum %s (%s = Cache-Control: max-age=1800) header')
+			.format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>', '<code>Cache-Control: max-age=1800</code>'));
+		o.datatype = 'min(900)';
 		o.placeholder = '900';
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Value, 'port', _('SOAP/HTTP port'));
 		o.datatype = 'port';
 		o.placeholder = '5000';
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
-		o = s.taboption('advanced', form.Value, 'presentation_url', _('Presentation URL'),
-			_('Report custom router web interface (presentation) URL'));
+		o = s.taboption('advanced', form.Value, 'presentation_url', _('Router/presentation URL'),
+			_('Report custom router web interface URL'));
 		o.placeholder = 'http://192.168.1.1/';
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Value, 'uuid', _('Device UUID'));
-		o.depends('enable_upnp', '1');
+		// o.depends('enable_upnp', '1');
+		o.depends('keep-translation', 'to-disable-as-rare-use');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Value, 'model_number', _('Announced model number'));
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Value, 'serial_number', _('Announced serial number'));
 		o.depends('enable_upnp', '1');
+		o.retain = true;
 
 		o = s.taboption('advanced', form.Flag, 'system_uptime', _('Report system instead of service uptime'));
 		o.default = '1';
-		o.depends('enable_upnp', '1');
+		o.depends('keep-translation', 'to-disable-as-rare-use');
+		o.retain = true;
 
 		s.taboption('advanced', form.Flag, 'log_output', _('Enable additional logging'),
 			_('Puts extra debugging information into the system log'));
 
 		o = s.taboption('advanced', form.Value, 'upnp_lease_file', _('Service lease file'));
-		o.placeholder = '/var/run/miniupnpd.leases';
+		o.depends('keep-translation', 'to-disable-as-rare-use');
+		o.retain = true;
 
 		s = m.section(form.GridSection, 'perm_rule', _('Service Access Control List'),
 			_('ACL specify which client addresses and ports can be mapped, IPv6 always allowed.'));
-		s.sortable = true;
 		s.anonymous = true;
 		s.addremove = true;
+		s.sortable = true;
 
 		s.option(form.Value, 'comment', _('Comment'));
 
-		o = s.option(form.Value, 'int_addr', _('Client Address'));
+		o = s.option(form.Value, 'int_addr', _('IP address'));
 		o.datatype = 'ip4addr';
 		o.placeholder = '0.0.0.0/0';
 
-		o = s.option(form.Value, 'int_ports', _('Client Port'));
+		o = s.option(form.Value, 'int_ports', _('Port'));
 		o.datatype = 'portrange';
 		o.placeholder = '1-65535';
 
-		o = s.option(form.Value, 'ext_ports', _('External Port'));
+		o = s.option(form.Value, 'ext_ports', _('External port'));
 		o.datatype = 'portrange';
 		o.placeholder = '1-65535';
 

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -61,15 +61,19 @@ return view.extend({
 				rule.proto,
 				expires_str,
 				'%h'.format(rule.descr),
-				E('button', {
+				rule.num != '0' ? E('button', {
 					'class': 'btn cbi-button-remove',
 					'click': L.bind(handleDelRule, this, rule.num),
 					'title': _('Delete')
+				}, [_('Delete')]) : E('button', {
+					'class': 'btn cbi-button-remove',
+					'title': _('Not yet deletable; UPnP IGDv2 IPv6 port maps expire sooner, have no description'),
+					'style': 'cursor: not-allowed'
 				}, [_('Delete')])
 			];
 		});
 
-		cbi_update_table(nodes.querySelector('#upnp_status_table'), rows, E('em', _('There are no active port maps.')));
+		cbi_update_table(nodes.querySelector('#upnp_status_table'), rows, E('em', _('There are no active IPv4/IPv6 port maps')));
 	},
 
 	render: function(data) {
@@ -121,15 +125,19 @@ return view.extend({
 					rule.proto,
 					'', // expires
 					'%h'.format(rule.descr),
-					E('button', {
+					rule.num != '0' ? E('button', {
 						'class': 'btn cbi-button-remove',
 						'click': L.bind(handleDelRule, this, rule.num),
 						'title': _('Delete')
+					}, [_('Delete')]) : E('button', {
+						'class': 'btn cbi-button-remove',
+						'title': _('Not yet deletable; UPnP IGDv2 IPv6 port maps expire sooner, have no description'),
+						'style': 'cursor: not-allowed'
 					}, [_('Delete')])
 				];
 			});
 
-			cbi_update_table(table, rows, E('em', _('There are no active port maps.')));
+			cbi_update_table(table, rows, E('em', _('There are no active IPv4/IPv6 port maps')));
 
 			return E('div', { 'class': 'cbi-section cbi-tblsection' }, [
 				E('h3', _('Active Port Maps')), table

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -6,6 +6,7 @@
 'require ui';
 'require rpc';
 'require form';
+'require tools.widgets as widgets';
 
 const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
@@ -80,8 +81,8 @@ return view.extend({
 			'<a href="https://en.wikipedia.org/wiki/Port_Control_Protocol" target="_blank" rel="noreferrer"><abbr title="Port Control Protocol">PCP</abbr></a>',
 			'<a href="https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol" target="_blank" rel="noreferrer"><abbr title="NAT Port Mapping Protocol">NAT-PMP</abbr></a>');
 		m = new form.Map('upnpd', _('UPnP IGD & PCP/NAT-PMP Service'),
-			_('The %s protocols allow clients on the local network to configure port maps/forwards on the router autonomously.',
-				'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols allow clients on the local network to configure port maps/forwards on the router autonomously.')
+			_('The %s protocols/service enable permitted devices on local networks to autonomously set up IPv4/IPv6 port maps/forwards on this router.',
+				'The %s (%s = UPnP IGD & PCP/NAT-PMP) protocols/service enable permitted devices on local networks to autonomously set up IPv4/IPv6 port maps/forwards on this router.')
 			.format(protocols)
 		);
 		if (!uci.get('upnpd', 'config')) {
@@ -93,6 +94,7 @@ return view.extend({
 		}
 
 		s = m.section(form.GridSection, '_active_rules');
+		s.disable = uci.get('upnpd', 'config', 'enabled') == '0';
 
 		s.render = L.bind(function(view, section_id) {
 			const table = E('table', { 'class': 'table cbi-section-table', 'id': 'upnp_status_table' }, [
@@ -144,42 +146,50 @@ return view.extend({
 			_('Enable the autonomous port mapping service'));
 		o.rmempty = false;
 
-		o = s.taboption('setup', form.Flag, 'enable_upnp', _('Enable UPnP IGD protocol'));
-		o.default = '1';
+		o = s.taboption('setup', form.ListValue, 'enable_protocols', _('Enable protocols'));
+		o.value('all', _('All protocols'));
+		o.value('upnp-igd', _('UPnP IGD'));
+		o.value('pcp+nat-pmp', _('PCP and NAT-PMP'));
+		o.default = 'all';
+		o.widget = 'radio';
 
-		o = s.taboption('setup', form.Flag, 'enable_natpmp', _('Enable PCP/NAT-PMP protocols'));
-		o.default = '1';
-
-		s.taboption('advanced', form.Flag, 'ext_allow_private_ipv4', _('Allow private IPv4'),
-			_('Enable forwarding for private/reserved IPv4 address'));
-
-		o = s.taboption('setup', form.Flag, 'igdv1', _('UPnP IGDv1 compatibility mode'),
-			_('Advertise as IGDv1 (IPv4 only) device instead of IGDv2'));
-		o.default = '1';
-		o.rmempty = false;
-		o.depends('enable_upnp', '1');
+		o = s.taboption('setup', form.ListValue, 'upnp_igd_compat', _('UPnP IGD compatibility'),
+			_('Set compatibility mode (act as device) to workaround IGDv2-incompatible clients; %s are known to only work with %s (or) <br />Emulate/report a specific/different device to workaround/support/handle/bypass/assist/mitigate... (Alternative text welcome)').format('Sony PS, Activision CoD…', 'IGDv1'));
+		o.value('igdv1', _('IGDv1 (IPv4 only)'));
+		o.value('igdv2', _('IGDv2 (with workarounds)'));
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
-		s.taboption('advanced', form.Flag, 'use_stun', _('Use %s', 'Use %s (%s = STUN)')
-			.format('<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
-			_('To detect the public IPv4 address for unrestricted full-cone/one-to-one NATs'));
+		o = s.taboption('advanced', form.RichListValue, 'allow_cgnat', _('Allow %s/%s', 'Allow %s/%s (%s = CGNAT, %s = STUN)')
+			.format('<a href="https://en.wikipedia.org/wiki/Carrier-grade_NAT" target="_blank" rel="noreferrer"><abbr title="Carrier-grade NAT">CGNAT</abbr></a>',
+				'<a href="https://en.wikipedia.org/wiki/STUN" target="_blank" rel="noreferrer"><abbr title="Session Traversal Utilities for NAT">STUN</abbr></a>'),
+			_('Allow use of unrestricted endpoint-independent (1:1) CGNATs and detect the public IPv4'));
+		o.value('', _('Disabled'), _('Manually override external IPv4 with public'));
+		o.value('1', _('Enabled'), _('Filtering test currently requires an extra firewall rule'));
+		o.value('allow-filtered', _('Enabled') + ' (' + _('allow filtered') + ')', _('Workaround filtered IPv4 CGNAT test result'));
+		o.value('report-private-ipv4', _('Disabled') + ' (' + _('report private IPv4, avoid') + ')', _('No STUN public IPv4 detection; client issues'));
+		o.optional = true;
 
-		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN host'));
-		o.datatype = 'host';
-		o.depends('use_stun', '1');
+		o = s.taboption('advanced', form.Value, 'stun_host', _('STUN server'));
+		o.datatype = 'or(hostname,hostport,ip4addr("nomask"))';
+		o.placeholder = 'stun.nextcloud.com';
+		o.depends('allow_cgnat', '1');
+		o.depends('allow_cgnat', 'allow-filtered');
 		o.retain = true;
 
-		o = s.taboption('advanced', form.Value, 'stun_port', _('STUN port'));
-		o.datatype = 'port';
-		o.placeholder = '3478';
-		o.depends('use_stun', '1');
-		o.retain = true;
+		o = s.taboption('advanced', form.Value, 'external_ip', _('Override external IPv4'),
+			_('Report custom public/external (WAN) IPv4 address'));
+		o.datatype = 'ip4addr("nomask")';
+		o.depends('allow_cgnat', '');
+		o.depends('allow_cgnat', 'report-private-ipv4');
 
-		o = s.taboption('advanced', form.Flag, 'secure_mode', _('Enable secure mode'),
-			_('Allow adding port maps for requesting IP addresses only'));
-		o.default = '1';
-		o.depends('enable_upnp', '1');
-		o.retain = true;
+		o = s.taboption('advanced', form.ListValue, 'allow_third_party_mapping', _('Allow third-party mapping'),
+			_('Allow adding port maps for non-requesting IP addresses; use with care'));
+		o.value('', _('Disabled') + ' (' + _('recommended') + ')');
+		o.value('1', _('Enabled'));
+		o.value('upnp-igd', _('Enabled') + ' (' + _('UPnP IGD only') + ')');
+		o.value('pcp', _('Enabled') + ' (' + _('PCP only') + ')');
 
 		s.taboption('advanced', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'));
 
@@ -188,46 +198,69 @@ return view.extend({
 		o.depends('keep-translation', 'to-disable-as-rare-use');
 		o.retain = true;
 
-		s.taboption('advanced', form.Flag, 'log_output', _('Enable additional logging'),
-			_('Puts extra debugging information into the system log'));
+		o = s.taboption('advanced', form.ListValue, 'log_output', _('Log level'));
+		o.value('default', _('Default'));
+		o.value('info', _('Info'));
+		o.value('debug', _('Debug'));
+		o.default = 'default';
+		o.widget = 'radio';
 
-		o = s.taboption('advanced', form.Value, 'upnp_lease_file', _('Service lease file'));
+		o = s.taboption('advanced', form.Value, 'lease_file', _('Service lease file'));
 		o.depends('keep-translation', 'to-disable-as-rare-use');
 		o.retain = true;
 
-		o = s.taboption('igd', form.Value, 'download', _('Download speed'),
-			_('Report maximum download speed in kByte/s'));
-		o.depends('enable_upnp', '1');
+		o = s.taboption('igd', form.Value, 'download_kbps', _('Download speed'),
+			_('Report maximum connection speed in kbit/s'));
+		o.datatype = 'uinteger';
+		o.placeholder = _('Default interface link speed');
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
-		o = s.taboption('igd', form.Value, 'upload', _('Upload speed'),
-			_('Report maximum upload speed in kByte/s'));
-		o.depends('enable_upnp', '1');
+		o = s.taboption('igd', form.Value, 'upload_kbps', _('Upload speed'),
+			_('Report maximum connection speed in kbit/s'));
+		o.datatype = 'uinteger';
+		o.placeholder = _('Default interface link speed');
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
+		o.retain = true;
+
+		o = s.taboption('igd', form.Value, 'friendly_name', _('Router/friendly name'));
+		o.placeholder = 'OpenWrt UPnP IGD & PCP';
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
 		o = s.taboption('igd', form.Value, 'model_number', _('Announced model number'));
-		o.depends('enable_upnp', '1');
+		// o.depends('enable_protocols', 'upnp-igd');
+		// o.depends('enable_protocols', 'all');
+		o.depends('keep-translation', 'to-disable-as-rare-use');
 		o.retain = true;
 
 		o = s.taboption('igd', form.Value, 'serial_number', _('Announced serial number'));
-		o.depends('enable_upnp', '1');
+		// o.depends('enable_protocols', 'upnp-igd');
+		// o.depends('enable_protocols', 'all');
+		o.depends('keep-translation', 'to-disable-as-rare-use');
 		o.retain = true;
 
 		o = s.taboption('igd', form.Value, 'presentation_url', _('Router/presentation URL'),
 			_('Report custom router web interface URL'));
 		o.placeholder = 'http://192.168.1.1/';
-		o.depends('enable_upnp', '1');
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
 		o = s.taboption('igd', form.Value, 'uuid', _('Device UUID'));
-		// o.depends('enable_upnp', '1');
+		// o.depends('enable_protocols', 'upnp-igd');
+		// o.depends('enable_protocols', 'all');
 		o.depends('keep-translation', 'to-disable-as-rare-use');
 		o.retain = true;
 
-		o = s.taboption('igd', form.Value, 'port', _('SOAP/HTTP port'));
+		o = s.taboption('igd', form.Value, 'http_port', _('SOAP/HTTP port'));
 		o.datatype = 'port';
 		o.placeholder = '5000';
-		o.depends('enable_upnp', '1');
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
 		o = s.taboption('igd', form.Value, 'notify_interval', _('Notify interval'),
@@ -236,7 +269,57 @@ return view.extend({
 			.format('<abbr title="Simple Service Discovery Protocol">SSDP</abbr>', '<code>Cache-Control: max-age=1800</code>'));
 		o.datatype = 'min(900)';
 		o.placeholder = '900';
-		o.depends('enable_upnp', '1');
+		o.depends('enable_protocols', 'upnp-igd');
+		o.depends('enable_protocols', 'all');
+		o.retain = true;
+
+		s = m.section(form.GridSection, 'internal_network', '<h5>' + _('Enable Networks / Access Control') + '</h5>',
+			_('Select local/internal (LAN) network interfaces to enable the service for.') + ' ' +
+			_('Set access control defaults for ports that all devices on a network can map.') + ' ' +
+			_('IPv6 is currently always accepted unless disabled. (Alternative text welcome)'));
+		s.anonymous = true;
+		s.addremove = true;
+		s.cloneable = true;
+		s.sortable = true;
+		s.nodescriptions = true;
+		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit Network Access Control Settings');
+
+		o = s.option(widgets.NetworkSelect, 'interface', _('Internal network'),
+			_('Select the local/internal (LAN) network interface to enable the service for'));
+		o.nocreate = true;
+		o.editable = true;
+		o.rmempty = false;
+		o.retain = true;
+		o.filter = function(section_id, value) {
+			return (value == 'wan' || value == 'wan6') ? '' : value;
+		};
+
+		o = s.option(form.ListValue, 'access_defaults', _('Access defaults'),
+			_('Set access control defaults for ports that all devices on the network can map'));
+		o.value('', _('None / accept extra ports only'));
+		o.value('accept-high-ports', _('Accept ports >= 1024'));
+		o.value('accept-web+high-ports', _('Accept HTTP/HTTPS + ports >= 1024'));
+		o.value('accept-web-ports', _('Accept HTTP/HTTPS ports'));
+		o.value('accept-all-ports', _('Accept all ports'));
+		o.editable = true;
+		o.retain = true;
+
+		o = s.option(form.Value, 'accept_ports', _('Accept extra ports'));
+		o.datatype = 'list(portrange)';
+		o.retain = true;
+
+		o = s.option(form.Value, 'reject_ports', _('Reject ports'),
+			_('Reject unsafe/insecure/risky FTP/Telnet/DCE/NetBIOS/SMB/RDP ports on the network by default; overrides other settings; use %s for none').format('<code>0</code>'));
+		o.datatype = 'list(portrange)';
+		o.placeholder = '21 23 135 137-139 445 3389';
+		o.modalonly = true;
+		o.retain = true;
+
+		o = s.option(form.Flag, 'check_acl', _('Check ACL'),
+			_('Extend or override access defaults by device-specific permissions using the access control list (ACL)') + '<br />' +
+			_('Sequence:') + ' 1. ' + _('Reject ports') + ', 2. ' + _('ACL entries (if checked)') + ', 3. ' + _('Access defaults') + ', 4. ' + _('Accept extra ports'));
+		o.default = '1';
+		o.editable = true;
 		o.retain = true;
 
 		s = m.section(form.GridSection, 'perm_rule', _('Service Access Control List'),
@@ -244,6 +327,15 @@ return view.extend({
 		s.anonymous = true;
 		s.addremove = true;
 		s.sortable = true;
+		// To do: ACL part of extra tab with dependency on option as immediately, and network section part of service setup tab
+		let acl_used = false;
+		for (let ifnr = 0; uci.get('upnpd', `@internal_network[${ifnr}]`, 'interface'); ifnr++) {
+			if (uci.get('upnpd', `@internal_network[${ifnr}]`, 'check_acl') != '0') {
+				acl_used = true;
+				break;
+			}
+		}
+		s.disable = !acl_used;
 
 		s.option(form.Value, 'comment', _('Comment'));
 
@@ -264,11 +356,13 @@ return view.extend({
 		o.value('deny', _('Deny'));
 
 		return m.render().then(L.bind(function(m, nodes) {
-			poll.add(L.bind(function() {
-				return Promise.all([
-					callUpnpGetStatus()
-				]).then(L.bind(this.poll_status, this, nodes));
-			}, this), 5);
+			if (uci.get('upnpd', 'config', 'enabled') != '0') {
+				poll.add(L.bind(function() {
+					return Promise.all([
+						callUpnpGetStatus()
+					]).then(L.bind(this.poll_status, this, nodes));
+				}, this), 5);
+			}
 			return nodes;
 		}, this, m));
 	}

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -322,11 +322,14 @@ return view.extend({
 		o.editable = true;
 		o.retain = true;
 
-		s = m.section(form.GridSection, 'perm_rule', _('Service Access Control List'),
-			_('ACL specify which client addresses and ports can be mapped, IPv6 always allowed.'));
+		s = m.section(form.GridSection, 'acl_entry', '<h5>' + _('Access Control List') + '</h5>',
+			_('The access control list (ACL) specifies which IPv4 addresses and ports can be mapped.') + ' ' +
+			_('ACL entries are checked in order, then rejected if not matched and not accepted by access defaults. (should be part of extra tab)'));
 		s.anonymous = true;
 		s.addremove = true;
+		s.cloneable = true;
 		s.sortable = true;
+		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit ACL Entry');
 		// To do: ACL part of extra tab with dependency on option as immediately, and network section part of service setup tab
 		let acl_used = false;
 		for (let ifnr = 0; uci.get('upnpd', `@internal_network[${ifnr}]`, 'interface'); ifnr++) {
@@ -337,23 +340,46 @@ return view.extend({
 		}
 		s.disable = !acl_used;
 
-		s.option(form.Value, 'comment', _('Comment'));
+		o = s.option(form.Value, 'comment', _('Comment'));
+		o.default = _('unspecified');
 
 		o = s.option(form.Value, 'int_addr', _('IP address'));
 		o.datatype = 'ip4addr';
-		o.placeholder = '0.0.0.0/0';
+		o.rmempty = false;
+		o.editable = true;
+		o.retain = true;
+		o.modalonly = false;
 
-		o = s.option(form.Value, 'int_ports', _('Port'));
-		o.datatype = 'portrange';
-		o.placeholder = '1-65535';
+		o = s.option(form.Value, 'int_addr', _('IP address'),
+			_('Enter device\'s IPv4 address, or an address and netmask'));
+		o.datatype = 'ip4addr';
+		o.rmempty = false;
+		o.retain = true;
+		o.modalonly = true;
 
-		o = s.option(form.Value, 'ext_ports', _('External port'));
+		o = s.option(form.Value, 'int_port', _('Port'));
 		o.datatype = 'portrange';
-		o.placeholder = '1-65535';
+		o.placeholder = '1-65535 (' + _('any port') + ')';
+		o.editable = true;
+		o.retain = true;
+
+		o = s.option(form.Value, 'ext_port', _('External port'));
+		o.datatype = 'portrange';
+		o.placeholder = '1-65535 (' + _('any port') + ')';
+		o.editable = true;
+		o.retain = true;
+
+		o = s.option(form.Value, 'descr_filter', _('Description filter'),
+			_('Regular expression to check description of UPnP IGD IPv4 port maps'));
+		o.placeholder = '.* (' + _('any description') + ')';
+		o.modalonly = true;
 
 		o = s.option(form.ListValue, 'action', _('Action'));
-		o.value('allow', _('Allow'));
-		o.value('deny', _('Deny'));
+		o.value('accept', _('Accept'));
+		o.value('reject', _('Reject'));
+		o.value('disabled', _('Disabled'));
+		o.editable = true;
+		o.retain = true;
 
 		return m.render().then(L.bind(function(m, nodes) {
 			if (uci.get('upnpd', 'settings', 'enabled') != '0') {

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -147,6 +147,7 @@ return view.extend({
 		s = m.section(form.NamedSection, 'settings', 'upnpd', _('Service Settings'));
 		s.addremove = false;
 		s.tab('setup', _('Service Setup'));
+		s.tab('access_control', _('Access Control'));
 		s.tab('advanced', _('Advanced Settings'));
 		s.tab('igd', _('UPnP IGD Adjustments'));
 
@@ -161,6 +162,18 @@ return view.extend({
 		o.default = 'all';
 		o.widget = 'radio';
 
+		o = s.taboption('setup', widgets.NetworkSelect, 'internal_iface', _('Enable networks'),
+			_('Select local/internal (LAN) network interfaces to enable the service for'));
+		o.nocreate = true;
+		o.multiple = true;
+		o.rmempty = false;
+		o.filter = function(section_id, value) {
+			return (value == 'wan' || value == 'wan6') ? '' : value;
+		};
+		o.write = function(section_id, formvalue) {
+			uci.set('upnpd', section_id, 'internal_iface', Array.isArray(formvalue) ? formvalue.join(' ') : formvalue);
+		};
+
 		o = s.taboption('setup', form.ListValue, 'upnp_igd_compat', _('UPnP IGD compatibility'),
 			_('Set compatibility mode (act as device) to workaround IGDv2-incompatible clients; %s are known to only work with %s (or) <br />Emulate/report a specific/different device to workaround/support/handle/bypass/assist/mitigate... (Alternative text welcome)').format('Sony PS, Activision CoD…', 'IGDv1'));
 		o.value('igdv1', _('IGDv1 (IPv4 only)'));
@@ -168,6 +181,34 @@ return view.extend({
 		o.depends('enable_protocols', 'upnp-igd');
 		o.depends('enable_protocols', 'all');
 		o.retain = true;
+
+		o = s.taboption('access_control', form.ListValue, 'access_defaults', _('Access defaults'),
+			_('Set access control defaults for ports that all devices can map'));
+		o.value('', _('None / accept extra ports only'));
+		o.value('accept-high-ports', _('Accept ports >= 1024'));
+		o.value('accept-web+high-ports', _('Accept HTTP/HTTPS + ports >= 1024'));
+		o.value('accept-web-ports', _('Accept HTTP/HTTPS ports'));
+		o.value('accept-all-ports', _('Accept all ports'));
+
+		o = s.taboption('access_control', form.Value, 'accept_ports', _('Accept extra ports'));
+		o.datatype = 'list(portrange)';
+
+		o = s.taboption('access_control', form.Value, 'reject_ports', _('Reject ports'),
+			_('Reject unsafe/insecure/risky FTP/Telnet/DCE/NetBIOS/SMB/RDP ports by default; overrides other settings; use %s for none').format('<code>0</code>'));
+		o.datatype = 'list(portrange)';
+		o.placeholder = '21 23 135 137-139 445 3389';
+
+		o = s.taboption('access_control', form.Flag, 'check_acl', _('Check ACL'),
+			_('Extend or override access defaults by device-specific permissions using the access control list (ACL)') + '<br />' +
+			_('Sequence:') + ' 1. ' + _('Reject ports') + ', 2. ' + _('ACL entries (if checked)') + ', 3. ' + _('Access defaults') + ', 4. ' + _('Accept extra ports'));
+		o.default = '1';
+		o.onchange = function(ev, section_id, value) {
+			let acl = document.getElementById('cbi-upnpd-acl_entry');
+			value == 0 ? acl.style.display = 'none' : acl.style.display = 'block';
+		};
+
+		s.taboption('access_control', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'),
+			_('IPv6 is currently always accepted unless disabled'));
 
 		o = s.taboption('advanced', form.RichListValue, 'allow_cgnat', _('Allow %s/%s', 'Allow %s/%s (%s = CGNAT, %s = STUN)')
 			.format('<a href="https://en.wikipedia.org/wiki/Carrier-grade_NAT" target="_blank" rel="noreferrer"><abbr title="Carrier-grade NAT">CGNAT</abbr></a>',
@@ -198,8 +239,6 @@ return view.extend({
 		o.value('1', _('Enabled'));
 		o.value('upnp-igd', _('Enabled') + ' (' + _('UPnP IGD only') + ')');
 		o.value('pcp', _('Enabled') + ' (' + _('PCP only') + ')');
-
-		s.taboption('advanced', form.Flag, 'ipv6_disable', _('Disable IPv6 mapping'));
 
 		o = s.taboption('advanced', form.Flag, 'system_uptime', _('Report system instead of service uptime'));
 		o.default = '1';
@@ -281,72 +320,16 @@ return view.extend({
 		o.depends('enable_protocols', 'all');
 		o.retain = true;
 
-		s = m.section(form.GridSection, 'internal_network', '<h5>' + _('Enable Networks / Access Control') + '</h5>',
-			_('Select local/internal (LAN) network interfaces to enable the service for.') + ' ' +
-			_('Set access control defaults for ports that all devices on a network can map.') + ' ' +
-			_('IPv6 is currently always accepted unless disabled. (Alternative text welcome)'));
-		s.anonymous = true;
-		s.addremove = true;
-		s.cloneable = true;
-		s.sortable = true;
-		s.nodescriptions = true;
-		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit Network Access Control Settings');
-
-		o = s.option(widgets.NetworkSelect, 'interface', _('Internal network'),
-			_('Select the local/internal (LAN) network interface to enable the service for'));
-		o.nocreate = true;
-		o.editable = true;
-		o.rmempty = false;
-		o.retain = true;
-		o.filter = function(section_id, value) {
-			return (value == 'wan' || value == 'wan6') ? '' : value;
-		};
-
-		o = s.option(form.ListValue, 'access_defaults', _('Access defaults'),
-			_('Set access control defaults for ports that all devices on the network can map'));
-		o.value('', _('None / accept extra ports only'));
-		o.value('accept-high-ports', _('Accept ports >= 1024'));
-		o.value('accept-web+high-ports', _('Accept HTTP/HTTPS + ports >= 1024'));
-		o.value('accept-web-ports', _('Accept HTTP/HTTPS ports'));
-		o.value('accept-all-ports', _('Accept all ports'));
-		o.editable = true;
-		o.retain = true;
-
-		o = s.option(form.Value, 'accept_ports', _('Accept extra ports'));
-		o.datatype = 'list(portrange)';
-		o.retain = true;
-
-		o = s.option(form.Value, 'reject_ports', _('Reject ports'),
-			_('Reject unsafe/insecure/risky FTP/Telnet/DCE/NetBIOS/SMB/RDP ports on the network by default; overrides other settings; use %s for none').format('<code>0</code>'));
-		o.datatype = 'list(portrange)';
-		o.placeholder = '21 23 135 137-139 445 3389';
-		o.modalonly = true;
-		o.retain = true;
-
-		o = s.option(form.Flag, 'check_acl', _('Check ACL'),
-			_('Extend or override access defaults by device-specific permissions using the access control list (ACL)') + '<br />' +
-			_('Sequence:') + ' 1. ' + _('Reject ports') + ', 2. ' + _('ACL entries (if checked)') + ', 3. ' + _('Access defaults') + ', 4. ' + _('Accept extra ports'));
-		o.default = '1';
-		o.editable = true;
-		o.retain = true;
-
 		s = m.section(form.GridSection, 'acl_entry', '<h5>' + _('Access Control List') + '</h5>',
 			_('The access control list (ACL) specifies which IPv4 addresses and ports can be mapped.') + ' ' +
-			_('ACL entries are checked in order, then rejected if not matched and not accepted by access defaults. (should be part of extra tab)'));
+			_('ACL entries are checked in order, then rejected if not matched and not accepted by access defaults. (To do: should be part of access control tab)'));
 		s.anonymous = true;
 		s.addremove = true;
 		s.cloneable = true;
 		s.sortable = true;
 		s.modaltitle = _('UPnP IGD & PCP/NAT-PMP') + ' - ' + _('Edit ACL Entry');
-		// To do: ACL part of extra tab with dependency on option as immediately, and network section part of service setup tab
-		let acl_used = false;
-		for (let ifnr = 0; uci.get('upnpd', `@internal_network[${ifnr}]`, 'interface'); ifnr++) {
-			if (uci.get('upnpd', `@internal_network[${ifnr}]`, 'check_acl') != '0') {
-				acl_used = true;
-				break;
-			}
-		}
-		s.disable = !acl_used;
+		// To do: ACL part of access control tab and hide (or dependency on option) instead of disable as immediately, and to not break onchange function
+		s.disable = uci.get('upnpd', 'settings', 'check_acl') == '0';
 
 		o = s.option(form.Value, 'comment', _('Comment'));
 		o.default = _('unspecified');

--- a/applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json
@@ -1,6 +1,6 @@
 {
 	"luci-app-upnp": {
-		"description": "Grant access to UPnP IGD & PCP/NAT-PMP",
+		"description": "Grant access to UPnP IGD & PCP/NAT-PMP service configuration",
 		"read": {
 			"ubus": {
 				"luci.upnp": [ "get_status" ]

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -59,6 +59,23 @@ const methods = {
 					}
 				}
 				ipt.close();
+
+				const iptipv6 = popen('ip6tables --line-numbers -xnvL MINIUPNPD 2>/dev/null');
+				if (iptipv6) {
+					for (let line = iptipv6.read('line'); length(line); line = iptipv6.read('line')) {
+						let m = match(line, /^([0-9]+) .+ ([0-9a-f:]+)  ([ut].p) dpt:([0-9]+)/);
+						if (m) {
+							push(rules, {
+								num: '0',
+								intaddr: arrtoip(iptoarr(m[2])),
+								intport: +m[4],
+								extport: +m[4],
+								proto: uc(m[3])
+							});
+						}
+					}
+					iptipv6.close();
+				}
 			}
 
 			const nft = popen('nft --handle list chain inet fw4 upnp_prerouting 2>/dev/null');
@@ -77,6 +94,27 @@ const methods = {
 					}
 				}
 				nft.close();
+
+				const nftipv6 = popen('nft --handle list chain inet fw4 upnp_forward 2>/dev/null');
+				if (nftipv6) {
+					for (let line = nftipv6.read('line'), num = 1; length(line); line = nftipv6.read('line')) {
+						let m = match(line, /^\t\tiif ".+" th dport ([0-9]+) @nh,192,128 0x([0-9a-f]+) @nh,48,8 (0x6|0x11) accept/);
+						if (m) {
+							push(rules, {
+								num: '0',
+								intaddr: arrtoip(iptoarr(join(':', [substr(m[2], 0, 4),
+									substr(m[2], 4, 4), substr(m[2], 8, 4), substr(m[2], 12, 4), substr(m[2], 16, 4),
+									substr(m[2], 20, 4), substr(m[2], 24, 4), substr(m[2], 28, 4)
+								]))),
+								intport: +m[1],
+								extport: +m[1],
+								proto: (m[3] == '0x6') ? 'TCP' : 'UDP'
+							});
+							num++;
+						}
+					}
+					nftipv6.close();
+				}
 			}
 
 			return ubus.defer('luci-rpc', 'getHostHints', {}, function(rc, host_hints) {
@@ -92,7 +130,7 @@ const methods = {
 						}
 					}
 					for (let mac, hint in host_hints) {
-						if (rule.intaddr in hint.ipaddrs) {
+						if (rule.intaddr in hint.ipaddrs || rule.intaddr in hint.ip6addrs) {
 							rule.host_hint = hint.name;
 							break;
 						}

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -16,7 +16,7 @@ const methods = {
 			const ubus = connect();
 			const rules = [];
 			const leases = [];
-			const leasefile = open(uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases', 'r');
+			const leasefile = open(uci.get('upnpd', 'settings', 'lease_file') || '/var/run/miniupnpd.leases', 'r');
 			if (leasefile) {
 				for (let line = leasefile.read('line'); length(line); line = leasefile.read('line')) {
 					const record = split(line, ':', 6);
@@ -109,7 +109,7 @@ const methods = {
 			const idx = +req.args?.token;
 			if (idx > 0) {
 				const uci = cursor();
-				const leasefile = uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases';
+				const leasefile = uci.get('upnpd', 'settings', 'lease_file') || '/var/run/miniupnpd.leases';
 				if (access(leasefile)) {
 					system(['sed', '-i', '-e', `${idx}d`, leasefile]);
 					system(['/etc/init.d/miniupnpd', 'restart']);

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -16,7 +16,7 @@ const methods = {
 			const ubus = connect();
 			const rules = [];
 			const leases = [];
-			const leasefile = open(uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases', 'r');
+			const leasefile = open(uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases', 'r');
 			if (leasefile) {
 				for (let line = leasefile.read('line'); length(line); line = leasefile.read('line')) {
 					const record = split(line, ':', 6);
@@ -109,7 +109,7 @@ const methods = {
 			const idx = +req.args?.token;
 			if (idx > 0) {
 				const uci = cursor();
-				const leasefile = uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases';
+				const leasefile = uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases';
 				if (access(leasefile)) {
 					system(['sed', '-i', '-e', `${idx}d`, leasefile]);
 					system(['/etc/init.d/miniupnpd', 'restart']);

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -1,3 +1,5 @@
+#!/usr/bin/env ucode
+
 // Copyright 2022 Jo-Philipp Wich <jo@mein.io>
 // Licensed to the public under the Apache License 2.0.
 
@@ -7,82 +9,73 @@ import { access, open, popen } from 'fs';
 import { connect } from 'ubus';
 import { cursor } from 'uci';
 
-// Establish ubus connection persistently outside of the call handler scope to
-// prevent premature GC'ing. Can be moved into `get_status` callback once
-// https://github.com/jow-/ucode/commit/a58fe4709f661b5f28e26701ea8638efccf5aeb6
-// is merged.
-const ubus = connect();
-
 const methods = {
 	get_status: {
 		call: function(req) {
 			const uci = cursor();
-
+			const ubus = connect();
 			const rules = [];
 			const leases = [];
-
-			const leasefile = open(uci.get('upnpd', 'config', 'upnp_lease_file'), 'r');
-
+			const leasefile = open(uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases', 'r');
 			if (leasefile) {
 				for (let line = leasefile.read('line'); length(line); line = leasefile.read('line')) {
 					const record = split(line, ':', 6);
-
 					if (length(record) == 6) {
+						let descr = trim(record[5]);
+						let m = match(descr, /^PCP [A-Z]+ ([0-9a-f]{24})$/);
+						if (m) descr = 'PCP (nonce ' + m[1] + ')';
+						else if (match(descr, /^NAT-PMP \d+ \w+$/)) descr = 'NAT-PMP';
+						else if (match(descr, /^IGD2 pinhole$/)) descr = 'UPnP IGDv2 IPv6';
+						else if (!match(descr, /^UPnP IGD/)) descr = 'UPnP IGD / ' + descr;
 						push(leases, {
 							proto: uc(record[0]),
 							extport: +record[1],
 							intaddr: arrtoip(iptoarr(record[2])),
 							intport: +record[3],
 							expires: record[4] - timelocal(localtime()),
-							description: trim(record[5])
+							descr: descr
 						});
 					}
 				}
-
 				leasefile.close();
 			}
 
-			const ipt = popen('iptables --line-numbers -t nat -xnvL MINIUPNPD 2>/dev/null');
-
+			// Workaround daemon bug with iptables >= 1.8.8 by parsing MINIUPNPD-POSTROUTING
+			// See https://github.com/miniupnp/miniupnp/issues/837
+			//const ipt = popen('iptables --line-numbers -t nat -xnvL MINIUPNPD 2>/dev/null');
+			const ipt = popen('iptables --line-numbers -t nat -xnvL MINIUPNPD-POSTROUTING 2>/dev/null');
 			if (ipt) {
 				for (let line = ipt.read('line'); length(line); line = ipt.read('line')) {
-					let m = match(line, /^([0-9]+)\s+([a-z]+).+dpt:([0-9]+) to:(\S+):([0-9]+)/);
-
+					//let m = match(line, /^([0-9]+) .+ ([ut].p) dpt:([0-9]+) to:(\S+):([0-9]+)/);
+					let m = match(line, /^([0-9]+) .+ \* +([0-9.]+) .+ ([ut].p) spt:([0-9]+) .+ ports: ([0-9]+)/);
 					if (m) {
 						push(rules, {
 							num: m[1],
-							proto: uc(m[2]),
-							extport: +m[3],
-							intaddr: arrtoip(iptoarr(m[4])),
-							intport: +m[5],
-							descr: ''
+							intaddr: arrtoip(iptoarr(m[2])),
+							intport: +m[4],
+							extport: +m[5],
+							proto: uc(m[3])
 						});
 					}
 				}
-
 				ipt.close();
 			}
 
 			const nft = popen('nft --handle list chain inet fw4 upnp_prerouting 2>/dev/null');
-
 			if (nft) {
 				for (let line = nft.read('line'), num = 1; length(line); line = nft.read('line')) {
-					let m = match(line, /^\t\tiif ".+" @nh,72,8 (0x6|0x11) th dport ([0-9]+) dnat ip to ([0-9.]+):([0-9]+)/);
-
+					let m = match(line, /^\t\tiif ".+" @nh,72,8 (0x6|0x11) th dport ([0-9]+).* dnat ip to ([0-9.]+):([0-9]+)/);
 					if (m) {
 						push(rules, {
 							num: `${num}`,
-							proto: (m[1] == '0x6') ? 'TCP' : 'UDP',
-							extport: +m[2],
 							intaddr: arrtoip(iptoarr(m[3])),
 							intport: +m[4],
-							descr: ''
+							extport: +m[2],
+							proto: (m[1] == '0x6') ? 'TCP' : 'UDP'
 						});
-
 						num++;
 					}
 				}
-
 				nft.close();
 			}
 
@@ -90,16 +83,14 @@ const methods = {
 				for (let rule in rules) {
 					for (let lease in leases) {
 						if (lease.proto == rule.proto &&
-						    lease.intaddr == rule.intaddr &&
-						    lease.intport == rule.intport &&
-						    lease.extport == rule.extport)
-						{
-							rule.descr = lease.description;
+							lease.intaddr == rule.intaddr &&
+							lease.intport == rule.intport &&
+							lease.extport == rule.extport) {
 							rule.expires = lease.expires;
+							rule.descr = lease.descr;
 							break;
 						}
 					}
-
 					for (let mac, hint in host_hints) {
 						if (rule.intaddr in hint.ipaddrs) {
 							rule.host_hint = hint.name;
@@ -107,7 +98,6 @@ const methods = {
 						}
 					}
 				}
-
 				req.reply({ rules });
 			});
 		}
@@ -117,19 +107,15 @@ const methods = {
 		args: { token: 'token' },
 		call: function(req) {
 			const idx = +req.args?.token;
-
 			if (idx > 0) {
 				const uci = cursor();
-				const leasefile = uci.get('upnpd', 'config', 'upnp_lease_file');
-
+				const leasefile = uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases';
 				if (access(leasefile)) {
 					system(['sed', '-i', '-e', `${idx}d`, leasefile]);
 					system(['/etc/init.d/miniupnpd', 'restart']);
 				}
-
 				return { result: 'OK' };
 			}
-
 			return { result: 'Bad request' };
 		}
 	}

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -16,7 +16,7 @@ const methods = {
 			const ubus = connect();
 			const rules = [];
 			const leases = [];
-			const leasefile = open(uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases', 'r');
+			const leasefile = open(uci.get('upnpd', 'settings', 'lease_file') || '/var/run/miniupnpd.leases', 'r');
 			if (leasefile) {
 				for (let line = leasefile.read('line'); length(line); line = leasefile.read('line')) {
 					const record = split(line, ':', 7);
@@ -112,7 +112,7 @@ const methods = {
 			const idx = +req.args?.token;
 			if (idx > 0) {
 				const uci = cursor();
-				const leasefile = uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases';
+				const leasefile = uci.get('upnpd', 'settings', 'lease_file') || '/var/run/miniupnpd.leases';
 				if (access(leasefile)) {
 					system(['sed', '-i', '-e', `${idx}d`, leasefile]);
 					system(['/etc/init.d/miniupnpd', 'restart']);

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -16,7 +16,7 @@ const methods = {
 			const ubus = connect();
 			const rules = [];
 			const leases = [];
-			const leasefile = open(uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases', 'r');
+			const leasefile = open(uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases', 'r');
 			if (leasefile) {
 				for (let line = leasefile.read('line'); length(line); line = leasefile.read('line')) {
 					const record = split(line, ':', 7);
@@ -112,7 +112,7 @@ const methods = {
 			const idx = +req.args?.token;
 			if (idx > 0) {
 				const uci = cursor();
-				const leasefile = uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases';
+				const leasefile = uci.get('upnpd', 'config', 'lease_file') || '/var/run/miniupnpd.leases';
 				if (access(leasefile)) {
 					system(['sed', '-i', '-e', `${idx}d`, leasefile]);
 					system(['/etc/init.d/miniupnpd', 'restart']);

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -1,3 +1,5 @@
+#!/usr/bin/env ucode
+
 // Copyright 2022 Jo-Philipp Wich <jo@mein.io>
 // Licensed to the public under the Apache License 2.0.
 
@@ -7,82 +9,76 @@ import { access, open, popen } from 'fs';
 import { connect } from 'ubus';
 import { cursor } from 'uci';
 
-// Establish ubus connection persistently outside of the call handler scope to
-// prevent premature GC'ing. Can be moved into `get_status` callback once
-// https://github.com/jow-/ucode/commit/a58fe4709f661b5f28e26701ea8638efccf5aeb6
-// is merged.
-const ubus = connect();
-
 const methods = {
 	get_status: {
 		call: function(req) {
 			const uci = cursor();
-
+			const ubus = connect();
 			const rules = [];
 			const leases = [];
-
-			const leasefile = open(uci.get('upnpd', 'config', 'upnp_lease_file'), 'r');
-
+			const leasefile = open(uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases', 'r');
 			if (leasefile) {
 				for (let line = leasefile.read('line'); length(line); line = leasefile.read('line')) {
-					const record = split(line, ':', 6);
-
-					if (length(record) == 6) {
+					const record = split(line, ':', 7);
+					if (length(record) == 6 || length(record) == 7) {
+						// Daemon version >2.3.11 changes lease file format
+						let recshift = 0;
+						if (length(record) == 7) recshift = 1;
+						let descr = trim(record[5 + recshift]);
+						let m = match(descr, /^PCP [A-Z]+ ([0-9a-f]{24})$/);
+						if (m) descr = 'PCP (nonce ' + m[1] + ')';
+						else if (match(descr, /^NAT-PMP \d+ \w+$/)) descr = 'NAT-PMP';
+						else if (match(descr, /^IGD2 pinhole$/)) descr = 'UPnP IGDv2 IPv6';
+						else if (!match(descr, /^UPnP IGD/)) descr = 'UPnP IGD / ' + descr;
 						push(leases, {
 							proto: uc(record[0]),
 							extport: +record[1],
-							intaddr: arrtoip(iptoarr(record[2])),
-							intport: +record[3],
-							expires: record[4] - timelocal(localtime()),
-							description: trim(record[5])
+							intaddr: arrtoip(iptoarr(record[2 + recshift])),
+							intport: +record[3 + recshift],
+							expires: record[4 + recshift] - timelocal(localtime()),
+							descr: descr
 						});
 					}
 				}
-
 				leasefile.close();
 			}
 
-			const ipt = popen('iptables --line-numbers -t nat -xnvL MINIUPNPD 2>/dev/null');
-
+			// Workaround daemon bug with iptables >= 1.8.8 by parsing MINIUPNPD-POSTROUTING
+			// See https://github.com/miniupnp/miniupnp/issues/837
+			//const ipt = popen('iptables --line-numbers -t nat -xnvL MINIUPNPD 2>/dev/null');
+			const ipt = popen('iptables --line-numbers -t nat -xnvL MINIUPNPD-POSTROUTING 2>/dev/null');
 			if (ipt) {
 				for (let line = ipt.read('line'); length(line); line = ipt.read('line')) {
-					let m = match(line, /^([0-9]+)\s+([a-z]+).+dpt:([0-9]+) to:(\S+):([0-9]+)/);
-
+					//let m = match(line, /^([0-9]+) .+ ([ut].p) dpt:([0-9]+) to:(\S+):([0-9]+)/);
+					let m = match(line, /^([0-9]+) .+ \* +([0-9.]+) .+ ([ut].p) spt:([0-9]+) .+ ports: ([0-9]+)/);
 					if (m) {
 						push(rules, {
 							num: m[1],
-							proto: uc(m[2]),
-							extport: +m[3],
-							intaddr: arrtoip(iptoarr(m[4])),
-							intport: +m[5],
-							descr: ''
+							intaddr: arrtoip(iptoarr(m[2])),
+							intport: +m[4],
+							extport: +m[5],
+							proto: uc(m[3])
 						});
 					}
 				}
-
 				ipt.close();
 			}
 
 			const nft = popen('nft --handle list chain inet fw4 upnp_prerouting 2>/dev/null');
-
 			if (nft) {
 				for (let line = nft.read('line'), num = 1; length(line); line = nft.read('line')) {
-					let m = match(line, /^\t\tiif ".+" @nh,72,8 (0x6|0x11) th dport ([0-9]+) dnat ip to ([0-9.]+):([0-9]+)/);
-
+					let m = match(line, /^\t\tiif ".+" @nh,72,8 (0x6|0x11) th dport ([0-9]+).* dnat ip to ([0-9.]+):([0-9]+)/);
 					if (m) {
 						push(rules, {
 							num: `${num}`,
-							proto: (m[1] == '0x6') ? 'TCP' : 'UDP',
-							extport: +m[2],
 							intaddr: arrtoip(iptoarr(m[3])),
 							intport: +m[4],
-							descr: ''
+							extport: +m[2],
+							proto: (m[1] == '0x6') ? 'TCP' : 'UDP'
 						});
-
 						num++;
 					}
 				}
-
 				nft.close();
 			}
 
@@ -90,16 +86,14 @@ const methods = {
 				for (let rule in rules) {
 					for (let lease in leases) {
 						if (lease.proto == rule.proto &&
-						    lease.intaddr == rule.intaddr &&
-						    lease.intport == rule.intport &&
-						    lease.extport == rule.extport)
-						{
-							rule.descr = lease.description;
+							lease.intaddr == rule.intaddr &&
+							lease.intport == rule.intport &&
+							lease.extport == rule.extport) {
 							rule.expires = lease.expires;
+							rule.descr = lease.descr;
 							break;
 						}
 					}
-
 					for (let mac, hint in host_hints) {
 						if (rule.intaddr in hint.ipaddrs) {
 							rule.host_hint = hint.name;
@@ -107,7 +101,6 @@ const methods = {
 						}
 					}
 				}
-
 				req.reply({ rules });
 			});
 		}
@@ -117,19 +110,15 @@ const methods = {
 		args: { token: 'token' },
 		call: function(req) {
 			const idx = +req.args?.token;
-
 			if (idx > 0) {
 				const uci = cursor();
-				const leasefile = uci.get('upnpd', 'config', 'upnp_lease_file');
-
+				const leasefile = uci.get('upnpd', 'config', 'upnp_lease_file') || '/var/run/miniupnpd.leases';
 				if (access(leasefile)) {
 					system(['sed', '-i', '-e', `${idx}d`, leasefile]);
 					system(['/etc/init.d/miniupnpd', 'restart']);
 				}
-
 				return { result: 'OK' };
 			}
-
 			return { result: 'Bad request' };
 		}
 	}

--- a/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/ucode/luci.upnp
@@ -62,6 +62,23 @@ const methods = {
 					}
 				}
 				ipt.close();
+
+				const iptipv6 = popen('ip6tables --line-numbers -xnvL MINIUPNPD 2>/dev/null');
+				if (iptipv6) {
+					for (let line = iptipv6.read('line'); length(line); line = iptipv6.read('line')) {
+						let m = match(line, /^([0-9]+) .+ ([0-9a-f:]+)  ([ut].p) dpt:([0-9]+)/);
+						if (m) {
+							push(rules, {
+								num: '0',
+								intaddr: arrtoip(iptoarr(m[2])),
+								intport: +m[4],
+								extport: +m[4],
+								proto: uc(m[3])
+							});
+						}
+					}
+					iptipv6.close();
+				}
 			}
 
 			const nft = popen('nft --handle list chain inet fw4 upnp_prerouting 2>/dev/null');
@@ -80,6 +97,27 @@ const methods = {
 					}
 				}
 				nft.close();
+
+				const nftipv6 = popen('nft --handle list chain inet fw4 upnp_forward 2>/dev/null');
+				if (nftipv6) {
+					for (let line = nftipv6.read('line'), num = 1; length(line); line = nftipv6.read('line')) {
+						let m = match(line, /^\t\tiif ".+" th dport ([0-9]+) @nh,192,128 0x([0-9a-f]+) @nh,48,8 (0x6|0x11) accept/);
+						if (m) {
+							push(rules, {
+								num: '0',
+								intaddr: arrtoip(iptoarr(join(':', [substr(m[2], 0, 4),
+									substr(m[2], 4, 4), substr(m[2], 8, 4), substr(m[2], 12, 4), substr(m[2], 16, 4),
+									substr(m[2], 20, 4), substr(m[2], 24, 4), substr(m[2], 28, 4)
+								]))),
+								intport: +m[1],
+								extport: +m[1],
+								proto: (m[3] == '0x6') ? 'TCP' : 'UDP'
+							});
+							num++;
+						}
+					}
+					nftipv6.close();
+				}
 			}
 
 			return ubus.defer('luci-rpc', 'getHostHints', {}, function(rc, host_hints) {
@@ -95,7 +133,7 @@ const methods = {
 						}
 					}
 					for (let mac, hint in host_hints) {
-						if (rule.intaddr in hint.ipaddrs) {
+						if (rule.intaddr in hint.ipaddrs || rule.intaddr in hint.ip6addrs) {
 							rule.host_hint = hint.name;
 							break;
 						}


### PR DESCRIPTION
As this PR is extensive, the descriptions of the individual commits are collapsed here:

<details><summary><b>1. Improve existing UI</b></summary>

- Workaround daemon bug to fix listing of active port maps with iptables >= 1.8.8, and relax nftables parsing for the new release
- Change `Active Service Port Maps` to `Active Port Maps`, use the same wording for the table headings and ACL as on the overview status page
- Change description field header to `Added via / description`, always include the protocol and clearer/less redundant protocol labels
- Disable IPv6 mapping (`ipv6_disable`): UI option added, UCI exists
- Don't clear dependent options if UPnP IGD/STUN temporarily disabled
- Set `notify_interval` minimum to 900 s (default), as recommended by [UDA 1.1] (2x=1800 in the standard), because daemon/OpenWrt wrongly suggested 30x less in the past, and to reduce multicast traffic and power consumption in wireless networks, clearer help
- Report system instead of service uptime, UUID and service lease file: UI options removed (disabled, to keep translations) as rarely used
- Slightly improve some text strings
- Show hint if no suitable configuration found (missing related update), link to package manager, and show form as read-only to prevent changes
- Configure service lease file by default in rpcd ucode for full UI functionality without option set
- Refactoring by moving ubus connection as jow-/ucode@a58fe47 was merged
- Adapt to JavaScript ES6 and remove some line breaks and format files
- A commit has been prepared that manually adjusts the translations, without losing them

Fixes: https://github.com/openwrt/openwrt/issues/12843

[UDA 1.1]: https://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf#page=30
</details>

<details><summary><b><i>2. Add UPnP IGD Adjustments tab</i></b></summary>

And rearrange as many options

(to merge with prior)
</details>

<details><summary><b>3. Revision and adapt to new UCI options</b></summary>

The following settings UCI options been added or changed, and the previous options are migrated on updating:

- Only display `Active Port Maps` if the service is enabled and `Access Control List` if it is used
- Enable protocols (`enable_protocols`): Combined UI option added
- Allow CGNAT/STUN (`allow_cgnat`): Accept new values for IPv4 CGNAT use and update help with newer wording of RFC 5780
- STUN server (`stun_host`): Allow port inclusion
- STUN port: Removed, as now accepted in STUN server
- Override external IPv4 (`external_ip`): UI option added for CGNAT use
- Allow third-party mapping (`allow_third_party_mapping`): Inverted from secure mode and optionally extended to PCP
- Log level (`log_output`): Allow info log level
- UPnP IGD compatibility (`upnp_igd_compat`): Reworded/extensible
- Download/upload speed (`download_kbps`/`upload_kbps`): In kbit/s and datatype set, now, interface link speed by default
- Router/friendly name (`friendly_name`): UI option added to set name displayed in Windows Explorer, model/serial number removed
- Enable Networks / Access Control (`internal_network`): Section added to select the enabled networks and their access control. By:
  - Internal network (`interface`): UI option added to select the local/internal (LAN) network interface to enable the service for
  - Access defaults (`access_defaults`): UI option added to select access defaults for ports that all devices on the network can map
  - Accept extra ports (`accept_ports`): UI option added to accept these ports or port ranges on the network as well
  - Reject ports (`reject_ports`): UI option added to reject ports on the network; overrides other settings
  - Check ACL (`check_acl`): UI option added to check the ACL entries first; these extend/override the defaults
- Slightly improve introduction text

More details on changed options can be found in the dependent package PR

Fixes: https://github.com/openwrt/luci/issues/8313
Fixes: https://github.com/openwrt/luci/issues/8677
Depends on: https://github.com/openwrt/packages/pull/28765
</details>

<details><summary><b><i>4. Rename UCI section to settings v2.0</i></b></summary>

Rename UCI section `config` (v1.0) -> `settings` (v2.0), helps on migration and to distinguish the updated config from the previous one

(to merge with prior)
</details>

<details><summary><b><i>5. Update ACL options, migrate section</i></b></summary>

- Disableable and cloneable ACL entries, always translated `Action`
- Improve UI with direct editability, clearer help wording, and rename to `Access Control List`
- The ACL is now rejected last if not accepted by access defaults. Add (disabled) ACL template entries on migration
- Migrate ACL entries to the new section name `acl_entry`
- The following ACL UCI options been added or changed, and the previous options are migrated on updating:

acl_entry UCI options       | Change                     | Previous name
----------------------------|----------------------------|--------------
action                      | New/updated values     (1) |
int_port                    | Remove colon separator (2) | int_ports
ext_port                    | Remove colon separator (2) | ext_ports
descr_filter                | New option             (3) |

1. Allow disabled, and update action option to use the nftables terms (allow/deny -> accept/reject). To avoid adding inverted actions when changing via LuCI, ensure any missing are set, as LuCI and UCI had not matching action defaults. Missing actions are now ignored/logged
2. Ensure that the hyphen (-) is only used as a port range separator by migration, as the colon (:) is not valid in LuCI
3. Add missing UCI option to set a regular expression to check for a UPnP IGD IPv4 port map description, and fix the current collision with the comment field which was not noticed due to a daemon bug https://github.com/openwrt/packages/pull/24495 https://github.com/miniupnp/miniupnp/pull/853

(to merge with prior)
</details>

<details><summary><b><i>6. List active IPv6 port maps</i></b></summary>

Supports nftables and ip6tables; IPv6 port maps not yet deletable, as not parsing extra IPv6 lease file

(Note: Daemon's IPv6 lease file differs from the IPv4 format in order and separator. With IPv4, the remote IP field is missing and not retained during daemon restarts. IMHO, it would be better to have a complete/combined IPv4/IPv6 lease file upstream, with unique mapping IDs for reliable deletion in the 1st field, with a standardised order and more fields, and then use it without rewriting the parsing.)

(to merge with prior)

Fixes: https://github.com/openwrt/luci/issues/2985
Fixes: https://github.com/openwrt/luci/issues/5197
Fixes: https://github.com/openwrt/luci/pull/8567
</details>

<details><summary><b><i>7. Service-wide access control settings</i></b></summary>

This implements variant B

upnpd.settings UCI options   | Change                    | Previous name
-----------------------------|---------------------------|--------------
access_defaults              | New option            (1) |
accept_ports                 | New option            (1) |
reject_ports                 | New option            (2) |
check_acl                    | New option            (1) |

Notes:
1. New options added for default ports that all devices can map, client-specific permissions using the access control list (ACL) can extend/override the defaults. Access defaults: accept-high-ports accept-web+high-ports/accept-web-ports/accept-all-ports
2. Reject ports; overrides other settings. By default reject unsafe: FTP (21), Telnet (23), DCE/NetBIOS/SMB (135/137-139/445), RDP (3389)

(to merge with prior)
</details>

(The italic commits are intended to be merged with the prior ones after review)

#### Screenshots

The new service-wide access control functionality… can best be described using the LuCI screenshots:

<details><summary><b>New Access Control tab</b></summary>

<img width="940" height="707" alt="luci-access-control" src="https://github.com/user-attachments/assets/86a57126-6437-489e-bad6-b957e7fd33d1" />
</details>

<details><summary><b>Advanced Settings with new CGNAT functionality</b></summary>

<img width="940" height="389" alt="luci-advanced" src="https://github.com/user-attachments/assets/1bd3ad2b-b7b7-4af0-9f24-2c5e217a49ea" />
</details>

<details><summary><b>UPnP IGD Adjustments tab (new)</b></summary>

<img width="940" height="440" alt="luci-igd" src="https://github.com/user-attachments/assets/cea2bf80-1ced-4f26-baa8-907f6d5976b8" />
</details>

<details><summary><b>LuCI notification if the related package is not updated</b></summary>

<img width="940" height="107" alt="luci-notification" src="https://github.com/user-attachments/assets/6f813b44-83d5-4d34-99a3-afb7f6d03c02" />
</details>

<details><summary><b>Full LuCI screenshot</b></summary>

<img width="940" height="642" alt="luci-screenshot" src="https://github.com/user-attachments/assets/c627c93c-b1a3-4aeb-b292-856ed004714e" />
</details>

Depends on packages PR: https://github.com/openwrt/packages/pull/28765
Tested on: OpenWrt 24.10.8/25.12.5 with iptables/nftables
Maintainer: @jow-

**miniupnpd: Core functionality issues**
https://github.com/Self-Hosting-Group/miniupnpd-issues

The Port Control Protocol (PCP) is the successor to NAT-PMP, shares similar protocol concepts and packet formats, but supports IPv6 port mapping and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2026+: About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview