### PR TITLE
rpcd-mod-rrdns/luci: lower cmake_minimum_required to 3.13

### DIFF
--- a/libs/rpcd-mod-luci/Makefile
+++ b/libs/rpcd-mod-luci/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-luci
 PKG_VERSION:=20240305
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 PKG_LICENSE:=Apache-2.0

--- a/libs/rpcd-mod-luci/src/CMakeLists.txt
+++ b/libs/rpcd-mod-luci/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.13)
 
 PROJECT(rpcd-mod-luci C)
 

--- a/libs/rpcd-mod-rrdns/Makefile
+++ b/libs/rpcd-mod-rrdns/Makefile
@@ -8,6 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-rrdns
 PKG_VERSION:=20170710
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 PKG_LICENSE:=Apache-2.0

--- a/libs/rpcd-mod-rrdns/src/CMakeLists.txt
+++ b/libs/rpcd-mod-rrdns/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.13)
 
 PROJECT(rpcd-mod-rrdns C)
 


### PR DESCRIPTION
## Pull request details

### Description

These packages only use basic CMake directives available since 2.x.
Requiring VERSION 3.31 breaks builds on common environments like
Ubuntu 22.04 which ships CMake 3.26.

### Maintainer _(preferred)_
@jow-

---

## Tested on

**OpenWrt version:** OpenWrt 23.05-SNAPSHOT

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: Yepday <365256281@qq.com>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile.
