### PR TITLE
[24.10] luci-app-pbr: bugfix

### DIFF
--- a/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
+++ b/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
@@ -216,7 +216,7 @@ get_supported_interfaces() {
 	config_foreach _build_ifaces_supported 'interface'
 	is_tor_running && ifacesSupported="$ifacesSupported tor"
 	for i in $supported_interface; do
-		is_xray "$i" && ifacesSupported="$ifacesSupported $i"
+		str_contains_word "$ifacesSupported" "$i" || ifacesSupported="${ifacesSupported}${i} "
 	done
 	[ "$webui_show_ignore_target" -eq '1' ] && ifacesSupported="$ifacesSupported ignore"
 	json_init


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.0

Description:
* fix: allow explicitly supported interfaces as targets in policies

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit ce7e1878280d8c7eebbc428baf71397f7771676c)