### PR TITLE
luci-proto-wireguard: add IPv6 routed prefix (ip6prefix) support

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -157,6 +157,10 @@ return network.registerProtocol('wireguard', {
 		o.datatype = 'ipaddr';
 		o.optional = true;
 
+		o = s.taboption('general', form.DynamicList, 'ip6prefix', _('IPv6 routed prefix'), _('IPv6 prefix routed to this interface for use by clients. Use this for Prefix Delegation.'));
+		o.datatype = 'cidr6';
+		o.optional = true;
+
 		o = s.taboption('general', form.Flag, 'nohostroute', _('No Host Routes'), _('Optional. Do not create host routes to peers.'));
 		o.optional = true;
 
@@ -181,9 +185,6 @@ return network.registerProtocol('wireguard', {
 
 			return true;
 		};
-
-		o = s.taboption('advanced', form.DynamicList, 'ip6prefix', _('IPv6 routed prefix'), _('This is the prefix routed to you by your provider for use by clients'));
-		o.datatype = 'cidr6';
 
 		// -- peers -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

\ip6prefix\ for WireGuard was added on the **Advanced** tab in #7548.
This PR moves it to **General** (like 6in4 and similar protocols) so
Prefix Delegation is easier to find. No change to the UCI option name.

## Related

- Supersedes closed attempts: #8049, #8050, #8487, #8517
- Builds on merged: #7548

## Checklist

- Single commit rebased on current \master\
- Signed-off-by matches author (Maksym Vasylchenko)
- Commit subject <= 60 characters
- No whitespace-only / tabs-to-spaces churn (1 file, 7 lines)