### PR TITLE
luci-mod-network: fill ieee-oui.txt from ufp-neigh

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
@@ -4,7 +4,24 @@
 'require fs';
 'require ui';
 'require uci';
+'require rpc';
 'require network';
+
+const callFingerprint = rpc.declare({
+	object: 'fingerprint',
+	method: 'fingerprint',
+	params: [ 'export' ],
+	expect: { '': {} }
+});
+
+const callServiceList = rpc.declare({
+	object: 'service',
+	method: 'list',
+	params: [ 'name' ],
+	expect: { ufp: {} }
+});
+
+let has_ufp;
 
 return view.extend({
 	handleCommand(exec, args) {
@@ -50,8 +67,11 @@ return view.extend({
 
 	handleArpScan(ev, cmd) {
 		const addr = ev.currentTarget.parentNode.previousSibling.value;
+		const ieee_file = '/tmp/arp-scan/ieee-oui.txt';
 
-		return this.handleCommand('arp-scan', [ '-l', '-I', addr ]);
+		if (!has_ufp)
+			return this.handleCommand('arp-scan', [ '-l', '-I', addr ]);
+		return this.handleCommand('arp-scan', [ '-l', '-I', addr, '-O', ieee_file ]);
 	},
 
 	load() {
@@ -60,14 +80,25 @@ return view.extend({
 			L.resolveDefault(fs.stat('/bin/traceroute6') || fs.stat('/usr/bin/traceroute6'), false),
 			L.resolveDefault(fs.stat('/usr/bin/arp-scan'), false),
 			network.getDevices(),
+			L.resolveDefault(callServiceList('ufp').then((res) => {
+				let instances = res.instances;
+
+				for (let i in instances) {
+					if (instances[i].running)
+						return callFingerprint(true);
+				}
+
+				return null;
+			}), null),
 			uci.load('luci')
 		]);
 	},
 
-	render([has_ping6, has_traceroute6, has_arpscan, devices]) {
+	render([has_ping6, has_traceroute6, has_arpscan, devices, ufp]) {
 		const dns_host = uci.get('luci', 'diag', 'dns') || 'openwrt.org';
 		const ping_host = uci.get('luci', 'diag', 'ping') || 'openwrt.org';
 		const route_host = uci.get('luci', 'diag', 'route') || 'openwrt.org';
+		has_ufp = ufp != null ? true : false;
 
 		const table = E('table', { 'class': 'table' }, [
 				E('tr', { 'class': 'tr' }, [

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -78,7 +78,9 @@
 				"/usr/bin/arp-scan": [ "exec", "list" ]
 			},
 			"ubus": {
-				"file": [ "exec", "stat" ]
+				"file": [ "exec", "stat" ],
+				"fingerprint": [ "fingerprint" ],
+				"service": [ "list" ]
 			},
 			"uci": [ "luci" ]
 		}


### PR DESCRIPTION
With ufp-neigh it is possible to get the vendor of a MAC address. Because arp-scan allows us to specify a txt file for lookup, it is suitable to use ufp-neigh to create a txt file on the spot and populate it with vendors of connected devices. This is only used if ufp is running as service.

Depends on changes to ufp.
https://lists.openwrt.org/pipermail/openwrt-devel/2026-April/044755.html

@systemcrash 

---


**OpenWrt version:** owrt-25.12
**LuCI version:** LuCI openwrt-25.12
**Web browser(s):** Firefox
---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
