### PR TITLE
[25.12] luci-app-radicale3: cherry-pick updates for Radicale 3.7.1

### DIFF
--- a/applications/luci-app-radicale3/Makefile
+++ b/applications/luci-app-radicale3/Makefile
@@ -10,6 +10,8 @@ PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PROVIDES:=luci-app-radicale2
 
+EXTRA_DEPENDS:=radicale3 (>= 3.7.1-1)
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-radicale3/htdocs/luci-static/resources/view/radicale3.js
+++ b/applications/luci-app-radicale3/htdocs/luci-static/resources/view/radicale3.js
@@ -453,21 +453,19 @@ return view.extend({
 		o = s.taboption('main', form.ListValue, 'level', _('Log Level'));
 		s.rmempty = true;
 		o.value('', _('Default (info)'));
+		o.value('trace', _('Trace'));
 		o.value('debug', _('Debug'));
 		o.value('info', _('Info'));
+		o.value('notice', _('Notice'));
 		o.value('warning', _('Warning'));
 		o.value('error', _('Error'));
 		o.value('critical', _('Critical'));
+		o.value('alert', _('Alert'));
 		o.default = '';
 
 		// TODO: Add more logging options
 
 		s.tab('advanced', _('Advanced'));
-
-		o = s.taboption('advanced', form.Flag, 'trace_on_debug', _('Trace on debug'), _('Do not filter debug messages starting with \'TRACE\''));
-		o.rmempty = true;
-		o.default = o.disabled;
-		o.depends('level', 'debug');
 
 		o = s.taboption('advanced', form.Flag, 'mask_passwords', _('Mask Passwords'), _('Redact passwords in logs'));
 		o.rmempty = true;


### PR DESCRIPTION
## Pull request details

### Description
Radicale 3.7.1 made some breaking changes to the config, so we need to update the UCI config to match.

(cherry picked from commit 8d4ebf01e7580348aef897f99d00e41bfaefb59b)

### Maintainer _(preferred)_
@danielfdickinson

---

## Tested on
**OpenWrt version:** OpenWrt 25.12-SNAPSHOT r32866-99a502bbc4
**LuCI version:** LuCI openwrt-25.12 branch (26.101.22673~0c81d2d)
**Web browser(s):** Firefox ESR 140.9.1esr (64-bit)

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [x] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
   Depends on https://github.com/openwrt/packages/pull/29175
