### PR TITLE
luci-mod-network: fix uci.remove() deleting entire radio section on wifi join

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -2359,7 +2359,7 @@ return view.extend({
 					uci.set('wireless', radioDev.getName(), 'htmode', 'HT'+w);
 				}
 				else {
-					uci.remove('wireless', radioDev.getName(), 'htmode');
+					uci.unset('wireless', radioDev.getName(), 'htmode');
 				}
 
 				uci.set('wireless', radioDev.getName(), 'channel', bss.channel);


### PR DESCRIPTION
## Problem

When joining a Wi-Fi network via Scan → Join Network, if the scanned BSS
has no VHT/HE capability information (e.g. a basic 802.11b/g/n AP), the
`handleJoinConfirm` callback enters the `else` branch at line 2152 and calls:

    uci.remove('wireless', radioDev.getName(), 'htmode');

The intent is to remove only the `htmode` option. However, `uci.remove()`
in `uci.js` only accepts two parameters `(conf, sid)` — the third parameter
is silently ignored. This causes the **entire wifi-device section** (e.g.
`radio0`) to be marked for deletion in the rpcd session delta.

## Symptoms

- After clicking "Join Network", the Wireless Overview page shows
  "This section contains no values yet"
- All wifi-iface entries disappear from the page
- The rpcd session delta file contains `-wireless.radio0`
- The bug persists until the user logs out or the session expires

## Root Cause

`uci.js` defines:

- `remove(conf, sid)` → deletes entire section
- `unset(conf, sid, opt)` → removes a single option (calls `set(conf, sid, opt, null)`)

The code should use `uci.unset()` instead of `uci.remove()` when removing
a single option.

## Fix

```diff
-				uci.remove('wireless', radioDev.getName(), 'htmode');
+				uci.unset('wireless', radioDev.getName(), 'htmode');

## Testing

Tested on OpenWrt 24.10-SNAPSHOT (aarch64, BCM43455):

1. Network → Wireless → Scan → Join a 2.4GHz b/g/n network
2. Wireless Overview page displays correctly after join
3. `uci show wireless` confirms radio0 section is preserved