### PR TITLE
luci-base: add additional information to upload modal

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4924,12 +4924,16 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * An optional DOM text node whose content text is set to the progress
 	 * percentage value during file upload.
 	 *
+	 * @param {string} [info]
+	 * An optional string that carries additional information that should
+	 * be shown under the progressbar.
+	 *
 	 * @returns {Promise<LuCI.ui.FileUploadReply>}
 	 * Returns a promise resolving to a file upload status object on success
 	 * or rejecting with an error in case the upload failed or has been
 	 * cancelled by the user.
 	 */
-	uploadFile(path, progressStatusNode) {
+	uploadFile(path, progressStatusNode, info) {
 		return new Promise((resolveFn, rejectFn) => {
 			UI.prototype.showModal(_('Uploading file…'), [
 				E('p', _('Please select the file to upload.')),
@@ -4985,7 +4989,11 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 
 								const progress = E('div', { 'class': 'cbi-progressbar', 'title': '0%' }, E('div', { 'style': 'width:0' }));
 
-								UI.prototype.showModal(_('Uploading file…'), [ progress ]);
+								let infoNode;
+								if (info)
+									infoNode = E('p', _('%s').format(info));
+
+								UI.prototype.showModal(_('Uploading file…'), [ progress, infoNode ? infoNode : null ]);
 
 								const data = new FormData();
 


### PR DESCRIPTION
### Description
<!-- Describe the changes proposed in this PR. -->
Sometimes it would be useful to display additional information in the modal (e.g. if upload takes some time on slower devices and feedback it so the user knows about the delay).

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->
<img width="600" height="128" alt="image" src="https://github.com/user-attachments/assets/4b1c47e9-b5d6-4614-9059-20eb2997356a" />

**Additional information under the progressbar**

### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** openwrt-25.12<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** firefox <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
