### PR TITLE
luci-mod-system: add current host to reset reconnect

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js
@@ -337,7 +337,7 @@ return view.extend({
 		if (opts['keep'][0].checked)
 			ui.awaitReconnect(window.location.host);
 		else
-			ui.awaitReconnect('192.168.1.1', 'openwrt.lan');
+			ui.awaitReconnect(window.location.host, '192.168.1.1', 'openwrt.lan');
 	},
 
 	handleBackupList(ev) {


### PR DESCRIPTION
## Pull Request details

### Description

When performing a sysupgrade without keeping settings, `ui.awaitReconnect()`
only tries the hardcoded `192.168.1.1` and `openwrt.lan`. This fails silently
when the device uses a different static IP, forcing the user to manually
navigate to the correct address.

This change prepends `window.location.host` to the reconnect target list in
the factory reset code path, keeping `192.168.1.1` and `openwrt.lan` as
fallbacks. This matches the behavior already used when settings are kept.

Common use case: custom images built with the OpenWrt Image Builder with
pre-configured static IPs. After flashing, the device comes back on a known
address that differs from the defaults.

### Screenshot or video of changes _(If applicable)_

N/A - behavior change only visible during sysupgrade reconnect.

### Maintainer _(Preferred)_

@jow-

---

## Tested on
**OpenWrt version:** 24.10.6
**LuCI version:** git-24.xxx (luci-mod-system)
**Web browser:** Firefox

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
