### PR TITLE
luci-mod-status: add dynamic ethernet devices to port status view

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/29_ports.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/29_ports.js
@@ -412,13 +412,18 @@ return baseclass.extend({
 				});
 			});
 
-			return Promise.all(psePromises).then((pseResults) => {
+			return Promise.all([
+				Promise.all(psePromises),
+				L.resolveDefault(fs.list('/sys/class/net'), [])
+			]).then(([pseResults, devs]) => {
 				const pseMap = {};
 				pseResults.forEach((r) => {
 					if (r.pse)
 						pseMap[r.name] = r.pse;
 				});
+				const present = (devs || []).map(d => d.name || d);
 				data.push(pseMap);
+				data.push(present);
 				return data;
 			});
 		});
@@ -459,6 +464,23 @@ return baseclass.extend({
 							netdev: network.instantiateDevice(board.network[k].device)
 						});
 				}
+			}
+		}
+
+		const presentDevices = new Set(data[6] || []);
+		for (const dev in port_map) {
+			if (dev === 'lo')
+				continue;
+		
+			if (!presentDevices.has(dev))
+				continue;
+		
+			if (!known_ports.find(p => p.device === dev)) {
+				known_ports.push({
+					role: 'extra',
+					device: dev,
+					netdev: network.instantiateDevice(dev)
+				});
 			}
 		}
 


### PR DESCRIPTION
Extend the port status view to include dynamically detected ethernet interfaces (e.g. USB adapters) in addition to board-defined ports.

Devices are derived from netifd's device map and merged into the existing port list if not already present. Loopback interfaces are excluded.

To ensure correct hotplug behaviour, the device list is filtered against the current kernel device list (/sys/class/net), preventing stale entries from being displayed after device removal.

Tested on:
- GL.iNet GL-MT6000
- OpenWrt 25.12.1
- Apple USB ethernet adapters (100 Mbps and 2.5 Gbps)

Verified link state changes and device hotplug (add/remove).