### PR TITLE
luci-proto-modemmanager: Fix command injection in ACL permissions

### DIFF
--- a/protocols/luci-proto-modemmanager/root/usr/share/rpcd/acl.d/luci-proto-modemmanager.json
+++ b/protocols/luci-proto-modemmanager/root/usr/share/rpcd/acl.d/luci-proto-modemmanager.json
@@ -5,9 +5,24 @@
 			"cgi-io": [ "exec" ],
 			"file": {
 				"/usr/bin/mmcli -L -J": [ "exec" ],
-				"/usr/bin/mmcli -m [0-9]* -J": [ "exec" ],
-				"/usr/bin/mmcli -i [0-9]* -J": [ "exec" ],
-				"/usr/bin/mmcli -m [0-9]* --location-get -J": [ "exec" ]
+
+				"/usr/bin/mmcli -m [0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9][0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9][0-9][0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9][0-9][0-9][0-9] -J": [ "exec" ],
+
+				"/usr/bin/mmcli -i [0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -i [0-9][0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -i [0-9][0-9][0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -i [0-9][0-9][0-9][0-9] -J": [ "exec" ],
+				"/usr/bin/mmcli -i [0-9][0-9][0-9][0-9][0-9] -J": [ "exec" ],
+
+				"/usr/bin/mmcli -m [0-9] --location-get -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9] --location-get -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9][0-9] --location-get -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9][0-9][0-9] --location-get -J": [ "exec" ],
+				"/usr/bin/mmcli -m [0-9][0-9][0-9][0-9][0-9] --location-get -J": [ "exec" ]
 			}
 		}
 	}


### PR DESCRIPTION
The ACL permissions were originally authored to support just a single set of modem interfaces, at the numbers 0-9.  Eventually this was adjusted to support from 0 to 999 avoiding command injection.

However, as new commands were added, this was reverted again unfortunately. Language like "regex" has been used in the commit history for this ACL, and likely the core of the issue is confusion on how these are parsed.  These are all parsed [1] with fnmatch(...), and not regex(..).

A future useful change could be for rpcd to set the FNM_EXTMATCH option for fnmatch(...) to simplify this particular match statement, but that's not considered here since that's a much broader change that needs a longer discussion.

[1] https://github.com/openwrt/rpcd/blob/a4a5a298588960638a2e1713eb8fb858e1dbedeb/session.c#L143-L147


Fixes: 54aa701 ("luci-proto-modemmanager: add status page")
