### PR TITLE
luci-app-nut: update to work with drivers in libexec

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -3,8 +3,23 @@
 'require fs';
 'require view';
 
-const driver_path = '/lib/nut/';
+const driver_path = '/usr/libexec/nut/';
+const old_driver_path = '/lib/nut/';
 const ups_daemon = '/usr/sbin/upsd';
+
+function resolveDriverList(path) {
+	return Promise.resolve(L.resolveDefault(fs.list(path), []).then(function(entries) {
+		var files = [];
+		if (entries && entries.length > 0) {
+			entries.forEach(object => {
+				if (object.type == 'file') {
+					files.push(object.name);
+				}
+			});
+		}
+		return files;
+	}));
+}
 
 return view.extend({
 	load: function() {
@@ -14,22 +29,15 @@ return view.extend({
 			}).then(function(stdout) {
 				return stdout.includes('libssl.so');
 			}),
-			L.resolveDefault(fs.list(driver_path), []).then(function(entries) {
-				var files = [];
-				entries.forEach(object => {
-					if (object.type == 'file') {
-						files.push(object.name);
-					}
-				});
-				return files;
-			}),
+			resolveDriverList(driver_path),
+			resolveDriverList(old_driver_path),
 		])
 	},
 
 	render: function(loaded_promises) {
 		let m, s, o;
 		const have_ssl_support = loaded_promises[0];
-		const driver_list = loaded_promises[1];
+		const driver_list = (loaded_promises[1].length > 0) ? loaded_promises[1] : loaded_promises[2];
 
 		m = new form.Map('nut_server', _('NUT Server'),
 			_('Network UPS Tools Server Configuration'));

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -3,8 +3,23 @@
 'require fs';
 'require view';
 
-const driver_path = '/lib/nut/';
+const driver_path = '/usr/libexec/nut/';
+const old_driver_path = '/lib/nut/';
 const ups_daemon = '/usr/sbin/upsd';
+
+function resolveDriverList(path) {
+	return Promise.resolve(L.resolveDefault(fs.list(path), []).then(function(entries) {
+		var files = [];
+		if (entries && entries.length > 0) {
+			entries.forEach(object => {
+				if (object.type == 'file') {
+					files.push(object.name);
+				}
+			})
+		}
+		return files;
+	}));
+}
 
 return view.extend({
 	load: function() {
@@ -14,22 +29,15 @@ return view.extend({
 			}).then(function(stdout) {
 				return stdout.includes('libssl.so');
 			}),
-			L.resolveDefault(fs.list(driver_path), []).then(function(entries) {
-				var files = [];
-				entries.forEach(object => {
-					if (object.type == 'file') {
-						files.push(object.name);
-					}
-				});
-				return files;
-			}),
+			resolveDriverList(driver_path),
+			resolveDriverList(old_driver_path),
 		])
 	},
 
 	render: function(loaded_promises) {
 		let m, s, o;
 		const have_ssl_support = loaded_promises[0];
-		const driver_list = loaded_promises[1];
+		const driver_list = (loaded_promises[1].length > 0) ? loaded_promises[1] : loaded_promises[2];
 
 		m = new form.Map('nut_server', _('NUT Server'),
 			_('Network UPS Tools Server Configuration'));

--- a/applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json
+++ b/applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json
@@ -7,6 +7,7 @@
 				"/tmp/*": [ "list" ],
 				"/lib/lnut": [ "read" ],
 				"/lib/nut/": [ "list" ],
+				"/usr/libexec/nut/": [ "list" ],
 				"/usr/sbin/upsd": [ "read" ],
 				"/usr/sbin/upsmon": [ "read" ],
 				"/var/run/nut": [ "read" ],


### PR DESCRIPTION

## Pull request details

### Description
Briefly, due to recent CI changes, it is was longer possible to have NUT drivers in /lib/nut as they are not libraries. This motivated moving them to /usr/libexec/nut (as they are executable binaries not libraries), which is the right thing to do even though the CI now allows using /lib/nut for the drivers.
https://github.com/openwrt/packages/pull/29592 makes that change for the `nut` package.

We update luci-app-nut so that it can work with either location. As a side benefit, this means this commit does not need to wait for the above PR to land in packages before adding this commit.

### Maintainer

@danielfdickinson, @systemcrash 

---

## Tested on
**OpenWrt version:** OpenWrt SNAPSHOT r34703-aa96b3ad55
**LuCI version:**  LuCI Master (26.149.54726~c4b9631) 
**Web browser(s):** 140.11.0esr (64-bit)

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
  Works with (but does not require, but is required for): https://github.com/openwrt/packages/pull/29592
