### PR TITLE
luci-proto-batman-adv: protocol "Batman VLAN Interface"

### DIFF
--- a/protocols/luci-proto-batman-adv/htdocs/luci-static/resources/protocol/batadv_vlan.js
+++ b/protocols/luci-proto-batman-adv/htdocs/luci-static/resources/protocol/batadv_vlan.js
@@ -1,0 +1,72 @@
+'use strict';
+'require uci';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^bat\d_\d+$/);
+
+return network.registerProtocol('batadv_vlan', {
+	getI18n: function() {
+		return _('Batman VLAN Interface');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || this.sid;
+	},
+
+	getOpkgPackage: function() {
+		return 'kmod-batman-adv';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var dev = this.getL3Device() || this.getDevice(),
+			o;
+
+		var batadvInterfaceNames = [];
+		var uciInterfaces = uci.sections('network', 'interface');
+		for (var i = 0; i < uciInterfaces.length; i++)
+			if (uciInterfaces[i].proto == 'batadv')
+				batadvInterfaceNames.push(uciInterfaces[i]['.name']);
+
+		o = s.taboption('general', widgets.DeviceSelect, '_batadv_vlan_device', _('Device'),
+				_('If not listed, please open the drop-down list and type in the name of the Batman VLAN device in the \'custom\' field.'));
+		o.ucioption = 'device';
+		o.optional = false;
+		o.placeholder = _('Select Batman VLAN device…');
+		o.filter = function(section_id, value) {
+			for (var i = 0; i < batadvInterfaceNames.length; i++)
+				if (value.startsWith(batadvInterfaceNames[i] + '.'))
+					return true;
+			return false;
+		}
+		o.validate = function(section_id, value) {
+			for (var i = 0; i < batadvInterfaceNames.length; i++)
+				if (value.startsWith(batadvInterfaceNames[i] + '.'))
+					return true;
+			return _("Please open the drop-down list and select or type in the name of the Batman VLAN device.");
+		}
+
+		o = s.taboption('general', form.Flag, 'ap_isolation', _('AP Isolation'),
+				_('Enable AP Isolation to isolate wireless clients connected to this Batman VLAN on this AP from wireless clients connected to this Batman VLAN on different APs.  To isolate all wireless clients connected to this Batman VLAN on all APs from each other, be sure to enable this option on all APs, and be sure to enable additional wireless client isolation options (\'isolate\' and \'bridge_isolate\') for all associated wireless interfaces on all APs.'));
+		o.default = o.disabled;
+		o.optional = false;
+	}
+});
+


### PR DESCRIPTION
A batman-adv VLAN interface has protocol 'batadv_vlan' and allows configuration of option 'ap_isolation' for a batman-adv VLAN device.

This adds support for configuration of such an interface to LuCI.

- :white_check_mark: This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- :white_check_mark: Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- :white_check_mark: Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
-  :white_check_mark: Tested on: x86_64, OpenWrt OpenWrt 25.12.1, r32768-b21cfa8f8c, firefox  :white_check_mark: ; aarch64_cortex-a53, ARMv8 Processor rev 4, OpenWrt 25.12.0 r32713-f919e7899d, firefox :white_check_mark:
- :white_check_mark: Mention: @onemarcfifty wrote the support for the other luci-proto-batman-adv scripts
- :white_check_mark: Description: LuCI -> Network -> Interfaces -> Add New Interface... -> Protocol: "Batman VLAN Interface". This requires that an interface with protocol "Batman Device" has already been created. For more information, see https://openwrt.org/docs/guide-user/network/wifi/mesh/batman?s[]=open#ap_isolation_for_batman-adv_vlans and https://openwrt.org/docs/guide-user/network/wifi/mesh/batman?s[]=open#batman-adv_options_for_vlans
