### PR TITLE
luci-app-adblock-fast: update to 1.2.2-r18

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=16
+PKG_RELEASE:=18
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-adblock-fast/

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -836,5 +836,6 @@ return L.Class.extend({
 	getServiceInfo: getServiceInfo,
 	getQueryLogStatus: getQueryLogStatus,
 	setQueryLog: setQueryLog,
+	setRpcdToken: RPC.setRpcdToken,
 	callLogRead: callLogRead,
 });

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
@@ -814,17 +814,17 @@ return view.extend({
 			"rpcd_token",
 			_("Remote Access Token"),
 			_(
-				"Token for <a href=\"" + pkg.URL + "#chrome-extension\" target=\"_blank\">Google Chrome extension</a> or other remote API access. " +
+				"Token for %sGoogle Chrome extension%s or other remote API access. " +
 				"Copy this value into the extension settings as the password. " +
 				"Changing it here will update the API user password on save.",
-			),
+			).format('<a href="' + pkg.URL + '#chrome-extension" target="_blank">', "</a>"),
 		);
 		o.default = "";
 		o.rmempty = true;
 		o.write = function (section_id, formvalue) {
 			var currentValue = L.uci.get(pkg.Name, section_id, "rpcd_token");
 			if (formvalue && formvalue !== currentValue) {
-				RPC.setRpcdToken(pkg.Name, formvalue);
+				adb.setRpcdToken(pkg.Name, formvalue);
 			}
 			return L.uci.set(pkg.Name, section_id, "rpcd_token", formvalue);
 		};

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -817,7 +817,10 @@ msgid "Thursday"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:817
-msgid "Token for <a href=\""
+msgid ""
+"Token for %sGoogle Chrome extension%s or other remote API access. Copy this "
+"value into the extension settings as the password. Changing it here will "
+"update the API user password on save."
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:590

--- a/applications/luci-app-adblock-fast/root/etc/uci-defaults/95_adblock-fast-api
+++ b/applications/luci-app-adblock-fast/root/etc/uci-defaults/95_adblock-fast-api
@@ -18,7 +18,7 @@ fi
 # Generate random rpcd_token if not already set
 _token="$(uci -q get adblock-fast.config.rpcd_token)"
 if [ -z "$_token" ]; then
-	_token="$(head -c 24 /dev/urandom | base64 | tr -d '/+=' | head -c 24)"
+	_token="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24)"
 	uci set adblock-fast.config.rpcd_token="$_token"
 	uci commit adblock-fast
 fi


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1

Description:
* reformat Chrome Extension helper message for i18n
* remove use of base64 in uci-defaults script (thanks @sppmaster)

Signed-off-by: Stan Grishin <stangri@melmac.ca>