### PR TITLE
luci-app-https-dns-proxy: update to 2026.03.18-1

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2025.12.29
-PKG_RELEASE:=5
+PKG_VERSION:=2026.03.18
+PKG_RELEASE:=1
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-https-dns-proxy/


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1

Description:
update to new upstream version

Makefile:
  - Bump PKG_VERSION to 2026.03.18.
  - Reset PKG_RELEASE to 1