### PR TITLE
luci-app-crowdsec-firewall-bouncer: rename UCI config to crowdsec-firewall-bouncer

### DIFF
--- a/applications/luci-app-crowdsec-firewall-bouncer/htdocs/luci-static/resources/view/crowdsec-firewall-bouncer/form.js
+++ b/applications/luci-app-crowdsec-firewall-bouncer/htdocs/luci-static/resources/view/crowdsec-firewall-bouncer/form.js
@@ -7,7 +7,7 @@ return view.extend({
 	render: function() {
 		let m, s, o;
 
-		m = new form.Map('crowdsec', _('CrowdSec'),
+		m = new form.Map('crowdsec-firewall-bouncer', _('CrowdSec'),
 			_('Gain %s protection against malicious IPs.'.format('<a href="http://www.crowdsec.net">crowd-sourced</a>')) + '<br/>' +
 			_('Benefit from the most accurate CTI in the world.'));
 

--- a/applications/luci-app-crowdsec-firewall-bouncer/root/usr/share/rpcd/acl.d/luci-app-crowdsec-firewall-bouncer.json
+++ b/applications/luci-app-crowdsec-firewall-bouncer/root/usr/share/rpcd/acl.d/luci-app-crowdsec-firewall-bouncer.json
@@ -2,10 +2,10 @@
 	"luci-app-crowdsec-firewall-bouncer": {
 		"description": "Grant UCI access to LuCI app crowdsec-firewall-bouncer",
 		"read": {
-			"uci": [ "crowdsec" ]
+			"uci": [ "crowdsec-firewall-bouncer" ]
 		},
 		"write": {
-			"uci": [ "crowdsec" ]
+			"uci": [ "crowdsec-firewall-bouncer" ]
 		}
 	}
 }


### PR DESCRIPTION
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: mediatek/filogic (Banana Pi BPI-R4), OpenWrt 25.12.0-rc5 :white_check_mark:
- [x] ( Preferred ) Mention: @ne20002
- [x] ( Optional ) Depends on: openwrt/packages#28991
- [x] Description: Update UCI config name from `crowdsec` to `crowdsec-firewall-bouncer` in
  `form.js` and the rpcd ACL file, to match the config file rename in the companion packages PR
  openwrt/packages#28991. Without this change, the LuCI app would silently read and write from
  the wrong UCI config file.
