### PR TITLE
[25.12] luci-app-openvpn: security fix

### DIFF
--- a/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
@@ -19,7 +19,15 @@ function ovpn_upload()
 	local uci     = require("luci.model.uci").cursor()
 	local upload  = http.formvalue("ovpn_file")
 	local name    = http.formvalue("instance_name2")
+
 	local basedir = "/etc/openvpn"
+	-- SECURITY FIX: Validate instance_name2 to prevent path traversal
+	-- Allow only alphanumeric, underscore, and hyphen (standard UCI naming)
+	if not name or not name:match("^[a-zA-Z0-9_-]+$") then
+		http.status(400, "Bad Request")
+		http.write("Invalid instance name")
+		return
+	end
 	local file    = basedir.. "/" ..name.. ".ovpn"
 
 	if not fs.stat(basedir) then


### PR DESCRIPTION
- fixed a critical path traversal vulnerability in `luci-app-openvpn`, 
  that allows authenticated users to upload arbitrary files
  and achieve root code execution.

Signed-off-by: Dirk Brenken <dev@brenken.org>