### PR TITLE
[25.12] luci-app-adblock-fast: update to 1.2.2-r12

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=10
+PKG_RELEASE:=12
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-adblock-fast/

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -12,7 +12,7 @@ var pkg = {
 		return "adblock-fast";
 	},
 	get LuciCompat() {
-		return 13;
+		return 14;
 	},
 	get ReadmeCompat() {
 		return "";
@@ -227,6 +227,13 @@ var _setInitAction = rpc.declare({
 	expect: { result: false },
 });
 
+var _setRpcdToken = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "setRpcdToken",
+	params: ["name", "token"],
+	expect: { result: false },
+});
+
 var RPC = {
 	listeners: [],
 	on: function (event, callback) {
@@ -259,6 +266,9 @@ var RPC = {
 					this.emit("setInitAction", { timeout: true });
 				}.bind(this),
 			);
+	},
+	setRpcdToken: function (name, token) {
+		return _setRpcdToken(name, token);
 	},
 };
 

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
@@ -803,6 +803,27 @@ return view.extend({
 		o.value("1", _("Enable Debugging"));
 		o.default = "0";
 
+		o = s1.taboption(
+			"tab_advanced",
+			form.Value,
+			"rpcd_token",
+			_("Remote Access Token"),
+			_(
+				"Token for <a href=\"" + pkg.URL + "#chrome-extension\" target=\"_blank\">Google Chrome extension</a> or other remote API access. " +
+				"Copy this value into the extension settings as the password. " +
+				"Changing it here will update the API user password on save.",
+			),
+		);
+		o.default = "";
+		o.rmempty = true;
+		o.write = function (section_id, formvalue) {
+			var currentValue = L.uci.get(pkg.Name, section_id, "rpcd_token");
+			if (formvalue && formvalue !== currentValue) {
+				RPC.setRpcdToken(pkg.Name, formvalue);
+			}
+			return L.uci.set(pkg.Name, section_id, "rpcd_token", formvalue);
+		};
+
 		s2 = m.section(
 			form.NamedSection,
 			"config",

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -15,7 +15,7 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:859
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:880
 msgid "Action"
 msgstr ""
 
@@ -41,11 +41,11 @@ msgstr ""
 msgid "AdBlock-Fast"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:810
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:831
 msgid "AdBlock-Fast - Allowed and Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:834
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:855
 msgid "AdBlock-Fast - Allowed and Blocked Lists URLs"
 msgstr ""
 
@@ -54,7 +54,7 @@ msgstr ""
 msgid "AdBlock-Fast - Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:403
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:413
 msgid "AdBlock-Fast - Status"
 msgstr ""
 
@@ -70,12 +70,12 @@ msgstr ""
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:860
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:865
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:881
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:886
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:818
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:839
 msgid "Allowed Domains"
 msgstr ""
 
@@ -96,17 +96,17 @@ msgstr ""
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:861
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:865
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:882
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:886
 msgid "Block"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:826
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:847
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:42
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:450
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:460
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
@@ -118,7 +118,7 @@ msgstr ""
 msgid "Cache file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:467
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:477
 msgid "Cache file found."
 msgstr ""
 
@@ -130,11 +130,11 @@ msgstr ""
 msgid "Compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:455
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:465
 msgid "Compressed cache file created."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:469
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:479
 msgid "Compressed cache file found."
 msgstr ""
 
@@ -194,7 +194,7 @@ msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:712
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:722
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:515
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:662
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:778
@@ -206,11 +206,11 @@ msgstr ""
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:422
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:432
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:706
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:716
 msgid "Disabling %s service"
 msgstr ""
 
@@ -238,12 +238,12 @@ msgstr ""
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:693
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:703
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:516
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:663
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:779
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:792
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:855
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:876
 msgid "Enable"
 msgstr ""
 
@@ -280,11 +280,11 @@ msgstr ""
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:687
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:697
 msgid "Enabling %s service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:550
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:560
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:924
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:945
 msgid "Failed to update cron schedule."
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:458
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:468
 msgid "Force DNS ports:"
 msgstr ""
 
@@ -414,7 +414,7 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:598
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:608
 msgid "Force redownloading %s block lists"
 msgstr ""
 
@@ -428,6 +428,10 @@ msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:588
 msgid "Friday"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/adblock-fast-api.json:3
+msgid "Grant API access for adblock-fast remote control"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json:3
@@ -458,11 +462,11 @@ msgid ""
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:819
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:840
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:827
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:848
 msgid "Individual domains to be blocked."
 msgstr ""
 
@@ -513,11 +517,11 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:877
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:898
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:868
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:889
 msgid "Name/URL"
 msgstr ""
 
@@ -537,7 +541,7 @@ msgstr ""
 msgid "No blocked list URLs nor blocked-domains enabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:437
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:447
 msgid "Not installed or not found"
 msgstr ""
 
@@ -545,10 +549,10 @@ msgstr ""
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:609
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:631
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:640
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:647
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:619
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:641
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:650
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:657
 msgid "Pause"
 msgstr ""
 
@@ -578,7 +582,7 @@ msgstr ""
 msgid "Pick the dnsmasq instance(s) for ad-blocking"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:482
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:492
 msgid "Please %sdonate%s to support development of this project."
 msgstr ""
 
@@ -599,8 +603,12 @@ msgstr ""
 msgid "Processing lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:604
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:614
 msgid "Redownload"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:810
+msgid "Remote Access Token"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:102
@@ -610,7 +618,7 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:70
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:647
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:657
 msgid "Restarting"
 msgstr ""
 
@@ -650,23 +658,23 @@ msgstr ""
 msgid "Select how often the update should run."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:752
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:762
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:476
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:486
 msgid "Service Details"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:537
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:547
 msgid "Service Errors"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:407
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:417
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:507
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:517
 msgid "Service Warnings"
 msgstr ""
 
@@ -680,11 +688,11 @@ msgstr ""
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:842
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:863
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:852
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:873
 msgid "Size: %s"
 msgstr ""
 
@@ -692,7 +700,7 @@ msgstr ""
 msgid "Some output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:585
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:595
 msgid "Start"
 msgstr ""
 
@@ -700,7 +708,7 @@ msgstr ""
 msgid "Starting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:579
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:589
 msgid "Starting %s service"
 msgstr ""
 
@@ -708,7 +716,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:674
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:684
 msgid "Stop"
 msgstr ""
 
@@ -720,7 +728,7 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:668
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:678
 msgid "Stopping %s service"
 msgstr ""
 
@@ -779,11 +787,15 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:812
+msgid "Token for <a href=\""
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:585
 msgid "Tuesday"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:881
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:902
 msgid "URL"
 msgstr ""
 
@@ -792,7 +804,7 @@ msgid ""
 "URL to the external dnsmasq config file, see the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:835
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:856
 msgid "URLs to file(s) containing lists to be allowed or blocked."
 msgstr ""
 
@@ -800,13 +812,13 @@ msgstr ""
 msgid "Unable to retrieve %s status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:846
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:873
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:867
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:894
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:50
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:547
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:557
 msgid "Unknown error"
 msgstr ""
 
@@ -814,7 +826,7 @@ msgstr ""
 msgid "Unknown message"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:517
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:527
 msgid "Unknown warning"
 msgstr ""
 
@@ -851,7 +863,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:410
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:420
 msgid "Version %s"
 msgstr ""
 

--- a/applications/luci-app-adblock-fast/root/etc/uci-defaults/41_adblock-fast-api
+++ b/applications/luci-app-adblock-fast/root/etc/uci-defaults/41_adblock-fast-api
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Create adblock-fast-api system user if it doesn't exist
+if ! grep -q '^adblock-fast-api:' /etc/passwd; then
+	echo 'adblock-fast-api:x:501:501:adblock-fast API user:/dev/null:/bin/false' >> /etc/passwd
+	echo 'adblock-fast-api:!:0:0:99999:7:::' >> /etc/shadow
+fi
+
+# Add rpcd login config if not present
+if ! uci -q get rpcd.adblock_fast_api >/dev/null 2>&1; then
+	uci set rpcd.adblock_fast_api='login'
+	uci set rpcd.adblock_fast_api.username='adblock-fast-api'
+	uci set rpcd.adblock_fast_api.password='$p$adblock-fast-api'
+	uci add_list rpcd.adblock_fast_api.read='adblock-fast-api'
+	uci add_list rpcd.adblock_fast_api.write='adblock-fast-api'
+	uci commit rpcd
+fi
+
+# Generate random rpcd_token if not already set
+_token="$(uci -q get adblock-fast.config.rpcd_token)"
+if [ -z "$_token" ]; then
+	_token="$(head -c 24 /dev/urandom | base64 | tr -d '/+=' | head -c 24)"
+	uci set adblock-fast.config.rpcd_token="$_token"
+	uci commit adblock-fast
+fi
+
+# Sync rpcd_token to system password for adblock-fast-api user
+if grep -q '^adblock-fast-api:' /etc/passwd; then
+	printf '%s\n%s\n' "$_token" "$_token" | passwd adblock-fast-api >/dev/null 2>&1
+fi
+
+[ -x /etc/init.d/rpcd ] && /etc/init.d/rpcd reload
+exit 0

--- a/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/adblock-fast-api.json
+++ b/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/adblock-fast-api.json
@@ -1,0 +1,19 @@
+{
+	"adblock-fast-api": {
+		"description": "Grant API access for adblock-fast remote control",
+		"read": {
+			"ubus": {
+				"luci.adblock-fast": [
+					"getInitStatus"
+				]
+			}
+		},
+		"write": {
+			"ubus": {
+				"luci.adblock-fast": [
+					"setInitAction"
+				]
+			}
+		}
+	}
+}

--- a/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json
+++ b/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json
@@ -33,7 +33,8 @@
 				"luci.adblock-fast": [
 					"syncCron",
 					"setCronEntry",
-					"setInitAction"
+					"setInitAction",
+					"setRpcdToken"
 				]
 			}
 		}

--- a/applications/luci-app-adblock-fast/root/usr/share/rpcd/ucode/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/share/rpcd/ucode/luci.adblock-fast
@@ -14,6 +14,7 @@ ubus call luci.adblock-fast getFileUrlFilesizes '{"name":"adblock-fast"}'
 ubus call luci.adblock-fast setCronEntry '{"name":"adblock-fast","entry":"0 4 * * * /etc/init.d/adblock-fast dl"}'
 ubus call luci.adblock-fast setInitAction '{"name":"adblock-fast","action":"start"}'
 ubus call luci.adblock-fast syncCron '{"name":"adblock-fast","action":"start"}'
+ubus call luci.adblock-fast setRpcdToken '{"name":"adblock-fast","token":"newtoken"}'
 */
 
 import adb from '/lib/adblock-fast/adblock-fast.uc';
@@ -21,7 +22,7 @@ import { readfile, writefile, stat, rename, unlink, chmod, mkdir, access } from 
 import { cursor } from 'uci';
 
 const packageName = 'adblock-fast';
-const rpcdCompat = 13; // ucode-lsp disable
+const rpcdCompat = 14; // ucode-lsp disable
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -440,6 +441,30 @@ const methods = {
 	syncCron: {
 		args: { name: 'name', action: 'action' },
 		call: sync_cron,
+	},
+	setRpcdToken: {
+		args: { name: 'name', token: 'token' },
+		call: function(req) {
+			let name = req.args.name || packageName;
+			let token = req.args.token;
+			if (name != packageName || !token || token == '')
+				return { result: false };
+
+			// Update UCI config
+			let uci_ctx = cursor();
+			uci_ctx.load(packageName);
+			uci_ctx.set(packageName, 'config', 'rpcd_token', token);
+			uci_ctx.commit(packageName);
+
+			// Sync to system password
+			if (system(sprintf("grep -q '^adblock-fast-api:' /etc/passwd")) == 0) {
+				system(sprintf("printf '%%s\\n%%s\\n' '%s' '%s' | passwd adblock-fast-api >/dev/null 2>&1",
+					replace(token, "'", "'\\''"),
+					replace(token, "'", "'\\''")));
+			}
+
+			return { result: true };
+		}
 	},
 };
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0

Description:
status.js:
* add: declare setRpcdToken call

overview.js:
* add: option to set a custom RPCD Token

Uci-defaults:
* add: new script to add adblock_fast_api

Acl.d:
* add: new manifest for adblock_fast_api access
* add: setRpcdToken call

RPCD:
* add: setRpcdToken sets password for adblock_fast_api user

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 13680954374a4a358b368a3a882460119230854c)