### PR TITLE
luci-base: fix getBuiltinEthernetPorts crashing due to missing realpath import

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { stdin, access, dirname, basename, open, popen, glob, lsdir, readfile, readlink, error } from 'fs';
+import { stdin, access, dirname, basename, open, popen, glob, lsdir, readfile, readlink, realpath, error } from 'fs';
 import { cursor } from 'uci';
 
 import { init_list, init_index, init_enabled, init_action, conntrack_list, process_list } from 'luci.sys';
@@ -636,7 +636,7 @@ const methods = {
 			/* Workaround for targets that do not enumerate  all netdevs in board.json */
 			if (uname().machine in [ 'x86_64' ] &&
 			    match(ports[0]?.device, /^eth\d+$/)) {
-				let bus = readlink(`/sys/class/net/${ports[0].device}/device/subsystem`);
+				let bus = realpath(`/sys/class/net/${ports[0].device}/device/subsystem`);
 
 				for (let netdev in lsdir('/sys/class/net')) {
 					if (!match(netdev, /^eth\d+$/))
@@ -645,7 +645,7 @@ const methods = {
 					if (length(filter(ports, port => port.device == netdev)))
 						continue;
 
-					if (readlink(`/sys/class/net/${netdev}/device/subsystem`) != bus)
+					if (realpath(`/sys/class/net/${netdev}/device/subsystem`) != bus)
 						continue;
 
 					push(ports, { role: 'unknown', device: netdev });


### PR DESCRIPTION
The getBuiltinEthernetPorts x86_64 workaround block uses realpath() to resolve PCI subsystem symlinks, but realpath was not included in the 'fs' module import statement. This caused the ubus method to crash with "Unknown error" on hardware where NICs have PCI subsystem symlinks at different sysfs depths (e.g. onboard NIC vs PCIe card NIC).

Additionally, the original readlink() call only returns the raw symlink target string without resolving it to an absolute path. On hardware where different NICs have subsystem symlinks of different depths:

  eth0: /sys/class/net/eth0/device/subsystem -> ../../../bus/pci
  eth1: /sys/class/net/eth1/device/subsystem -> ../../../../bus/pci
  eth2: /sys/class/net/eth2/device/subsystem -> ../../../../bus/pci

readlink() returns different strings ("../../../bus/pci" vs "../../../../bus/pci") even though both resolve to /sys/bus/pci, causing eth1 and eth2 to be incorrectly excluded from the result.

Fix both issues by:
1. Adding realpath to the 'fs' module import statement
2. Replacing readlink() with realpath() in the workaround block so that symlinks of varying depths are correctly normalized before comparison

<img width="1634" height="294" alt="スクリーンショット 2026-03-16 200219" src="https://github.com/user-attachments/assets/1f65d51b-e5c8-4624-b3d6-96404c0000e0" />


<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] N/A (luci-base uses auto-generated version from git hash)
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)


* Mention: @jow for feedback

* Tested on: x86_64, OpenWrt 24.10 (kernel 6.6.71), Firefox

* Description:
  Fix two bugs in getBuiltinEthernetPorts that prevent PCI Ethernet
  ports from being detected on x86_64 hardware where onboard NIC and
  PCIe card NICs have sysfs subsystem symlinks at different depths.

  Bug 1: realpath() was called in the x86_64 workaround block but was
  not included in the 'fs' module import, causing ubus call luci
  getBuiltinEthernetPorts to crash with "Unknown error".

  Bug 2: The original readlink() returns raw symlink strings that
  differ by depth ("../../../bus/pci" vs "../../../../bus/pci"),
  causing ports to be incorrectly filtered out even though all paths
  resolve to /sys/bus/pci. Replacing with realpath() normalizes all
  paths before comparison.

Replaces #8425