### PR TITLE
luci-mod-system, luci-app-acl: add password policy

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -3,11 +3,19 @@
 'require dom';
 'require fs';
 'require ui';
+'require rpc';
 'require uci';
 'require form';
 'require tools.widgets as widgets';
 
 const aclList = {};
+
+const callSetPassword = rpc.declare({
+	object: 'luci',
+	method: 'setPassword',
+	params: [ 'username', 'password', 'oldpassword', 'rpcd' ],
+	expect: { result: 1 }
+});
 
 function globListToRegExp(section_id, option) {
 	const list = L.toArray(uci.get('rpcd', section_id, option));
@@ -271,15 +279,12 @@ return view.extend({
 		};
 		o.write = function(section_id, value) {
 			const variant = this.map.lookupOption('_variant', section_id)[0];
+			const user = this.map.lookupOption('username', section_id)[0].formvalue(section_id);
 
 			if (variant.formvalue(section_id) == 'crypted' && value.substring(0, 3) != '$1$')
-				return fs.exec('/usr/sbin/uhttpd', [ '-m', value ]).then(function(res) {
-					if (res.code == 0 && res.stdout)
-						uci.set('rpcd', section_id, 'password', res.stdout.trim());
-					else
-						throw new Error(res.stderr);
-				}).catch(function(err) {
-					throw new Error(_('Unable to encrypt plaintext password: %s').format(err.message));
+				return callSetPassword(user, value, '', true).then(function(success) {
+					if (!success)
+						throw new Error('Failed to create password');
 				});
 
 			uci.set('rpcd', section_id, 'password', value);

--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -7,6 +7,7 @@
 'require uci';
 'require form';
 'require tools.widgets as widgets';
+'require tools.password as pwtool';
 
 const aclList = {};
 
@@ -16,6 +17,31 @@ const callSetPassword = rpc.declare({
 	params: [ 'username', 'password', 'oldpassword', 'rpcd' ],
 	expect: { result: 1 }
 });
+
+function checkPassword(value) {
+	const pw_enabled = uci.get('rpcd', 'policy', 'enabled');
+	const pw_length = uci.get('rpcd', 'policy', 'pw_length');
+	const pw_digits = uci.get('rpcd', 'policy', 'digits');
+	const pw_ul = uci.get('rpcd', 'policy', 'uc_lc');
+	const special = uci.get('rpcd', 'policy', 'special_characters');
+
+	if (!pw_enabled)
+		return true;
+
+	if (pw_length && !pwtool.checkLength(value, pw_length))
+		return _('Policy: min. length of %s characters').format(pw_length);
+
+	if (pw_digits && !pwtool.checkDigits(value))
+		return _('Policy: contain digits');
+
+	if (pw_ul && !pwtool.checkUpperLower(value))
+		return _('Policy: contain uppercase/lowercase');
+
+	if (special && !pwtool.checkSpecialChars(value))
+		return _('Policy: contain special characters');
+
+	return true;
+}
 
 function globListToRegExp(section_id, option) {
 	const list = L.toArray(uci.get('rpcd', section_id, option));
@@ -170,7 +196,8 @@ return view.extend({
 		return L.resolveDefault(fs.list('/usr/share/rpcd/acl.d'), []).then(function(entries) {
 			const tasks = [
 				L.resolveDefault(fs.stat('/usr/sbin/uhttpd'), null),
-				fs.lines('/etc/passwd')
+				fs.lines('/etc/passwd'),
+				uci.load('rpcd')
 			];
 
 			for (let e of entries)
@@ -181,7 +208,7 @@ return view.extend({
 		});
 	},
 
-	render([has_uhttpd, passwd, ...acls]) {
+	render([has_uhttpd, passwd, uci_rpcd, ...acls]) {
 		ui.addNotification(null, E('p', [
 			_('The LuCI ACL management is in an experimental stage! It does not yet work reliably with all applications')
 		]), 'warning');
@@ -275,7 +302,7 @@ return view.extend({
 					return _('Cannot encrypt plaintext password since uhttpd is not installed.');
 			}
 
-			return true;
+			return checkPassword(value);
 		};
 		o.write = function(section_id, value) {
 			const variant = this.map.lookupOption('_variant', section_id)[0];
@@ -286,8 +313,6 @@ return view.extend({
 					if (!success)
 						throw new Error('Failed to create password');
 				});
-
-			uci.set('rpcd', section_id, 'password', value);
 		};
 		o.remove = function() {};
 

--- a/applications/luci-app-acl/root/usr/share/rpcd/acl.d/luci-app-acl.json
+++ b/applications/luci-app-acl/root/usr/share/rpcd/acl.d/luci-app-acl.json
@@ -13,7 +13,10 @@
 			"uci": [ "rpcd" ]
 		},
 		"write": {
-			"uci": [ "rpcd" ]
+			"uci": [ "rpcd" ],
+			"ubus": {
+				"luci": [ "setPassword" ]
+			}
 		}
 	}
 }

--- a/modules/luci-base/htdocs/luci-static/resources/tools/password.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/password.js
@@ -1,0 +1,32 @@
+'use strict';
+
+'require baseclass';
+'require uci';
+
+return baseclass.extend({
+	checkLength(p, required) {
+		let enough = p.length >= parseInt(required);
+
+		if (required && !enough)
+			return false;
+
+		return true;
+	},
+
+	checkDigits(p) {
+		let m = p.match(/\d/);
+
+		return m ? true : false;
+	},
+
+	checkUpperLower(p) {
+
+		return /[a-z]/.test(p) && /[A-Z]/.test(p);
+	},
+
+	checkSpecialChars(p) {
+		let m = p.match(/[^a-zA-Z0-9]/);
+
+		return m ? true : false;
+	}
+});

--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -46,6 +46,69 @@ function callPackageVersionCheck(pkg) {
 	return version;
 }
 
+function set_new_pwd(user, pwd) {
+	const ctx = cursor();
+	let cmd, fd, value;
+
+	cmd = sprintf('/usr/sbin/uhttpd -m %s', shellquote(pwd));
+	fd = popen(cmd);
+	value = trim(fd.read('line'));
+
+	fd.close();
+
+	ctx.foreach('rpcd', 'login', s => {
+		if (s.username == user) {
+			ctx.set('rpcd', s['.name'], 'password', value);
+			ctx.commit();
+		}
+	});
+}
+
+function check_oldpwd(user, pwd) {
+	let cmd, fd, value;
+	const ctx = cursor();
+	let valid = false;
+
+	cmd = sprintf('/usr/sbin/uhttpd -m %s', shellquote(pwd));
+	fd = popen(cmd);
+	value = trim(fd.read('line'));
+	fd.close();
+
+	ctx.foreach('rpcd', 'login', s => {
+		if (s.username == user && s.password == value)
+			valid = true;
+	});
+
+	return valid;
+}
+
+function check_user(source, entry) {
+	let found = false;
+
+	switch (source) {
+		case 'unix': {
+			const fd = open('/etc/passwd');
+
+			for (let line = fd.read('line'); length(line); line = fd.read('line')) {
+				let user = split(line, /:/)[0];
+				if (user == entry)
+					found = true;
+			}
+			break;
+		}
+
+		case 'rpcd': {
+			const ctx = cursor();
+			ctx.foreach('rpcd', 'login', s => {
+				if (s.username == entry)
+					found = true;
+				});
+		}
+		break;
+	}
+	return found;
+}
+
 const methods = {
 	getVersion: {
 		call: function(request) {
@@ -469,14 +532,58 @@ const methods = {
 	},
 
 	setPassword: {
-		args: { username: 'root', password: 'password' },
+		args: {
+			username: 'root',
+			password: 'password',
+			oldpassword: '',
+			rpcd: false,
+		},
 		call: function(request) {
-			const u = shellquote(request.args.username);
-			const p = shellquote(request.args.password);
+			const user = request.args.username;
+			const pwd = request.args.password;
+			const oldpwd = request.args.oldpassword;
+			const type = request.args.rpcd == true ? 'rpcd' : 'unix';
+			const known_user = check_user(type, user);
+			const uci = cursor();
 
-			return {
-				result: system(`(echo ${p}; sleep 1; echo ${p}) | /bin/busybox passwd ${u} >/dev/null 2>&1`) == 0
-			};
+			if (type == 'unix') {
+				const u = shellquote(user);
+				const p = shellquote(pwd);
+
+				return {
+					result: system(`(echo ${p}; sleep 1; echo ${p}) | /bin/busybox passwd ${u} >/dev/null 2>&1`) == 0
+				};
+			}
+
+			if (!access('/usr/sbin/uhttpd', 'x'))
+				return { 
+					result: 0 ,
+					msg: "uhttpd not installed"
+				};
+
+			if (known_user) {
+				if (!oldpwd)
+					return { result: 0 };
+
+				/*
+				* check if login is valid
+				*/
+				if (!check_oldpwd(user, oldpwd))
+					return { result: 0 };
+			} else {
+				/*
+				 * create user to keep logic of luci-app-acl
+				 */
+				const sid = uci.add('rpcd', 'login');
+				uci.set('rpcd', sid, 'username', user);
+				uci.commit('rpcd');
+			}
+
+			/*
+			 * encrypt password and assign it to rpcd login
+			 */
+			 set_new_pwd(user, pwd);
+			 return { result: 1 };
 		}
 	},
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
@@ -2,11 +2,17 @@
 'require view';
 'require dom';
 'require ui';
+'require fs';
+'require uci';
 'require form';
 'require rpc';
 
 var formData = {
-	password: {
+	data: {
+		rpc_user: null,
+		user: null,
+		rpcd: null,
+		oldpw: null,
 		pw1: null,
 		pw2: null
 	}
@@ -15,8 +21,8 @@ var formData = {
 var callSetPassword = rpc.declare({
 	object: 'luci',
 	method: 'setPassword',
-	params: [ 'username', 'password' ],
-	expect: { result: false }
+	params: [ 'username', 'password', 'oldpassword', 'rpcd' ],
+	expect: { result: 1 }
 });
 
 return view.extend({
@@ -40,13 +46,66 @@ return view.extend({
 		return true;
 	},
 
-	render: function() {
-		var m, s, o;
+	load: function() {
+		return Promise.all([
+			L.resolveDefault(fs.stat('/usr/sbin/uhttpd'), null),
+			fs.lines('/etc/passwd'),
+			uci.load('rpcd')
+		]);
+	},
 
-		m = new form.JSONMap(formData, _('Router Password'), _('Changes the administrator password for accessing the device'));
+	render: function([has_uhttpd, passwd]) {
+		var m, s, o, rpcd;
+
+		const known_unix_users = {};
+
+		for (let p of passwd) {
+			const parts = p.split(/:/);
+
+			if (parts.length >= 7)
+				known_unix_users[parts[0]] = true;
+		}
+
+		m = new form.JSONMap(formData, _('Password'), _('Changes the password for accessing the device as (rpcd) user'));
 		m.readonly = !L.hasViewPermission();
 
-		s = m.section(form.NamedSection, 'password', 'password');
+		s = m.section(form.NamedSection, 'data', 'data');
+
+		if (has_uhttpd) {
+			let logins = [];
+
+			uci.sections('rpcd', 'login', s => logins.push(s.username));
+
+			rpcd = s.option(form.Flag, 'rpcd', _('Change password for rpcd user'));
+			rpcd.default = false;
+
+			o = s.option(form.Value, 'rpc_user', _('rpcd username'));
+			for (let user of logins) {
+				if (user == 'root')
+					continue;
+
+				o.value(user, _('%s').format(user));
+			}
+			o.rmempty = false;
+			o.depends({ 'rpcd': '1' });
+
+			o = s.option(form.Value, 'user', _('Router username'));
+			for (let user in known_unix_users)
+				o.value(user, _('%s').format(user));
+			o.rmempty = false;
+			o.depends({ 'rpcd': '0' });
+
+			o = s.option(form.Value, 'oldpw', _('Old Password'));
+			o.password = true;
+			o.depends({ 'rpcd': '1' });
+		}
+
+		if (!has_uhttpd) {
+			o = s.option(form.Value, 'user', _('Router username'));
+			for (let user in known_unix_users)
+				o.value(user);
+			o.rmempty = false;
+		}
 
 		o = s.option(form.Value, 'pw1', _('Password'));
 		o.password = true;
@@ -72,22 +131,39 @@ return view.extend({
 		var map = document.querySelector('.cbi-map');
 
 		return dom.callClassMethod(map, 'save').then(function() {
-			if (formData.password.pw1 == null || formData.password.pw1.length == 0)
+			let rpc_user = formData.data.rpc_user;
+			let user = formData.data.user;
+			let rpcd = formData.data.rpcd;
+			let oldpw = formData.data.oldpw;
+
+			if (rpc_user && (oldpw == null || oldpw.length == 0))
 				return;
 
-			if (formData.password.pw1 != formData.password.pw2) {
+			if (formData.data.pw1 == null || formData.data.pw1.length == 0)
+				return;
+
+			if (formData.data.pw1 != formData.data.pw2) {
 				ui.addNotification(null, E('p', _('Given password confirmation did not match, password not changed!')), 'danger');
 				return;
 			}
 
-			return callSetPassword('root', formData.password.pw1).then(function(success) {
+			return callSetPassword(
+				rpc_user ? rpc_user : user,
+				formData.data.pw1,
+				oldpw ? oldpw : '',
+				rpcd ? true : false,
+			).then(function(success) {
 				if (success)
 					ui.addNotification(null, E('p', _('The system password has been successfully changed.')), 'info');
 				else
 					ui.addNotification(null, E('p', _('Failed to change the system password.')), 'danger');
 
-				formData.password.pw1 = null;
-				formData.password.pw2 = null;
+				formData.data.rpc_user = null;
+				formData.data.user = null;
+				formData.data.rpcd = null;
+				formData.data.pw1 = null;
+				formData.data.pw2 = null;
+				formData.data.oldpw = null;
 
 				dom.callClassMethod(map, 'render');
 			});

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
@@ -6,6 +6,7 @@
 'require uci';
 'require form';
 'require rpc';
+'require tools.password as pwtool';
 
 var formData = {
 	data: {
@@ -32,6 +33,12 @@ return view.extend({
 		    mediumRegex = new RegExp("^(?=.{7,})(((?=.*[A-Z])(?=.*[a-z]))|((?=.*[A-Z])(?=.*[0-9]))|((?=.*[a-z])(?=.*[0-9]))).*$", "g"),
 		    enoughRegex = new RegExp("(?=.{6,}).*", "g");
 
+		const pw_enabled = uci.get('rpcd', 'policy', 'enabled');
+		const pw_length = uci.get('rpcd', 'policy', 'pw_length');
+		const pw_digits = uci.get('rpcd', 'policy', 'digits');
+		const pw_ul = uci.get('rpcd', 'policy', 'uc_lc');
+		const special = uci.get('rpcd', 'policy', 'special_characters');
+
 		if (strength && value.length) {
 			if (false == enoughRegex.test(value))
 				strength.innerHTML = '%s: <span style="color:red">%s</span>'.format(_('Password strength'), _('More Characters'));
@@ -43,6 +50,21 @@ return view.extend({
 				strength.innerHTML = '%s: <span style="color:red">%s</span>'.format(_('Password strength'), _('Weak'));
 		}
 
+		if (!pw_enabled)
+			return true;
+
+		if (pw_length && !pwtool.checkLength(value, pw_length))
+			return _('Policy: min. length of %s characters').format(pw_length);
+
+		if (pw_digits && !pwtool.checkDigits(value))
+			return _('Policy: contain digits');
+
+		if (pw_ul && !pwtool.checkUpperLower(value))
+			return _('Policy: contain uppercase/lowercase');
+
+		if (special && !pwtool.checkSpecialChars(value))
+			return _('Policy: contain special characters');
+
 		return true;
 	},
 
@@ -50,7 +72,8 @@ return view.extend({
 		return Promise.all([
 			L.resolveDefault(fs.stat('/usr/sbin/uhttpd'), null),
 			fs.lines('/etc/passwd'),
-			uci.load('rpcd')
+			uci.load('rpcd'),
+			uci.load('luci')
 		]);
 	},
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/pwpolicy.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/pwpolicy.js
@@ -1,0 +1,57 @@
+'use strict';
+
+'require form';
+'require uci';
+'require view';
+
+return view.extend({
+	load: function () {
+		return Promise.all([
+			uci.load('rpcd')
+		]);
+	},
+
+	render: function () {
+		let m, s, o;
+
+		if (!uci.get('rpcd', 'policy'))
+			uci.add('rpcd', 'policy', 'policy');
+
+		m = new form.Map('rpcd', _('Policy'));
+		m.readonly = !L.hasViewPermission();
+
+		s = m.section(form.NamedSection, 'policy')
+		s.addremove = false;
+		s.anonymous = true;
+
+		o = s.option(form.Flag, 'enabled',
+			_('Enable password policy'));
+		o.default = o.disabled;
+
+		o = s.option(form.Value, 'pw_length',
+			_('Require a minimum password length'));
+		o.datatype = 'uinteger';
+		o.rmempty = true;
+		o.depends('enabled', '1');
+
+		o = s.option(form.Flag, 'digits',
+			_('Require digits'));
+		o.default = o.disabled;
+		o.rmempty = true;
+		o.depends('enabled', '1');
+
+		o = s.option(form.Flag, 'uc_lc',
+			_('Require upper/lower case'));
+		o.default = o.disabled;
+		o.rmempty = true;
+		o.depends('enabled', '1');
+
+		o = s.option(form.Flag, 'special_characters',
+			_('Require special characters <br/> (e.g., !, @, #, $, %, &)'));
+		o.default = o.disabled;
+		o.rmempty = true;
+		o.depends('enabled', '1');
+
+		return m.render();
+	}
+});

--- a/modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json
@@ -34,9 +34,21 @@
 		}
 	},
 
+	"admin/system/admin/pwpolicy": {
+		"title": "Password Policy",
+		"order": 2,
+		"action": {
+			"type": "view",
+			"path": "system/pwpolicy"
+		},
+		"depends": {
+			"acl": [ "luci-mod-system-pwpolicy" ]
+		}
+	},
+
 	"admin/system/admin/dropbear": {
 		"title": "SSH Access",
-		"order": 2,
+		"order": 5,
 		"action": {
 			"type": "view",
 			"path": "system/dropbear"
@@ -49,7 +61,7 @@
 
 	"admin/system/admin/sshkeys": {
 		"title": "SSH-Keys",
-		"order": 3,
+		"order": 6,
 		"action": {
 			"type": "view",
 			"path": "system/sshkeys"
@@ -62,7 +74,7 @@
 
 	"admin/system/admin/uhttpd": {
 		"title": "HTTP(S) Access",
-		"order": 4,
+		"order": 7,
 		"action": {
 			"type": "view",
 			"path": "system/uhttpd"
@@ -75,7 +87,7 @@
 
 	"admin/system/admin/repokeys": {
 		"title": "Repo Public Keys",
-		"order": 5,
+		"order": 8,
 		"action": {
 			"type": "view",
 			"path": "system/repokeys"
@@ -87,7 +99,7 @@
 
 	"admin/system/plugins": {
 		"title": "Plugins",
-		"order": 3,
+		"order": 4,
 		"action": {
 			"type": "view",
 			"path": "system/plugins"

--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -2,13 +2,20 @@
 	"luci-mod-system-config": {
 		"description": "Grant access to system configuration",
 		"read": {
+			"cgi-io": [ "read" ],
+			"file": {
+				"/etc/passwd": [ "read" ]
+			},
 			"ubus": {
 				"luci": [ "getLEDs", "getTimezones", "getUSBDevices", "getUnixtime" ],
 				"rc": [ "list" ]
 			},
-			"uci": [ "luci", "system" ]
+			"uci": [ "luci", "system", "rpcd" ]
 		},
 		"write": {
+			"file": {
+				"/usr/sbin/uhttpd -m *": [ "exec" ]
+			},
 			"ubus": {
 				"luci": [ "setLocaltime", "setPassword" ],
 				"rc": [ "init" ]

--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -222,5 +222,16 @@
 				"system": [ "reboot" ]
 			}
 		}
+	},
+
+	"luci-mod-system-pwpolicy": {
+		"description": "Grant access to password policy configuration",
+		"read": {
+			"uci": [ "rpcd" ]
+		},
+		"write": {
+			"uci": [ "rpcd" ]
+		}
 	}
+
 }


### PR DESCRIPTION
### Description
In order to enforce a password policy, this PR does the following:
1. Change `ubus call luci setPassword` that it can be used for rpcd also
2. Use it in `luci-app-acl`
3. Add a password policy tab (length, digits, uppercase/lowercase, special characters)
4. Enforce it on `luci-mod-system` and `luci-app-acl`



### Screenshot or video of changes _(if applicable)_
**Administration:**
assets/bd648ad7-41fd-4b8d-b1ba-8b952d822192" />
<img width="801" height="459" alt="image" src="https://github.com/user-attachments/assets/1c7be565-6716-4b5c-9776-97d0d097da02" />

**Policy:**
<img width="1429" height="289" alt="image" src="https://github.com/user-attachments/assets/c2ff5f00-28ee-4cb3-a653-346673a012de" />


**ACL:**
<!-- Insert your screenshot or video here. -->
<img width="720" height="328" alt="image" src="https://github.com/user-attachments/assets/6299a8d4-cd38-4d43-a54a-ef3a2425fbcc" />




### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12
**LuCI version:** LuCI openwrt-25.12
**Web browser(s):** Firefox

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.