### PR TITLE
[25.12] luci-app-pbr: update to 1.2.2-r12

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=10
+PKG_RELEASE:=12
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0

Description:
* version bump to match principal package

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 29dc13f4e0f5827876329174d8ccb07c11783862)