### PR TITLE
luci-app-rustdesk-server: add keep.d file

### DIFF
--- a/applications/luci-app-rustdesk-server/Makefile
+++ b/applications/luci-app-rustdesk-server/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=20250610
-PKG_RELEASE:=4
+PKG_VERSION:=20260313
+PKG_RELEASE:=1
 PKG_NAME:=luci-app-rustdesk-server
 PKG_MAINTAINER:=Guilherme Cardoso <luminoso@gmail.com>
 

--- a/applications/luci-app-rustdesk-server/root/lib/upgrade/keep.d/rustdesk-server
+++ b/applications/luci-app-rustdesk-server/root/lib/upgrade/keep.d/rustdesk-server
@@ -1,0 +1,4 @@
+/etc/rustdesk
+/usr/bin/hbbr
+/usr/bin/hbbs
+/usr/bin/rustdesk-utils


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)


Add a keep.d so that user doesn't loose the rustdesk private key generated and being used by the service when upgrading OpenWRT.

I've included the binaries that the user has to put in root, until I have some time to create the packages and then make this app depend on those packages.