### PR TITLE
[24.10] luci-app-adblock-fast: update to 1.2.2-r16

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=14
+PKG_RELEASE:=16
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-adblock-fast/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1

Description:
* version bump to match principal package

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 885f67a651a51ae676e4d5fb7d92c1872c465d02)