### PR TITLE
luci-app-https-dns-proxy: update dns.sb bootstrap IPs

### DIFF
--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/sb.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/sb.dns.json
@@ -1,7 +1,7 @@
 {
 	"title": "DoH DNS (SB)",
 	"template": "https://doh.dns.sb/dns-query",
-	"bootstrap_dns": "185.222.222.222,185.184.222.222",
+	"bootstrap_dns": "185.222.222.222,45.11.45.11",
 	"help_link": "https://dns.sb/doh/",
 	"http2_only": true
 }


### PR DESCRIPTION
Update the bootstrap DNS addresses for DNS.SB to match their current official recommendations. This ensures reliable resolution of the DoH endpoint.

Reference: https://dns.sb/doh/