### PR TITLE
luci-proto-qmi: validate PDP index and context input

### DIFF
--- a/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
+++ b/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
@@ -143,13 +143,13 @@ return network.registerProtocol('qmi', {
 		o = s.taboption('advanced', form.Value, 'profile',
 			_('APN profile index'));
 		o.placeholder = '1';
-		o.datatype = 'uinteger';
+		o.datatype = 'range(1,9)';
 
 		if (L.hasSystemFeature('ipv6')) {
 			o = s.taboption('advanced', form.Value, 'v6profile',
 				_('IPv6 APN profile index'));
 			o.placeholder = '1';
-			o.datatype = 'uinteger';
+			o.datatype = 'range(1,9)';
 			o.depends('pdptype', 'ipv4v6');
 		};
 	}


### PR DESCRIPTION
This update adds input validation for the PDP context index within the LuCI QMI protocol configuration page. 

It ensures that users provide a valid index, preventing potential connection failures caused by incorrect or out-of-range PDP context values being passed to the underlying qmi.sh script.