### PR TITLE
luci-proto-openvpn: fix askpass name

### DIFF
--- a/protocols/luci-proto-openvpn/htdocs/luci-static/resources/protocol/openvpn.js
+++ b/protocols/luci-proto-openvpn/htdocs/luci-static/resources/protocol/openvpn.js
@@ -953,7 +953,7 @@ const openvpnOptions = [
 		tab: 'cryptography',
 		type: form.FileUpload,
 		root_directory: '/etc',
-		name: 'askpass_file',
+		name: 'askpass',
 		label: _('Get certificate password from file before we daemonize')
 	},
 	{


### PR DESCRIPTION
Description:
OpenVPN fails when you need a private key password file
( askpass_file tag not found in the other packages)

Error:
```
Wed May 13 16:17:17 2026 daemon.err openvpn_vpn[16106]: neither stdin nor stderr are a tty device and you have neither a controlling tty nor systemd - can't ask for 'Enter Private Key Password:'.  If you used --daemon, you need to use --askpass to make passphrase-protected keys work, and you can not use --auth-nocache.
Wed May 13 16:17:17 2026 daemon.notice openvpn_vpn[16106]: Exiting due to fatal error
Wed May 13 16:17:17 2026 daemon.notice netifd: Interface 'vpn' is now down
```
Solution:
Rename `askpass_file` to `askpass`

Example of tag "askpass" used in other repo/packages
[openvpn.sh](https://github.com/openwrt/packages/blob/021d62d58ffbb770e92faeb9c82df4bbcbc39d60/net/openvpn/files/lib/netifd/proto/openvpn.sh#L161)
`json_get_vars auth_user_pass askpass username password cert_password`

[openvpn.uc](https://github.com/openwrt/packages/blob/021d62d58ffbb770e92faeb9c82df4bbcbc39d60/net/openvpn/files/lib/netifd/proto/openvpn.uc#L116)
`{ name: 'askpass' },`

Signed-off-by: David Perez <d4v1dp3@gmail.com>