### PR TITLE
luci-app-https-dns-proxy: update to 2025.12.29-5

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=2025.12.29
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-https-dns-proxy/

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
@@ -211,7 +211,7 @@ var status = baseclass.extend({
 			} else {
 				text = _("Not installed or not found");
 			}
-			var statusText = E("output", { id: pkg.Name + "-status", class: "cbi-value-description" }, text);
+			var statusText = E("output", { id: pkg.Name + "-status" }, text);
 			var statusField = E("div", { class: "cbi-value-field" }, statusText);
 			var statusDiv = E("div", { class: "cbi-value" }, [
 				statusTitle,
@@ -225,14 +225,6 @@ var status = baseclass.extend({
 					{ class: "cbi-value-title", for: pkg.Name + "-instances" },
 					_("Service Instances")
 				);
-				text = _("See the %sREADME%s for details.").format(
-					'<a href="' +
-					pkg.URL +
-					'#a-word-about-default-routing " target="_blank">',
-					"</a>"
-				);
-				var instancesDescr = E("div", { class: "cbi-value-description" }, "");
-
 				text = "";
 				Object.values(reply.ubus.instances).forEach((element) => {
 					var resolver;
@@ -289,15 +281,17 @@ var status = baseclass.extend({
 							"<br />"
 						);
 				});
-				text +=
-					"<br />" +
-					_("Please %sdonate%s to support development of this project.").format(
+				var instancesText = E("output", { id: pkg.Name + "-instances" }, text);
+				var instancesDescr = E("div", { class: "cbi-value-description" },
+					_(
+						"Please %sdonate%s to support development of this project.",
+					).format(
 						"<a href='" + pkg.DonateURL + "' target='_blank'>",
-						"</a>"
-					);
-				var instancesText = E("output", { id: pkg.Name + "-instances", class: "cbi-value-description" }, text);
+						"</a>",
+					));
 				var instancesField = E("div", { class: "cbi-value-field" }, [
 					instancesText,
+					E("br"),
 					instancesDescr,
 				]);
 				instancesDiv = E("div", { class: "cbi-value" }, [

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,11 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:283
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:275
 msgid "%s%s%s proxy at %s on port %s.%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:275
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:267
 msgid "%s%s%s proxy on port %s.%s"
 msgstr ""
 
@@ -213,11 +213,11 @@ msgstr ""
 msgid "Direct"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:407
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:401
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:401
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:395
 msgid "Disabling %s service"
 msgstr ""
 
@@ -237,11 +237,11 @@ msgstr ""
 msgid "ECS Optimized"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:388
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:382
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:382
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:376
 msgid "Enabling %s service"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Parameter"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:294
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:287
 msgid "Please %sdonate%s to support development of this project."
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Quad 9"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:350
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:344
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:344
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:338
 msgid "Restarting %s service"
 msgstr ""
 
@@ -609,15 +609,11 @@ msgstr ""
 msgid "Security Filter"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:228
-msgid "See the %sREADME%s for details."
-msgstr ""
-
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:104
 msgid "Select the DNSMASQ Configs to update"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:433
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:427
 msgid "Service Control"
 msgstr ""
 
@@ -663,11 +659,11 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:331
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:325
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:325
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:319
 msgid "Starting %s service"
 msgstr ""
 
@@ -676,11 +672,11 @@ msgstr ""
 msgid "Statistic Interval"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:369
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:363
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:363
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:357
 msgid "Stopping %s service"
 msgstr ""
 

--- a/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
+++ b/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
@@ -17,17 +17,19 @@ readonly providersJson="/usr/share/${packageName}/providers.json"
 . "${IPKG_INSTROOT}/lib/functions.sh"
 . "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"
 
-is_enabled() { "/etc/init.d/${1}" enabled; }
-is_running() { [ "$(ubus call service list "{ 'name': '$1' }" | jsonfilter -q -e "@['$1'].instances[*].running" | uniq)" = 'true' ]; }
+is_enabled() { "/etc/init.d/${1}" enabled >/dev/null 2>&1; }
+is_running() { "/etc/init.d/${1}" running >/dev/null 2>&1; }
 get_version() { /usr/sbin/https-dns-proxy -V | head -1; }
 check_http2() { /usr/sbin/https-dns-proxy -V | grep -q 'nghttp2'; }
 check_http3() { /usr/sbin/https-dns-proxy -V | grep -q 'nghttp3'; }
-ubus_get_ports() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances[*].data.firewall.*.dest_port"; }
+ubus_get_ports() { ubus call service list "{\"name\":\"$packageName\"}" | jsonfilter -e "@[\"${packageName}\"].instances.*.data.firewall.*.dest_port"; }
 logger() { /usr/bin/logger -t "$packageName" "$@"; }
 print_json_bool() { json_init; json_add_boolean "$1" "$2"; json_dump; json_cleanup; }
 
 get_init_list() {
-	local name="$1"
+	local name
+	name="$(basename "$1")"
+	name="${name:-${packageName}}" 
 	json_init
 	json_add_object "$name"
 	if is_enabled "$name"; then
@@ -74,7 +76,6 @@ get_init_status() {
 		json_add_boolean 'force_dns_active' '0'
 	fi
 	json_add_string 'version' "$version"
-	json_close_array
 	json_close_object
 	json_dump
 	json_cleanup


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1

Description:
update to PKG_RELEASE 5 and status page improvements

applications/luci-app-https-dns-proxy/Makefile:
  - Bump PKG_RELEASE from 4 to 5.

applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:
  - Remove redundant 'cbi-value-description' class from statusText element.
  - Remove old README link from instances description.
  - Restructure instances description to correctly display donate link.
  - Add a line break element after the instancesText output.

applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot:
  - Update POT file to reflect changes in status.js.

applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy:
  - Redirect stderr for `is_enabled` and `is_running` functions to /dev/null.
  - Correctly retrieve service name in `get_init_list` using basename.
  - Remove extraneous `json_close_array` call from `get_init_status`.
  - Ensure `ubus_get_ports` uses correct JSON quoting