### PR TITLE
luci-app-mwan3: fix missing translation call for Weight label

### DIFF
--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/member.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/member.js
@@ -58,7 +58,7 @@ return view.extend({
 			_('Acceptable values: 1-256. Defaults to 1 if not set'));
 		o.datatype = 'range(1, 256)';
 
-		o = s.option(form.Value, 'weight', ('Weight'),
+		o = s.option(form.Value, 'weight', _('Weight'),
 			_('Acceptable values: 1-1000. Defaults to 1 if not set'));
 		o.datatype = 'range(1, 1000)';
 


### PR DESCRIPTION
The 'Weight' option label in the member configuration page uses
`('Weight')` instead of `_('Weight')`, so the string is never passed
through the translation function. This causes the label to always display
in English regardless of the selected UI language.

The translation for 'Weight' already exists in luci-base, so this
one-character fix is sufficient.
