### PR TITLE
luci-app-https-dns-proxy: add ADnull DNS provider

### DIFF
--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adnull.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adnull.dns.json
@@ -1,0 +1,6 @@
+{
+	"title": "ADnull (UA)",
+	"template": "https://dns.adnull.com/dns-query",
+	"bootstrap_dns": "188.190.191.78,188.190.191.52",
+	"help_link": "https://adnull.com"
+}


### PR DESCRIPTION
Adds ADnull — a personal DNS-over-HTTPS resolver with ad, tracker and malware blocking. Based in Ukraine.

- DoH URL: `https://dns.adnull.com/dns-query`
- Bootstrap DNS: `188.190.191.78`, `188.190.191.52`
- Privacy policy: https://adnull.com/en/privacy-policy