### PR TITLE
luci-app-strongswan-swanctl: fix Tunnel/Remote modal crash

### DIFF
--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
@@ -121,14 +121,14 @@ return view.extend({
 			this.keylist = [];
 			this.vallist = [];
 
-			var sections = uci.sections('ipsec', 'crypto_proposal');
+			var sections = uci.sections('ipsec', 'crypto_proposal').filter(function (section) {
+				return section.is_esp != '1';
+			});
 			if (sections.length == 0) {
 				this.value('', _('Please create a Proposal first'));
 			} else {
 				sections.forEach(L.bind(function (section) {
-					if (section.is_esp != '1') {
-						this.value(section['.name']);
-					}
+					this.value(section['.name']);
 				}, this));
 			}
 
@@ -318,14 +318,14 @@ return view.extend({
 			this.keylist = [];
 			this.vallist = [];
 
-			var sections = uci.sections('ipsec', 'crypto_proposal');
+			var sections = uci.sections('ipsec', 'crypto_proposal').filter(function (section) {
+				return section.is_esp == '1';
+			});
 			if (sections.length == 0) {
 				this.value('', _('Please create an ESP Proposal first'));
 			} else {
 				sections.forEach(L.bind(function (section) {
-					if (section.is_esp == '1') {
-						this.value(section['.name']);
-					}
+					this.value(section['.name']);
 				}, this));
 			}
 


### PR DESCRIPTION
## Pull request details

### Description

Fixes [#8606](https://github.com/openwrt/luci/issues/8606): opening the Tunnel (or Remote) configuration modal throws

> TypeError: Cannot convert undefined or null to object

and the modal never opens.

**Root cause.** The `crypto_proposal` `form.MultiValue` fields on the Remote and Tunnel sections check whether *any* `crypto_proposal` sections exist before falling back to the "Please create a Proposal first" placeholder. When proposals exist but none match the required type (IKE/non-ESP for Remote, ESP for Tunnel) the inner `forEach` adds no choices, leaving `keylist` empty.

An empty `keylist` makes `form.MultiValue.transformChoices()` return `null`, which is then passed straight into `ui.Dropdown`. Because `typeof null === 'object'`, the null-check in `UIDropdown.__init__` (`modules/luci-base/.../ui.js`) does not replace it, and the subsequent `Object.keys(this.choices)` call throws.

This is reproducible by following the natural setup order described in the issue: create some Phase-1 (IKE) Encryption Proposals first, then click *Add* on Tunnel Configuration — the tunnel side filters for `is_esp == '1'`, finds nothing, and the modal explodes.

**Fix.** Filter the section list by `is_esp` *before* the length check, in both `crypto_proposal` load functions, so the placeholder is shown whenever no proposals of the *required* type exist.

```diff
-			var sections = uci.sections('ipsec', 'crypto_proposal');
+			var sections = uci.sections('ipsec', 'crypto_proposal').filter(function (section) {
+				return section.is_esp != '1';
+			});
 			if (sections.length == 0) {
 				this.value('', _('Please create a Proposal first'));
 			} else {
 				sections.forEach(L.bind(function (section) {
-					if (section.is_esp != '1') {
-						this.value(section['.name']);
-					}
+					this.value(section['.name']);
 				}, this));
 			}
```

(plus the symmetric change in the Tunnel section, where the filter is `is_esp == '1'` and the placeholder reads "Please create an ESP Proposal first".)

### Maintainer

@systemcrash — recent maintainer of this app.

---

## Tested on

**OpenWrt version:** 25.12.2 (r32802-f505120278) — same as the issue reporter
**Web browser(s):** Chrome

Reproduction steps from the issue: create Phase-1 IKE proposals only, click *Add* on Tunnel Configuration → the modal opens with the placeholder "Please create an ESP Proposal first" instead of throwing. Same behaviour symmetrically when only ESP proposals exist and the Remote modal is opened.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch, but a *separate* branch.
- [x] Each commit has a valid `Signed-off-by:` row.
- [x] Each commit and PR title has a valid `<package name>: title` first line subject.
- [ ] Incremented any `PKG_VERSION` in the Makefile. _(N/A — `luci-app-strongswan-swanctl` has no `PKG_VERSION`; version is derived by `luci.mk`.)_
- [x] Includes what Issue it closes — fixes openwrt/luci#8606.
- [ ] _(Optional)_ Includes what it depends on. _(N/A.)_