### PR TITLE
luci-app-nut: update deprecated config names

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
@@ -148,7 +148,7 @@ return view.extend({
 			o.default = false;
 		}
 
-		s = m.section(form.TypedSection, 'master', _('UPS Primary'));
+		s = m.section(form.TypedSection, 'primary', _('UPS Primary'));
 		s.optional = true;
 		s.addremove = true;
 		s.anonymous = true;
@@ -177,7 +177,65 @@ return view.extend({
 		o.optional = false;
 		o.password = true;
 
-		s = m.section(form.TypedSection, 'slave', _('UPS Auxiliary'));
+		s = m.section(form.TypedSection, 'secondary', _('UPS Auxiliary'));
+		s.optional = true;
+		s.addremove = true;
+		s.anonymous = true;
+
+		o = s.option(form.Value, 'upsname', _('Name of UPS'), _('As configured by NUT'));
+		o.optional = false;
+
+		o = s.option(form.Value, 'hostname', _('Hostname or address of UPS'));
+		o.optional = false;
+		o.datatype = 'or(host,ipaddr)';
+
+		o = s.option(form.Value, 'port', _('Port'));
+		o.optional = true;
+		o.placeholder = 3493;
+		o.datatype = 'port';
+
+		o = s.option(form.Value, 'powervalue', _('Power value'));
+		o.optional = false;
+		o.datatype = 'uinteger';
+		o.default = 1;
+
+		o = s.option(form.Value, 'username', _('Username'));
+		o.optional = false;
+
+		o = s.option(form.Value, 'password', _('Password'));
+		o.optional = false;
+		o.password = true;
+
+		s = m.section(form.TypedSection, 'master', _('UPS Primary (deprecated)'), _('Uses deprecated section name. Please convert to "UPS Primary"'));
+		s.optional = true;
+		s.addremove = true;
+		s.anonymous = true;
+
+		o = s.option(form.Value, 'upsname', _('Name of UPS'), _('As configured by NUT'));
+		o.optional = false;
+
+		o = s.option(form.Value, 'hostname', _('Hostname or address of UPS'));
+		o.optional = false;
+		o.datatype = 'or(host,ipaddr)';
+
+		o = s.option(form.Value, 'port', _('Port'));
+		o.optional = true;
+		o.placeholder = 3493;
+		o.datatype = 'port';
+
+		o = s.option(form.Value, 'powervalue', _('Power value'));
+		o.optional = false;
+		o.datatype = 'uinteger';
+		o.default = 1;
+
+		o = s.option(form.Value, 'username', _('Username'));
+		o.optional = false;
+
+		o = s.option(form.Value, 'password', _('Password'));
+		o.optional = false;
+		o.password = true;
+
+		s = m.section(form.TypedSection, 'slave', _('UPS Auxiliary (deprecated)'), _('Uses deprecated section name. Please convert to "UPS Auxilary"'));
 		s.optional = true;
 		s.addremove = true;
 		s.anonymous = true;

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -56,8 +56,10 @@ return view.extend({
 		o.optional = true;
 
 		o = s.option(form.ListValue, 'upsmon', _('Role'));
-		o.value('slave', _('Auxiliary'));
-		o.value('master', _('Primary'));
+		o.value('secondary', _('Auxiliary'));
+		o.value('primary', _('Primary'));
+		o.value('slave', _('Auxiliary (deprecated)'));
+		o.value('master', _('Primary (deprecated)'));
 		o.optional = false;
 
 		// Listen settings


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
      OpenWrt Version: OpenWrt SNAPSHOT r33436-7d2c244646
      OpenWrt Target/Subtarget: bcm27xx/bcm2709
      OpenWrt Device: Raspberry Pi 2 Model B Rev 1.1

      UPS: Tripp-Lite ECO550U
      UPS: Tripp-Lite AVR550UPS
      UPS: dummy-ups
- [x] \( Preferred ) Mention: @danielfdickinson @systemcrash 
- [x] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
      Depends on: https://github.com/openwrt/packages/pull/28875
- [x] Description: (describe the changes proposed in this PR)

**Description:**
  Some years ago upstream changed the names the primary/secondary
    UPS system/monitor from master/slave to primary/secondary. It is uncertain
    how much longer these deprecated names will be accepted by NUT.
    Therefore update naming to match upstream documentation and configuration.
    See <https://networkupstools.org/docs/man/upsmon.html>,
    <https://networkupstools.org/docs/man/upsmon.conf.html>, and
    <https://networkupstools.org/docs/man/upsd.users.html>.
