### PR TITLE
luci-app-attendedsysupgrade: format error details

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -283,6 +283,9 @@ return view.extend({
 			...firmware
 		};
 		const request_str = JSON.stringify(request_data, null, 4);
+		if (typeof response.detail != "string") {
+			response.detail = JSON.stringify(response.detail, null, 4);
+		}
 		let body = [
 			E('p', {}, [
 				_('First, check'), ' ',


### PR DESCRIPTION
On certain rare errors, the ASU server returns a JSON formatted block of details.  The app was just displaying this object directly, resulting in displaying a useless 'Object [object]'.  If the error details are not a string, then stringify it so we can make sense of the error.
