### PR TITLE
luci-base: fix "null" text appearing in modal

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -1376,11 +1376,12 @@
 				return null;
 
 			if (Array.isArray(children)) {
-				for (let i = 0; i < children.length; i++)
+				for (let i = 0; i < children.length; i++) {
 					if (this.elem(children[i]))
 						node.appendChild(children[i]);
-					else if (children !== null && children !== undefined)
+					else if (children[i] !== null && children[i] !== undefined)
 						node.appendChild(document.createTextNode(`${children[i]}`));
+				}
 
 				return node.lastChild;
 			}

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4993,7 +4993,7 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 								if (info)
 									infoNode = E('p', _('%s').format(info));
 
-								UI.prototype.showModal(_('Uploading file…'), [ progress, infoNode ? infoNode : null ]);
+								UI.prototype.showModal(_('Uploading file…'), [ progress, infoNode ]);
 
 								const data = new FormData();
 


### PR DESCRIPTION



fix "null" text appearing in modal
### Description
<!-- Describe the changes proposed in this PR. -->

This is in a nutshell @AndyChiang888 's PR with the suggested `{}`-enclosed for-loop,
as suggested by @systemcrash .

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash @feckert @AndyChiang888 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** luci openwrt-25.12<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Firefox<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
