### PR TITLE
luci: add user-defined label for physical switch ports

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
@@ -58,12 +58,21 @@ function updateDevBadge(node, dev) {
 	const type = dev.getType();
 	const up = dev.getCarrier();
 
+	let label = null;
+	uci.sections('network', 'device', function(s) {
+		if (s.name === dev.getName() && s.label)
+			label = s.label;
+	});
+
 	dom.content(node, [
-		E('img', {
-			'class': 'middle',
-			'src': L.resource('icons/%s%s.svg').format(type, up ? '' : '_disabled')
-		}),
-		'\x0a', dev.getName()
+		E('span', { 'style': 'text-align:center;display:block' }, [
+			E('img', {
+				'class': 'middle',
+				'src': L.resource('icons/%s%s.svg').format(type, up ? '' : '_disabled')
+			})
+		]),
+		E('span', { 'style': 'text-align:center;display:block' }, [dev.getName()]),
+		E('small', { 'style': 'font-weight:normal;text-align:center;display:block' }, [label || '\u00a0'])
 	]);
 
 	return node;
@@ -1128,6 +1137,12 @@ return baseclass.extend({
 		o = this.replaceOption(s, 'devgeneral', form.Value, 'txqueuelen', _('TX queue length'));
 		o.placeholder = dev ? dev._devstate('qlen') : '';
 		o.datatype = 'uinteger';
+
+		if (dev && dev.getType() === 'switch' && dev.getParent() != null) {
+			o = this.replaceOption(s, 'devgeneral', form.Value, 'label', _('Label'),
+				_('Optional human-friendly name for this port, shown in the UI alongside the device name.'));
+			o.rmempty = true;
+		}
 
 		/* PSE / PoE options */
 		if (hasPSE) {

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1761,6 +1761,15 @@ return view.extend({
 			}, [ val ]) : (mtu || '-').toString();
 		};
 
+		o = s.option(form.DummyValue, 'label', _('Label'));
+		o.modalonly = false;
+		o.textvalue = function(section_id) {
+			const dev = getDevice(section_id);
+			if (!dev || dev.getType() !== 'switch' || dev.getParent() == null)
+				return E('span', {});
+			return uci.get('network', section_id, 'label') || '-';
+		};
+
 		s = m.section(form.TypedSection, 'globals', _('Global network options'));
 		s.addremove = false;
 		s.anonymous = true;

--- a/modules/luci-mod-status/Makefile
+++ b/modules/luci-mod-status/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Status Pages
 LUCI_DEPENDS:=+luci-base +libiwinfo +rpcd-mod-iwinfo
 
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_BUILD_DEPENDS:=iwinfo
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/29_ports.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/29_ports.js
@@ -466,6 +466,12 @@ return baseclass.extend({
 			return L.naturalCompare(a.device, b.device);
 		});
 
+		/* Build a map of device name → user label from config device sections */
+		const labelMap = {};
+		for (const s of uci.sections('network', 'device'))
+			if (s.name && s.label)
+				labelMap[s.name] = s.label;
+
 		return E('div', { 'style': 'display:grid;grid-template-columns:repeat(auto-fit, minmax(70px, 1fr));margin-bottom:1em' }, known_ports.map(function(port) {
 			const speed = port.netdev.getSpeed();
 			const duplex = port.netdev.getDuplex();
@@ -475,6 +481,7 @@ return baseclass.extend({
 			const pse = pseMap[port.device];
 			const pseInfo = getPSEStatus(pse);
 			const psePower = formatPSEPower(pse);
+			const portLabel = labelMap[port.device];
 
 			/* Select port icon based on carrier and PSE status */
 			let portIcon;
@@ -498,7 +505,11 @@ return baseclass.extend({
 			statsContent.push(E('span', { 'class': 'cbi-tooltip' }, formatStats(port.netdev, pse)));
 
 			return E('div', { 'class': 'ifacebox', 'style': 'margin:.25em;min-width:70px;max-width:100px' }, [
-				E('div', { 'class': 'ifacebox-head', 'style': 'font-weight:bold' }, [ port.netdev.getName() ]),
+				E('div', { 'class': 'ifacebox-head', 'style': 'font-weight:bold' }, [
+					port.netdev.getName(),
+					E('br'),
+					E('small', { 'style': 'font-weight:normal;word-break:break-word' }, [ portLabel || '\u00a0' ])
+				]),
 				E('div', { 'class': 'ifacebox-body' }, [
 					E('img', { 'src': L.resource('icons/port_%s.svg').format(portIcon) }),
 					E('br'),


### PR DESCRIPTION


Add support for a UCI label option on network device sections (config device), allowing users to assign a human-friendly display name to each physical DSA switch port (e.g. lan1 → 'NAS', wan → 'ISP ONT').

Labels are shown in:

Network > Interfaces > Devices grid (Label column)
Network > Interfaces > Bridge VLAN filtering port headers
Network > Interfaces > device Configure modal (switch ports only)
Status > Overview port status boxes
Only DSA switch ports are affected, identified via the public API:
dev.getType() === 'switch' && dev.getParent() != null

The DSA parent switch device (e.g. eth0) and all other device types (bridges, VLANs, WiFi) are unaffected. swconfig devices see no UI changes and no breakage.

Screenshot :
<img width="2561" height="1535" alt="Screenshot_20260422_215833" src="https://github.com/user-attachments/assets/ca725c13-b304-4313-a858-236f43c24bd7" />


Maintainer (preferred)
@jow-