### PR TITLE
luci-app-snmpd: add strong SNMPv3 crypto options

### DIFF
--- a/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
+++ b/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
@@ -457,10 +457,14 @@ return L.view.extend({
 		go = g.option(form.ListValue, 'auth_type',
 			_('SNMPv3 authentication type'));
 		go.value('', _('none'));
+		go.value('SHA-512', _('SHA-512'));
+		go.value('SHA-384', _('SHA-384'));
+		go.value('SHA-256', _('SHA-256'));
+		go.value('SHA-224', _('SHA-224'));
 		go.value('SHA', _('SHA'));
 		go.value('MD5', _('MD5'));
 		go.rmempty = true;
-		go.default = 'SHA';
+		go.default = 'SHA-256';
 
 		// SNMPv3 auth pass
 		go = g.option(form.Value, 'auth_pass',
@@ -476,6 +480,8 @@ return L.view.extend({
 		go = g.option(form.ListValue, 'privacy_type',
 			_('SNMPv3 encryption type'));
 		go.value('', _('none'));
+		go.value('AES-256', _('AES-256'));
+		go.value('AES-192', _('AES-192'));
 		go.value('AES', _('AES'));
 		go.value('DES', _('DES'));
 		go.rmempty = true;


### PR DESCRIPTION
Add SHA-256, SHA-384, SHA-512, SHA-224 authentication and AES-192,
AES-256 encryption options to the SNMPv3 user configuration.

net-snmp has supported these algorithms for a while, but the LuCI
dropdown only offered SHA(-1), MD5, AES(-128) and DES. Modern security
standards (e.g. EN 18031 CCK-1) require at least 112-bit security
strength, which rules out SHA-1 (80-bit) and DES (56-bit).

The default authentication type is changed from SHA to SHA-256.

The init script already passes `auth_type` and `privacy_type` directly to
net-snmp's `createUser`, so no backend changes are needed.

Tested with net-snmp 5.9.4 on OpenWrt 25.12 (aarch64).