### PR TITLE
Alternative view for configuring switch ports and VLANs

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/switchconfig.css
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/switchconfig.css
@@ -1,0 +1,391 @@
+/*
+ * Switch config view — port-centric VLAN assignment
+ * Injected as a stylesheet <link> in switchconfig.js load() (LuCI has no L.loadCSS).
+ * Scoped under .switchconfig-pc to avoid polluting other views.
+ */
+
+/* ------------------------------------------------------------------ layout */
+
+/*
+ * Reserve bottom padding for the fixed .assign-dock.
+ * LuCI nests .switchconfig-pc inside #maincontent, so the fixed dock
+ * sits relative to the viewport, not this element.
+ */
+.switchconfig-pc {
+	padding-bottom: clamp(14rem, 38vh, 26rem);
+	box-sizing: border-box;
+}
+
+/* ------------------------------------------------------------------ assign dock (fixed bottom bar) */
+
+.switchconfig-pc .assign-dock {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 850;
+	background: var(--background-color-high);
+	border-top: 1px solid var(--border-color-medium);
+	box-shadow: 0 -2px 8px hsla(0, 0%, 0%, .08);
+}
+
+.switchconfig-pc .assign-dock > .container {
+	padding-top: .5rem;
+	padding-bottom: 0;
+}
+
+.switchconfig-pc .assign-dock .cbi-section > legend:first-child {
+	padding-top: 8px;
+}
+
+.switchconfig-pc .assign-dock .cbi-page-actions {
+	margin-bottom: 0;
+}
+
+.switchconfig-pc .assign-dock-tools {
+	display: flex;
+	flex-wrap: wrap;
+	gap: .375rem;
+	margin: .25rem 0 .5rem;
+}
+
+/* ------------------------------------------------------------------ port grid */
+
+.switchconfig-pc .pc-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(108px, 120px));
+	gap: .5rem .625rem;
+	justify-content: start;
+	align-items: start;
+	margin: .5rem 0 0;
+}
+
+/* ------------------------------------------------------------------ port chip */
+
+.switchconfig-pc .pc-chip {
+	width: 120px;
+	height: 126px;
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--border-color-medium);
+	border-radius: 3px;
+	padding: 6px;
+	cursor: pointer;
+	box-sizing: border-box;
+	background: var(--background-color-high);
+	box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, .6);
+	overflow: hidden;
+}
+
+.switchconfig-pc .pc-chip:hover {
+	border-color: var(--primary-color-high);
+}
+
+.switchconfig-pc .pc-chip.selected {
+	outline: 2px solid var(--primary-color-high);
+	outline-offset: 1px;
+	background: var(--background-color-low);
+}
+
+.switchconfig-pc .pc-name {
+	font-family: var(--font-mono);
+	font-weight: bold;
+	font-size: .75rem;
+	text-align: center;
+	color: var(--text-color-high);
+	flex-shrink: 0;
+}
+
+/* ------------------------------------------------------------------ link status indicator */
+
+.switchconfig-pc .pc-link {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+	margin-top: 2px;
+	font-size: .5625rem;
+	line-height: 1.15;
+	flex-shrink: 0;
+}
+
+.switchconfig-pc .pc-link-ico {
+	display: inline-block;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	box-shadow: inset 0 -1px 1px rgba(0, 0, 0, .18);
+}
+
+.switchconfig-pc .pc-link--up .pc-link-ico {
+	background: linear-gradient(180deg, var(--success-color-high), var(--success-color-medium));
+	box-shadow: 0 0 0 1px rgba(var(--success-color-high-rgb), .35);
+}
+
+.switchconfig-pc .pc-link--down .pc-link-ico {
+	background: linear-gradient(180deg, var(--error-color-medium), var(--error-color-low));
+	box-shadow: 0 0 0 1px rgba(var(--error-color-high-rgb), .28);
+}
+
+.switchconfig-pc .pc-link--up .pc-link-desc {
+	color: var(--success-color-medium);
+	font-weight: bold;
+}
+
+.switchconfig-pc .pc-link--down .pc-link-desc {
+	color: var(--error-color-medium);
+	font-weight: bold;
+}
+
+/* ------------------------------------------------------------------ chip summary text */
+
+.switchconfig-pc .pc-sum {
+	margin-top: 3px;
+	font-size: .6875rem;
+	line-height: 1.35;
+	word-break: break-word;
+	overflow-wrap: anywhere;
+	color: var(--text-color-medium);
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+}
+
+.switchconfig-pc .pc-sum strong {
+	color: var(--text-color-high);
+}
+
+.switchconfig-pc .pc-sum em {
+	font-style: normal;
+	font-weight: bold;
+	color: var(--primary-color-medium);
+}
+
+.switchconfig-pc .chip-empty {
+	color: var(--text-color-low);
+}
+
+/* ------------------------------------------------------------------ port label input (inside chip) */
+
+.switchconfig-pc .pc-port-label {
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	margin-top: 2px;
+	padding: 1px 3px;
+	font-size: .625rem;
+	line-height: 1.15;
+	font-weight: normal;
+	font-family: var(--font-sans);
+	color: var(--text-color-medium);
+	border: 1px solid var(--border-color-medium);
+	border-radius: 2px;
+	background: var(--background-color-medium);
+}
+
+/* ------------------------------------------------------------------ native VLAN select (dock) */
+
+.switchconfig-pc .assign-dock .cbi-value-field > span.cbi-select {
+	display: inline-block;
+	vertical-align: middle;
+	position: relative;
+	width: 210px;
+	max-width: min(100%, 210px);
+	height: 30px;
+	min-height: 30px;
+	padding: 0 !important;
+	margin: 0;
+	box-sizing: border-box;
+	overflow: hidden;
+	border: 1px solid var(--border-color-high);
+	border-radius: 3px;
+	background: linear-gradient(var(--background-color-high), var(--border-color-low));
+}
+
+.switchconfig-pc .assign-dock .cbi-value-field > span.cbi-select select {
+	display: block;
+	width: 100% !important;
+	height: 30px !important;
+	min-height: 30px !important;
+	margin: 0 !important;
+	padding: 0 1.75em 0 6px !important;
+	line-height: 28px !important;
+	font-size: .8125rem;
+	font-family: var(--font-sans);
+	color: var(--text-color-high);
+	background: transparent !important;
+	border: none !important;
+	box-shadow: none !important;
+	-webkit-appearance: none;
+	appearance: none;
+	cursor: pointer;
+}
+
+/* ------------------------------------------------------------------ tagged VLAN custom dropdown */
+
+.switchconfig-pc .ck-dd {
+	position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	max-width: 100%;
+}
+
+.switchconfig-pc .assign-dock button.ck-dd-toggle {
+	appearance: none;
+	font-family: var(--font-sans);
+	font-size: .8125rem;
+	height: 30px;
+	min-height: 30px;
+	max-height: 30px;
+	margin: 0;
+	padding: 0 8px;
+	box-sizing: border-box;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	width: fit-content;
+	max-width: min(100%, 260px);
+	text-align: left;
+	color: var(--text-color-high);
+	cursor: pointer;
+	background: linear-gradient(var(--background-color-high), var(--border-color-low));
+	border: 1px solid var(--border-color-high);
+	border-radius: 3px;
+}
+
+.switchconfig-pc .assign-dock .ck-dd-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	flex: 0 1 auto;
+	min-width: 0;
+}
+
+.switchconfig-pc .ck-dd-menu {
+	display: none;
+	position: absolute;
+	left: 0;
+	top: 100%;
+	margin-top: 3px;
+	min-width: 12rem;
+	width: max-content;
+	max-width: min(calc(100vw - 24px), 20rem);
+	max-height: 12rem;
+	overflow-y: auto;
+	z-index: 9000;
+	padding: 5px 6px;
+	background: var(--background-color-high);
+	border: 1px solid var(--border-color-medium);
+	border-radius: 3px;
+	box-shadow: 0 4px 12px hsla(0, 0%, 0%, .15);
+	list-style: none;
+}
+
+.switchconfig-pc .ck-dd.open > .ck-dd-menu {
+	display: block;
+}
+
+.switchconfig-pc .ck-dd-menu li.ck-dd-meta {
+	margin: 0 0 5px;
+	padding: 0 0 6px;
+	border-bottom: 1px solid var(--border-color-medium);
+	list-style: none;
+}
+
+.switchconfig-pc .ck-dd-menu .ck-dd-tag-bulk {
+	display: block;
+	width: 100%;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 5px 6px;
+	font-size: .75rem;
+	font-weight: bold;
+	text-align: left;
+	cursor: pointer;
+	color: var(--primary-color-medium);
+	background: var(--background-color-low);
+	border: 1px solid var(--border-color-medium);
+	border-radius: 3px;
+}
+
+.switchconfig-pc .ck-dd-menu .ck-dd-tag-bulk:hover:not(:disabled) {
+	background: var(--background-color-medium);
+	color: var(--primary-color-low);
+}
+
+.switchconfig-pc .ck-dd-menu .ck-dd-tag-bulk:disabled {
+	opacity: var(--disabled-opacity);
+	cursor: not-allowed;
+}
+
+.switchconfig-pc .ck-dd-menu li label.ck-dd-vlan {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	margin: 0;
+	padding: 4px 6px;
+	font-size: .8125rem;
+	cursor: pointer;
+	border-radius: 2px;
+}
+
+/* ------------------------------------------------------------------ preview / status line */
+
+.switchconfig-pc #scp-preview {
+	margin: .5rem 0 .75rem;
+	font-size: .75rem;
+	line-height: 1.45;
+	max-height: 6.5rem;
+	overflow: auto;
+}
+
+/* ------------------------------------------------------------------ VLAN catalogue section */
+
+.switchconfig-pc fieldset.vlan-maint-section {
+	margin-top: 1.5rem;
+}
+
+.switchconfig-pc .vlan-catalog-line {
+	font-family: var(--font-mono);
+	font-size: .75rem;
+	margin-bottom: .625rem;
+}
+
+.switchconfig-pc .vlan-maint-add .cbi-value-field {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: .5rem;
+}
+
+.switchconfig-pc .vlan-maint-add input[type="number"] {
+	width: 108px;
+	flex-shrink: 0;
+}
+
+.switchconfig-pc .vlan-maint-add input.scp-vlan-add-label {
+	flex: 1 1 12rem;
+	min-width: 10rem;
+	max-width: 36rem;
+	font-size: .8125rem;
+	padding: 3px 8px;
+	box-sizing: border-box;
+}
+
+.switchconfig-pc .scp-vlan-label {
+	width: 100%;
+	max-width: 18rem;
+	box-sizing: border-box;
+	font-size: .75rem;
+	padding: 2px 6px;
+}
+
+.switchconfig-pc #scp-vlan-table td:last-child {
+	width: 7rem;
+}
+
+.switchconfig-pc #scp-vlan-table td:first-child {
+	font-family: var(--font-mono);
+}

--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/switchconfig_bridge.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/switchconfig_bridge.js
@@ -1,0 +1,149 @@
+'use strict';
+'require baseclass';
+'require uci';
+
+/** @file Bridge / VLAN inference helpers for the port-centric Switch config view (self-contained). */
+
+return baseclass.extend(/** @lends luci.tools.switchconfig_bridge.prototype */{
+	netdevMap(netDevices) {
+		const m = {};
+
+		for (let i = 0; i < netDevices.length; i++)
+			m[netDevices[i].getName()] = netDevices[i];
+
+		return m;
+	},
+
+	inferBridgeHint() {
+		let q;
+
+		try {
+			q = new URL(window.location.href);
+		}
+		catch (e) {
+			return null;
+		}
+
+		if (!q.searchParams)
+			return null;
+
+		let v = q.searchParams.get('device') || q.searchParams.get('bridge');
+
+		if (typeof v === 'string')
+			v = v.trim();
+
+		return (v != null && v !== '') ? v : null;
+	},
+
+	bridgesFromUciSections() {
+		return uci.sections('network', 'device')
+			.filter(function(ds) { return ds.type === 'bridge' && ds.name; })
+			.sort(function(a, b) { return L.naturalCompare(a.name, b.name); });
+	},
+
+	branchVlanRefsCount(devname) {
+		let n = 0;
+
+		uci.sections('network', 'bridge-vlan', function(bvs) {
+			if (bvs.device === devname)
+				n++;
+		});
+
+		return n;
+	},
+
+	inferSwitchBridge(netDevices, hinted) {
+		const ndm = this.netdevMap(netDevices);
+
+		if (hinted) {
+			if (uci.sections('network', 'bridge-vlan').some(function(bv) {
+				return bv.device === hinted;
+			})) {
+				return hinted;
+			}
+
+			const netd = ndm[hinted];
+
+			if (netd != null && netd.isBridge())
+				return hinted;
+		}
+
+		let bestName = null;
+		let bestScore = -1;
+
+		for (let ds of this.bridgesFromUciSections()) {
+			const name = ds.name;
+			const ports = L.toArray(ds.ports);
+			const bv = this.branchVlanRefsCount(name);
+			let sc = ports.length + bv * 4;
+
+			if (ports.length >= 8 || bv >= 8)
+				sc += 80;
+
+			if (sc > bestScore) {
+				bestScore = sc;
+				bestName = name;
+			}
+		}
+
+		if (bestScore > 0)
+			return bestName;
+
+		for (let i = 0; i < netDevices.length; i++) {
+			const d = netDevices[i];
+
+			if (!d.isBridge())
+				continue;
+
+			const pname = d.getName();
+			const bv = this.branchVlanRefsCount(pname);
+			let sc = (d.getPorts() || []).length + bv * 6;
+
+			if (bv >= 4)
+				sc += 120;
+
+			if (sc > bestScore) {
+				bestScore = sc;
+				bestName = pname;
+			}
+		}
+
+		return bestName || null;
+	},
+
+	collectSeenPortsBridge(bridgeName) {
+		const seenPorts = {};
+		const bridges = this.bridgesFromUciSections().filter(function(ds) {
+			return ds.name === bridgeName;
+		});
+
+		for (let ds of bridges)
+			L.toArray(ds.ports).forEach(function(port) {
+				seenPorts[port.replace(/:.*/, '') || port] = true;
+			});
+
+		uci.sections('network', 'bridge-vlan', function(bvs) {
+			if (bvs.device !== bridgeName)
+				return;
+
+			L.toArray(bvs.ports).forEach(function(portspec) {
+				const mm = portspec.match(/^([^:]+)(?::[ut*]+)?$/);
+
+				if (mm)
+					seenPorts[mm[1]] = true;
+			});
+		});
+
+		return Object.keys(seenPorts);
+	},
+
+	/*
+	 * Same scope as the Bridge VLAN filtering tab in tools/network.js: options there
+	 * depend on `type` being `bridge` (vlan_filtering / bridge-vlan rows).
+	 */
+	hasVlanAwareBridgeConfigured() {
+		return uci.sections('network', 'device').some(function(d) {
+			return d.type === 'bridge' && d.name;
+		});
+	}
+});

--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/switchconfig_labels.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/switchconfig_labels.js
@@ -1,0 +1,169 @@
+'use strict';
+'require baseclass';
+'require uci';
+
+/**
+ * User-only annotations for Switch config: stored in /etc/config/luci (not network).
+ * Expect one section each:
+ *   config switchconfig_port_labels
+ *       option lan1 'uplink'
+ *   config switchconfig_vlan_labels
+ *       option 10 'Guest'
+ */
+
+const T_PORT_LABELS = 'switchconfig_port_labels';
+const T_VLAN_LABELS = 'switchconfig_vlan_labels';
+
+return baseclass.extend(/** @lends luci.tools.switchconfig_labels.prototype */{
+	T_PORT_LABELS: T_PORT_LABELS,
+
+	T_VLAN_LABELS: T_VLAN_LABELS,
+
+	_singleSectionSid(typ) {
+		const secs = uci.sections('luci', typ);
+
+		return secs.length ? secs[0]['.name'] : null;
+	},
+
+	_ensurePortMapSid() {
+		let sid = this._singleSectionSid(T_PORT_LABELS);
+
+		if (!sid)
+			sid = uci.add('luci', T_PORT_LABELS);
+
+		return sid;
+	},
+
+	_ensureVlanMapSid() {
+		let sid = this._singleSectionSid(T_VLAN_LABELS);
+
+		if (!sid)
+			sid = uci.add('luci', T_VLAN_LABELS);
+
+		return sid;
+	},
+
+	_mapToObject(sid) {
+		const m = {};
+
+		if (!sid)
+			return m;
+
+		const row = uci.get('luci', sid);
+
+		if (!row || typeof row != 'object')
+			return m;
+
+		for (const k in row) {
+			if (k.charAt(0) === '.')
+				continue;
+
+			const v = row[k];
+
+			m[k] = Array.isArray(v) ? v.join(' ') : String(v != null ? v : '');
+		}
+
+		return m;
+	},
+
+	/**
+	 * Remove label options whose port / VLAN no longer exists on this bridge.
+	 */
+	pruneSwitchconfigLabels(validPortIds, validVids) {
+		const vp = {};
+
+		for (let i = 0; i < validPortIds.length; i++)
+			vp[validPortIds[i]] = true;
+
+		const vv = {};
+
+		for (let j = 0; j < validVids.length; j++)
+			vv[String(validVids[j])] = true;
+
+		const psid = this._singleSectionSid(T_PORT_LABELS);
+
+		if (psid) {
+			const pm = this._mapToObject(psid);
+
+			for (const port in pm) {
+				if (!vp[port])
+					uci.unset('luci', psid, port);
+			}
+		}
+
+		const vsid = this._singleSectionSid(T_VLAN_LABELS);
+
+		if (vsid) {
+			const vm = this._mapToObject(vsid);
+
+			for (const vid in vm) {
+				if (!vv[vid])
+					uci.unset('luci', vsid, vid);
+			}
+		}
+	},
+
+	getPortLabelMap() {
+		const sid = this._singleSectionSid(T_PORT_LABELS);
+
+		return this._mapToObject(sid);
+	},
+
+	getVlanLabelMap() {
+		const sid = this._singleSectionSid(T_VLAN_LABELS);
+
+		return this._mapToObject(sid);
+	},
+
+	setPortLabel(port, labelText) {
+		const t = String(labelText || '').trim();
+		const sid = this._ensurePortMapSid();
+
+		if (!t)
+			uci.unset('luci', sid, port);
+		else
+			uci.set('luci', sid, port, t);
+
+		return uci.save();
+	},
+
+	setVlanLabel(vlanId, labelText) {
+		const vidKey = String(vlanId);
+		const t = String(labelText || '').trim();
+		const sid = this._ensureVlanMapSid();
+
+		if (!t)
+			uci.unset('luci', sid, vidKey);
+		else
+			uci.set('luci', sid, vidKey, t);
+
+		return uci.save();
+	},
+
+	/**
+	 * Flush draft labels without racing parallel uci saves: runs setPortLabel / setVlanLabel in order.
+	 */
+	syncAllDraftLabels(portSpecs, vlanSpecs) {
+		let chain = Promise.resolve();
+
+		for (let i = 0; i < portSpecs.length; i++) {
+			const port = portSpecs[i].port;
+			const label = portSpecs[i].label;
+
+			chain = chain.then(L.bind(function() {
+				return this.setPortLabel(port, label);
+			}, this));
+		}
+
+		for (let j = 0; j < vlanSpecs.length; j++) {
+			const vlan = vlanSpecs[j].vlan;
+			const label = vlanSpecs[j].label;
+
+			chain = chain.then(L.bind(function() {
+				return this.setVlanLabel(vlan, label);
+			}, this));
+		}
+
+		return chain;
+	}
+});

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switchconfig.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switchconfig.js
@@ -1,0 +1,1083 @@
+'use strict';
+'require view';
+'require uci';
+'require ui';
+'require network';
+'require tools.switchconfig_bridge as svnbr';
+'require tools.switchconfig_labels as scLbl';
+
+function netdevOrderedPorts(bridge, netDevices) {
+	const raw = svnbr.collectSeenPortsBridge(bridge);
+	let sortable = [];
+
+	for (let i = 0; i < raw.length; i++) {
+		const dev = network.instantiateDevice(raw[i]);
+
+		if (dev.getType() !== 'wifi' || dev.isUp())
+			sortable.push(dev);
+	}
+
+	sortable.sort(function(a, b) {
+		return L.naturalCompare(a.getName(), b.getName());
+	});
+
+	const out = [];
+	const seen = {};
+
+	for (let j = 0; j < sortable.length; j++) {
+		const n = sortable[j].getName();
+
+		if (seen[n])
+			continue;
+
+		seen[n] = true;
+		out.push(n);
+	}
+
+	if (out.length)
+		return out;
+
+	const ndm = svnbr.netdevMap(netDevices);
+	const brn = ndm[bridge];
+
+	if (brn != null && typeof brn.getPorts === 'function') {
+		for (let p of (brn.getPorts() || [])) {
+			const n = p.getName();
+
+			if (!seen[n]) {
+				seen[n] = true;
+				out.push(n);
+			}
+		}
+	}
+
+	return out;
+}
+
+function parseBridgeVlanForPorts(bridge, portIds, netDevices) {
+	const ndm = svnbr.netdevMap(netDevices);
+	const ports = [];
+	const portById = {};
+
+	for (let i = 0; i < portIds.length; i++) {
+		const id = portIds[i];
+		const d = ndm[id];
+		let carrier = false, speed = 0, duplex = null;
+
+		if (d != null) {
+			carrier = !!d.getCarrier();
+			speed = d.getSpeed() || 0;
+			duplex = d.getDuplex();
+		}
+
+		const p = {
+			id: id,
+			native: '',
+			tagged: '',
+			carrier: carrier,
+			speed: speed,
+			duplex: duplex,
+			_link: null,
+			_sx: null
+		};
+
+		ports.push(p);
+		portById[id] = p;
+	}
+
+	const vlanSeen = {};
+	const bridgeVlans = [];
+	const localByVid = {};
+	const secs = uci.sections('network', 'bridge-vlan');
+
+	for (let si = 0; si < secs.length; si++) {
+		const s = secs[si];
+
+		if (s.device !== bridge)
+			continue;
+
+		const vidStr = String(s.vlan);
+
+		if (!vidStr || vidStr === 'null')
+			continue;
+
+		if (!vlanSeen[vidStr]) {
+			vlanSeen[vidStr] = true;
+			bridgeVlans.push(+vidStr);
+		}
+
+		if (s.local != null && s.local !== '')
+			localByVid[vidStr] = s.local;
+
+		const pl = L.toArray(s.ports);
+
+		for (let pi = 0; pi < pl.length; pi++) {
+			const spec = String(pl[pi]);
+			const m = spec.match(/^([^:]+)(?::(.*))?$/);
+
+			if (!m)
+				continue;
+
+			const pname = m[1];
+			const rest = m[2] || '';
+			const pr = portById[pname];
+
+			if (!pr)
+				continue;
+
+			if (/t/.test(rest)) {
+				const tags = pr.tagged ? pr.tagged.split(/\s+/).filter(Boolean) : [];
+
+				tags.push(vidStr);
+
+				const uniq = {};
+				const merged = [];
+
+				for (let ti = 0; ti < tags.length; ti++) {
+					const t = tags[ti];
+
+					if (!uniq[t]) {
+						uniq[t] = true;
+						merged.push(t);
+					}
+				}
+
+				merged.sort(function(a, b) { return +a - +b; });
+				pr.tagged = merged.join(' ');
+			}
+			else {
+				pr.native = vidStr;
+			}
+		}
+	}
+
+	bridgeVlans.sort(function(a, b) { return a - b; });
+
+	return { ports: ports, bridgeVlans: bridgeVlans, localByVid: localByVid };
+}
+
+function deepSnapshot(ports, bridgeVlans, localByVid) {
+	return {
+		ports: ports.map(function(p) {
+			return {
+				id: p.id, native: p.native, tagged: p.tagged,
+				carrier: p.carrier, speed: p.speed, duplex: p.duplex
+			};
+		}),
+		bridgeVlans: bridgeVlans.slice(),
+		localByVid: Object.assign({}, localByVid)
+	};
+}
+
+function flushBridgeVlanUci(bridge, ctx) {
+	const wanted = {};
+
+	for (let i = 0; i < ctx.bridgeVlans.length; i++)
+		wanted[String(ctx.bridgeVlans[i])] = true;
+
+	/* Remove obsolete sections in one pass */
+	uci.sections('network', 'bridge-vlan').forEach(function(s) {
+		if (s.device === bridge && !wanted[String(s.vlan)])
+			uci.remove('network', s['.name']);
+	});
+
+	/* Upsert: snapshot once to avoid repeated re-query inside the loop */
+	for (let vi = 0; vi < ctx.bridgeVlans.length; vi++) {
+		const vid = ctx.bridgeVlans[vi];
+		const vs = String(vid);
+
+		/* Find existing section for this bridge+vlan */
+		const existing = uci.sections('network', 'bridge-vlan').filter(function(s) {
+			return s.device === bridge && String(s.vlan) === vs;
+		})[0];
+
+		const sid = existing
+			? existing['.name']
+			: uci.add('network', 'bridge-vlan');
+
+		if (!existing) {
+			uci.set('network', sid, 'device', bridge);
+			uci.set('network', sid, 'vlan', vs);
+		}
+
+		const portArr = [];
+
+		for (let k = 0; k < ctx.ports.length; k++) {
+			const p = ctx.ports[k];
+
+			if (String(p.native) === vs)
+				portArr.push(p.id);
+			else if ((p.tagged || '').split(/\s+/).filter(Boolean).indexOf(vs) >= 0)
+				portArr.push(p.id + ':t');
+		}
+
+		uci.set('network', sid, 'ports', portArr);
+
+		const loc = ctx.localByVid[vs];
+		uci.set('network', sid, 'local', (loc != null && loc !== '') ? loc : '1');
+	}
+}
+
+return view.extend({
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+
+	load() {
+		if (!document.getElementById('switchconfig-css-sheet'))
+			document.querySelector('head').appendChild(E('link', {
+				'id': 'switchconfig-css-sheet',
+				'rel': 'stylesheet',
+				'type': 'text/css',
+				'href': L.resource('switchconfig.css')
+			}));
+
+		return Promise.all([
+			network.getDevices(),
+			uci.load('network'),
+			uci.load('luci')
+		]);
+	},
+
+	render(data) {
+		const netDevices = data[0];
+
+		if (!svnbr.hasVlanAwareBridgeConfigured())
+			return E('div', { 'class': 'alert-message notice' }, [
+				E('p', {}, _('Switch config is available after you add a bridge device under Network → Interfaces → Devices. Enable VLAN filtering and VLANs on the bridge there if needed.'))
+			]);
+
+		const hint   = svnbr.inferBridgeHint();
+		const bridge = svnbr.inferSwitchBridge(netDevices, hint);
+
+		if (!bridge)
+			return E('div', { 'class': 'cbi-map' }, [
+				E('h2', { 'name': 'content' }, _('Switch config')),
+				E('div', { 'class': 'cbi-map-descr' },
+					_('No suitable VLAN-aware bridge was found. Configure a bridge with VLAN filtering under Network → Interfaces → Devices.'))
+			]);
+
+		const portIds = netdevOrderedPorts(bridge, netDevices);
+
+		if (!portIds.length)
+			return E('div', { 'class': 'cbi-map' }, [
+				E('h2', { 'name': 'content' }, _('Switch config')),
+				E('div', { 'class': 'cbi-map-descr' },
+					_('No switch ports were found on bridge "%s".').format(bridge))
+			]);
+
+		const parsed = parseBridgeVlanForPorts(bridge, portIds, netDevices);
+		const ctx = {
+			bridge: bridge,
+			ports: parsed.ports,
+			bridgeVlans: parsed.bridgeVlans,
+			localByVid: parsed.localByVid
+		};
+
+		scLbl.pruneSwitchconfigLabels(
+			ctx.ports.map(function(p) { return p.id; }),
+			ctx.bridgeVlans
+		);
+
+		uci.save().catch(function() {});
+
+		const portLabelMap = scLbl.getPortLabelMap();
+		const initial     = deepSnapshot(ctx.ports, ctx.bridgeVlans, ctx.localByVid);
+		const ndm         = svnbr.netdevMap(netDevices);
+
+		/* ---- helpers ---------------------------------------------------- */
+
+		function chipHtml(pc) {
+			const u    = (pc.native || '').trim();
+			const t    = (pc.tagged || '').trim();
+			const bits = [];
+
+			if (u)
+				bits.push(E('span', {}, [ E('strong', {}, [ 'U:' ]), document.createTextNode(u) ]));
+
+			if (t) {
+				const tagged = t.split(/\s+/).filter(Boolean).join(', ');
+				bits.push(E('span', {}, [ E('em', {}, [ 'T:' ]), document.createTextNode(tagged) ]));
+			}
+
+			if (!bits.length)
+				return E('span', { 'class': 'chip-empty' }, [ _('No VLAN membership') ]);
+
+			const wrap = E('span', {});
+
+			for (let i = 0; i < bits.length; i++) {
+				if (i > 0)
+					wrap.appendChild(document.createTextNode(' · '));
+
+				wrap.appendChild(bits[i]);
+			}
+
+			return wrap;
+		}
+
+		function refreshPortTile(p) {
+			const d = ndm[p.id];
+
+			if (d != null) {
+				p.carrier = !!d.getCarrier();
+				p.speed   = d.getSpeed() || 0;
+				p.duplex  = d.getDuplex();
+			}
+
+			if (p._link) {
+				const up = !!p.carrier;
+				const sp = +p.speed || 0;
+				const du = p.duplex;
+				let descText, titleText;
+
+				if (!up) {
+					descText  = _('no link');
+					titleText = _('no link');
+				}
+				else if (sp > 0 && du === 'full') {
+					descText  = '%dFD'.format(sp);
+					titleText = _('%s, %d MBit/s, %s').format(_('Connected'), sp, _('full-duplex'));
+				}
+				else if (sp > 0 && du === 'half') {
+					descText  = '%dHD'.format(sp);
+					titleText = _('%s, %d MBit/s, %s').format(_('Connected'), sp, _('half-duplex'));
+				}
+				else if (sp > 0) {
+					descText  = '%dbaseT'.format(sp);
+					titleText = _('%s, %d MBit/s').format(_('Connected'), sp);
+				}
+				else {
+					descText  = _('Connected');
+					titleText = _('Connected');
+				}
+
+				p._link.className = 'pc-link ' + (up ? 'pc-link--up' : 'pc-link--down');
+				p._link.title     = titleText;
+				p._link.innerHTML = '';
+				p._link.append(
+					E('span', { 'class': 'pc-link-ico' }),
+					E('span', { 'class': 'pc-link-desc' }, [ descText ])
+				);
+			}
+
+			if (p._sx) {
+				p._sx.innerHTML = '';
+				p._sx.appendChild(chipHtml(p));
+			}
+		}
+
+		function stripVidFromAllPorts(vid) {
+			for (let i = 0; i < ctx.ports.length; i++) {
+				const p = ctx.ports[i];
+
+				if (+p.native === +vid)
+					p.native = '';
+
+				p.tagged = p.tagged.split(/\s+/).filter(Boolean).filter(function(x) {
+					return +x !== +vid;
+				}).join(' ');
+
+				refreshPortTile(p);
+			}
+		}
+
+		/* ---- dock elements --------------------------------------------- */
+
+		const selNative = E('select', { 'id': 'scp-unt-select', 'aria-labelledby': 'scp-dock-title-native' });
+
+		const menuTagged = E('ul', { 'class': 'ck-dd-menu', 'id': 'scp-menu-tagged' });
+		menuTagged.addEventListener('click', function(e) { e.stopPropagation(); });
+
+		const lblTagged = E('span', { 'id': 'scp-lbl-tagged', 'class': 'ck-dd-label' });
+		const ddWrap    = E('div',  { 'class': 'ck-dd', 'id': 'scp-dd-tagged', 'data-dd': true }, [
+			E('button', {
+				'type': 'button',
+				'class': 'ck-dd-toggle',
+				'id': 'scp-tagged-toggle',
+				'aria-labelledby': 'scp-dock-title-tagged',
+				'click': function(ev) {
+					ev.preventDefault();
+					ev.stopPropagation();
+					const opening = !ddWrap.classList.contains('open');
+					document.querySelectorAll('.switchconfig-pc [data-dd]').forEach(function(w) {
+						w.classList.toggle('open', w === ddWrap && opening);
+					});
+				}
+			}, [ lblTagged, E('span', { 'class': 'dd-caret', 'aria-hidden': 'true' }, [ '\u25bc' ]) ]),
+			menuTagged
+		]);
+
+		const preview     = E('pre', { 'id': 'scp-preview', 'class': 'switchvlan-preview', 'aria-live': 'polite' });
+		const vlanCatalog = E('p',   { 'id': 'scp-vlan-catalog', 'class': 'cbi-section-descr vlan-catalog-line' });
+		const vlanTbody   = E('tbody', { 'id': 'scp-vlan-tbody' });
+		const portFarm    = E('div',   { 'class': 'pc-grid', 'id': 'scp-port-farm' });
+		const selCount    = E('strong', { 'id': 'scp-sel-count' }, [ '0' ]);
+
+		/* ---- UI refresh helpers ----------------------------------------- */
+
+		function refillNativeSelect() {
+			const keep = selNative.value;
+			const vlm  = scLbl.getVlanLabelMap();
+
+			selNative.innerHTML = '';
+			selNative.appendChild(E('option', { 'value': '' }, [ _('(none)') ]));
+
+			for (let i = 0; i < ctx.bridgeVlans.length; i++) {
+				const v   = ctx.bridgeVlans[i];
+				const lab = vlm[String(v)]
+					? _('VLAN %s — %s').format(v, vlm[String(v)])
+					: _('VLAN %s').format(v);
+
+				selNative.appendChild(E('option', { 'value': String(v) }, [ lab ]));
+			}
+
+			for (let j = 0; j < selNative.options.length; j++) {
+				if (selNative.options[j].value === keep) {
+					selNative.value = keep;
+					break;
+				}
+			}
+		}
+
+		function refreshTaggedMetaButton(menuUl) {
+			const btn = menuUl.querySelector('.ck-dd-tag-bulk');
+
+			if (!btn)
+				return;
+
+			const inputs = menuUl.querySelectorAll('input[type=checkbox][data-vlan]');
+
+			if (!inputs.length) {
+				btn.textContent = _('Select all');
+				btn.setAttribute('title', _('No VLANs in catalogue'));
+				btn.disabled = true;
+				return;
+			}
+
+			btn.disabled = false;
+
+			let all = true;
+			inputs.forEach(function(inp) {
+				if (!inp.checked) all = false;
+			});
+
+			if (all) {
+				btn.textContent = _('De-select all');
+				btn.setAttribute('title', _('De-Select all VLAN tags'));
+			}
+			else {
+				btn.textContent = _('Select all');
+				btn.setAttribute('title', _('Select all VLAN tags'));
+			}
+		}
+
+		function fillMenuUl(ul) {
+			const vlm = scLbl.getVlanLabelMap();
+
+			ul.innerHTML = '';
+
+			const metaLi = E('li', { 'class': 'ck-dd-meta' });
+			metaLi.appendChild(E('button', { 'type': 'button', 'class': 'ck-dd-tag-bulk' }));
+			ul.appendChild(metaLi);
+
+			for (let i = 0; i < ctx.bridgeVlans.length; i++) {
+				const v  = ctx.bridgeVlans[i];
+				const cb = E('input', { 'type': 'checkbox', 'data-vlan': String(v) });
+				const txt = vlm[String(v)]
+					? (' VLAN ' + v + ' — ' + vlm[String(v)])
+					: (' VLAN ' + v);
+
+				ul.appendChild(E('li', {}, [
+					E('label', { 'class': 'ck-dd-vlan' }, [
+						cb,
+						document.createTextNode(txt)
+					])
+				]));
+			}
+		}
+
+		function ddLabelCounts() {
+			const tc = document.querySelectorAll('.switchconfig-pc #scp-menu-tagged input[data-vlan]:checked').length;
+			lblTagged.textContent = tc
+				? _('Tagged VLANs (%d selected)').format(tc)
+				: _('Tagged VLANs (multi-select…)');
+		}
+
+		function resyncDdListeners() {
+			fillMenuUl(menuTagged);
+			refreshTaggedMetaButton(menuTagged);
+
+			const bulk = menuTagged.querySelector('.ck-dd-tag-bulk');
+
+			if (bulk) {
+				bulk.addEventListener('click', function(ev) {
+					ev.preventDefault();
+					ev.stopPropagation();
+
+					if (bulk.disabled)
+						return;
+
+					const inputs = menuTagged.querySelectorAll('input[type=checkbox][data-vlan]');
+
+					if (!inputs.length)
+						return;
+
+					let all = true;
+					inputs.forEach(function(inp) {
+						if (!inp.checked) all = false;
+					});
+					inputs.forEach(function(inp) {
+						inp.checked = !all;
+					});
+
+					refreshTaggedMetaButton(menuTagged);
+					ddLabelCounts();
+					previewLine();
+				});
+			}
+
+			menuTagged.querySelectorAll('input[data-vlan]').forEach(function(inp) {
+				inp.addEventListener('change', function() {
+					refreshTaggedMetaButton(menuTagged);
+					ddLabelCounts();
+					previewLine();
+				});
+			});
+
+			ddLabelCounts();
+		}
+
+		function selectedTiles() {
+			const out = [];
+			document.querySelectorAll('.switchconfig-pc .pc-chip.selected').forEach(function(n) {
+				out.push(n.dataset.port);
+			});
+			return out;
+		}
+
+		function vidsTagged() {
+			const o = [];
+			document.querySelectorAll('.switchconfig-pc #scp-menu-tagged input[data-vlan]:checked').forEach(function(c) {
+				o.push(+c.dataset.vlan);
+			});
+			return o.sort(function(a, b) { return a - b; });
+		}
+
+		function previewLine() {
+			const hv = selectedTiles();
+
+			selCount.textContent = String(hv.length);
+
+			const tags = vidsTagged();
+			const lines = [
+				_('Selected: %s').format(hv.join(', ')),
+				_('Native: %s').format(selNative.value ? _('VLAN %s').format(String(selNative.value)) : _('(none)')),
+				_('Tagged: %s').format(tags.length ? tags.join(', ') : _('(none)'))
+			];
+
+			preview.textContent = lines.join('\n');
+		}
+
+		function clearTaggedMenu() {
+			document.querySelectorAll('.switchconfig-pc #scp-menu-tagged input[data-vlan]').forEach(function(c) {
+				c.checked = false;
+			});
+			refreshTaggedMetaButton(menuTagged);
+			ddLabelCounts();
+		}
+
+		/* ---- VLAN catalogue table --------------------------------------- */
+
+		function renderVlanMaintTable() {
+			vlanTbody.innerHTML = '';
+
+			const vlm = scLbl.getVlanLabelMap();
+
+			for (let i = 0; i < ctx.bridgeVlans.length; i++) {
+				const vid  = ctx.bridgeVlans[i];
+				const vInp = E('input', {
+					'type': 'text',
+					'class': 'cbi-input-text scp-vlan-label',
+					'placeholder': _('Note'),
+					'value': vlm[String(vid)] || '',
+					'title': _('Stored in /etc/config/luci only; not applied to bridge VLAN settings.')
+				});
+
+				vInp.addEventListener('change', function() {
+					scLbl.setVlanLabel(vid, vInp.value).catch(function(e) {
+						ui.addNotification(null, E('p', [ e ]));
+					});
+					refillNativeSelect();
+					resyncDdListeners();
+				});
+
+				const rm = E('button', {
+					'type': 'button',
+					'class': 'cbi-button cbi-button-remove',
+					'data-remove-vid': String(vid),
+					'title': _('Remove VLAN %d from bridge and all ports').format(vid)
+				}, [ _('Remove') ]);
+
+				vlanTbody.appendChild(E('tr', { 'class': 'tr' }, [
+					E('td', { 'class': 'td' }, [ String(vid) ]),
+					E('td', { 'class': 'td' }, [ vInp ]),
+					E('td', { 'class': 'td' }, [ rm ])
+				]));
+			}
+		}
+
+		function updateVlanCatalogueUi() {
+			scLbl.pruneSwitchconfigLabels(
+				ctx.ports.map(function(p) { return p.id; }),
+				ctx.bridgeVlans
+			);
+
+			uci.save().catch(function() {});
+
+			if (ctx.bridgeVlans.length)
+				vlanCatalog.textContent = _('Configured VLAN IDs (%d): %s').format(
+					ctx.bridgeVlans.length,
+					ctx.bridgeVlans.slice().sort(function(a, b) { return a - b; }).join(', ')
+				);
+			else
+				vlanCatalog.textContent = _('No VLANs configured — add at least one ID above.');
+
+			renderVlanMaintTable();
+			refillNativeSelect();
+			resyncDdListeners();
+			previewLine();
+		}
+
+		/* ---- VLAN add / remove ------------------------------------------ */
+
+		function addBridgeVlan(vid, optLabelNote) {
+			if (ctx.bridgeVlans.indexOf(vid) !== -1) {
+				ui.addNotification(null, E('p', _('VLAN %d is already configured.').format(vid)));
+				return false;
+			}
+
+			ctx.bridgeVlans.push(vid);
+			ctx.bridgeVlans.sort(function(a, b) { return a - b; });
+			ctx.localByVid[String(vid)] = '1';
+
+			const t = String(optLabelNote || '').trim();
+
+			if (t)
+				scLbl.setVlanLabel(vid, t)
+					.then(updateVlanCatalogueUi)
+					.catch(function(e) {
+						ui.addNotification(null, E('p', [ e ]));
+						updateVlanCatalogueUi();
+					});
+			else
+				updateVlanCatalogueUi();
+
+			return true;
+		}
+
+		function removeBridgeVlan(vid) {
+			const ix = ctx.bridgeVlans.indexOf(vid);
+
+			if (ix === -1)
+				return;
+
+			ctx.bridgeVlans.splice(ix, 1);
+			delete ctx.localByVid[String(vid)];
+			stripVidFromAllPorts(vid);
+			updateVlanCatalogueUi();
+		}
+
+		/* ---- save / reset ----------------------------------------------- */
+
+		function gatherLabelDraftSpecs() {
+			const portSpecs = [];
+
+			for (let pi = 0; pi < ctx.ports.length; pi++) {
+				const p = ctx.ports[pi];
+
+				if (p._portLabelInp)
+					portSpecs.push({ port: p.id, label: p._portLabelInp.value });
+			}
+
+			const vlanSpecs = [];
+
+			vlanTbody.querySelectorAll('tr').forEach(function(tr) {
+				const tds = tr.querySelectorAll('td');
+
+				if (tds.length < 2)
+					return;
+
+				const vidTxt = String(tds[0].textContent || '').trim();
+				const inp = tds[1].querySelector('input.scp-vlan-label');
+
+				if (!/^[1-9][0-9]*$/.test(vidTxt) || !inp)
+					return;
+
+				vlanSpecs.push({ vlan: vidTxt, label: inp.value });
+			});
+
+			return { portSpecs: portSpecs, vlanSpecs: vlanSpecs };
+		}
+
+		function commitToPorts(applyAfterSave) {
+			const drafts = gatherLabelDraftSpecs();
+
+			scLbl.syncAllDraftLabels(drafts.portSpecs, drafts.vlanSpecs).then(function() {
+				const hv = selectedTiles();
+
+				if (!hv.length) {
+					scLbl.pruneSwitchconfigLabels(
+						ctx.ports.map(function(p) { return p.id; }),
+						ctx.bridgeVlans
+					);
+
+					return uci.save().then(function() {
+						ui.addNotification(null, E('p', _('LuCI annotations saved (port and VLAN labels).')));
+
+						if (applyAfterSave)
+							ui.changes.apply(false);
+					});
+				}
+
+				const tagStr = vidsTagged().map(String).join(' ');
+
+				for (let i = 0; i < hv.length; i++) {
+					const rec = ctx.ports.filter(function(p) { return p.id === hv[i]; })[0];
+
+					if (!rec)
+						continue;
+
+					rec.native = selNative.value || '';
+					rec.tagged = tagStr;
+					refreshPortTile(rec);
+				}
+
+				clearTaggedMenu();
+				flushBridgeVlanUci(bridge, ctx);
+
+				return uci.save().then(function() {
+					scLbl.pruneSwitchconfigLabels(
+						ctx.ports.map(function(p) { return p.id; }),
+						ctx.bridgeVlans
+					);
+
+					return uci.save();
+				}).then(function() {
+					ui.addNotification(null, E('p', _('Network configuration saved.')));
+
+					if (applyAfterSave)
+						ui.changes.apply(false);
+				});
+			}).catch(function(err) {
+				ui.addNotification(null, E('p', [ err ]));
+			});
+
+			previewLine();
+		}
+
+		function resetAll() {
+			ctx.bridgeVlans = initial.bridgeVlans.slice();
+			ctx.localByVid  = Object.assign({}, initial.localByVid);
+
+			for (let i = 0; i < initial.ports.length; i++) {
+				const src = initial.ports[i];
+				const p   = ctx.ports[i];
+
+				p.native = src.native;
+				p.tagged = src.tagged;
+				refreshPortTile(p);
+			}
+
+			selNative.value = '';
+			clearTaggedMenu();
+
+			document.querySelectorAll('.switchconfig-pc .pc-chip.selected').forEach(function(z) {
+				z.classList.remove('selected');
+			});
+
+			/* Flush UCI so the model matches the reset state */
+			flushBridgeVlanUci(bridge, ctx);
+
+			updateVlanCatalogueUi();
+
+			const pm = scLbl.getPortLabelMap();
+
+			for (let ri = 0; ri < ctx.ports.length; ri++) {
+				const pr = ctx.ports[ri];
+
+				if (pr._portLabelInp)
+					pr._portLabelInp.value = pm[pr.id] || '';
+			}
+		}
+
+		/* ---- event: VLAN table remove button ---------------------------- */
+
+		vlanTbody.addEventListener('click', function(ev) {
+			const b = ev.target && ev.target.closest
+				? ev.target.closest('button[data-remove-vid]')
+				: null;
+
+			if (!b)
+				return;
+
+			ev.preventDefault();
+			removeBridgeVlan(+b.getAttribute('data-remove-vid'));
+		});
+
+		/* ---- build port chips ------------------------------------------- */
+
+		for (let i = 0; i < ctx.ports.length; i++) {
+			const pc = ctx.ports[i];
+			const el = E('div', {
+				'class': 'pc-chip',
+				'data-port': pc.id,
+				'click': function(ev) {
+					ev.preventDefault();
+					el.classList.toggle('selected');
+					previewLine();
+				}
+			});
+
+			const nt    = E('div',   { 'class': 'pc-name' }, [ pc.id ]);
+			const plInp = E('input', {
+				'type': 'text',
+				'class': 'pc-port-label',
+				'placeholder': _('Label'),
+				'value': portLabelMap[pc.id] || '',
+				'title': _('Optional note stored in /etc/config/luci (not applied to bridge VLAN settings).')
+			});
+
+			plInp.addEventListener('click',    function(ev) { ev.stopPropagation(); });
+			plInp.addEventListener('mousedown', function(ev) { ev.stopPropagation(); });
+			plInp.addEventListener('keydown',   function(ev) { ev.stopPropagation(); });
+			plInp.addEventListener('change', function() {
+				scLbl.setPortLabel(pc.id, plInp.value).catch(function(e) {
+					ui.addNotification(null, E('p', [ e ]));
+				});
+			});
+
+			pc._portLabelInp = plInp;
+
+			const lk = E('span', { 'class': 'pc-link' });
+			const sx = E('div',  { 'class': 'pc-sum' });
+
+			pc._link = lk;
+			pc._sx   = sx;
+
+			el.append(nt, plInp, lk, sx);
+			portFarm.appendChild(el);
+			refreshPortTile(pc);
+		}
+
+		/* ---- global click: close open dropdowns ------------------------- */
+
+		selNative.addEventListener('change', previewLine);
+
+		/* Use capturing on document to avoid stacking listeners on re-render */
+		const closeDropdowns = function() {
+			document.querySelectorAll('.switchconfig-pc [data-dd].open').forEach(function(x) {
+				x.classList.remove('open');
+			});
+		};
+
+		document.addEventListener('click', closeDropdowns);
+
+		/* ---- VLAN add controls ------------------------------------------ */
+
+		const vlanAddInput = E('input', {
+			'type': 'number',
+			'id': 'scp-vlan-add',
+			'min': 1,
+			'max': 4094,
+			'step': 1
+		});
+
+		const vlanAddLabelInput = E('input', {
+			'type': 'text',
+			'class': 'cbi-input-text scp-vlan-add-label',
+			'id': 'scp-vlan-add-label',
+			'placeholder': _('Label (optional)'),
+			'title': _('Optional note in /etc/config/luci, same as the catalogue table column.')
+		});
+
+		function submitNewVlan(ev) {
+			if (ev && ev.preventDefault)
+				ev.preventDefault();
+
+			const v = +vlanAddInput.value;
+
+			if (!(v >= 1 && v <= 4094)) {
+				ui.addNotification(null, E('p', _('Enter a VLAN ID between 1 and 4094.')));
+				vlanAddInput.focus();
+				return;
+			}
+
+			if (addBridgeVlan(v, vlanAddLabelInput.value)) {
+				vlanAddInput.value      = '';
+				vlanAddLabelInput.value = '';
+				vlanAddInput.focus();
+			}
+		}
+
+		function vlanAddKey(ev) {
+			if (ev.key === 'Enter') {
+				ev.preventDefault();
+				submitNewVlan(ev);
+			}
+		}
+
+		vlanAddInput.addEventListener('keydown', vlanAddKey);
+		vlanAddLabelInput.addEventListener('keydown', vlanAddKey);
+
+		const btnAddVlan = E('button', {
+			'type': 'button',
+			'class': 'cbi-button cbi-button-add',
+			'id': 'scp-vlan-add-btn',
+			'click': submitNewVlan
+		}, [ _('Add') ]);
+
+		/* ---- assemble the view ------------------------------------------ */
+
+		const root = E('div', { 'class': 'switchconfig-pc' }, [
+			E('h2', { 'name': 'content' }, [ _('Switch config') ]),
+			E('div', { 'class': 'cbi-map-descr' }, [
+				E('p', {}, [
+					_('Port-centric VLAN management for bridge "%h".').format(bridge)
+				]),
+				E('p', { 'class': 'cbi-section-descr' }, [
+					_('Optional port and VLAN labels.')
+				])
+			]),
+			E('fieldset', { 'class': 'cbi-section' }, [
+				E('legend', {}, [ _('Port membership(s)') ]),
+				portFarm
+			]),
+			E('fieldset', { 'class': 'cbi-section vlan-maint-section' }, [
+				E('legend', {}, [ _('VLANs') ]),
+				E('p', { 'class': 'cbi-section-descr' }, [
+					_('Add or remove VLAN IDs. Removing a VLAN strips it from all ports. Use the dock below to assign native (untagged) and tagged memberships.')
+				]),
+				vlanCatalog,
+				E('div', { 'class': 'cbi-value vlan-maint-add' }, [
+					E('span', { 'class': 'cbi-value-title' }, [ _('Add VLAN ID') ]),
+					E('div',  { 'class': 'cbi-value-field' }, [ vlanAddInput, vlanAddLabelInput, btnAddVlan ])
+				]),
+				E('table', { 'class': 'table', 'id': 'scp-vlan-table' }, [
+					E('thead', {}, [ E('tr', {}, [
+						E('th', { 'class': 'th' }, [ _('VLAN ID') ]),
+						E('th', { 'class': 'th' }, [ _('Label (note)') ]),
+						E('th', { 'class': 'th' }, [ ' ' ])
+					]) ]),
+					vlanTbody
+				])
+			]),
+			E('div', { 'class': 'assign-dock' }, [
+				E('div', { 'class': 'container' }, [
+					E('fieldset', { 'class': 'cbi-section' }, [
+						E('p', { 'class': 'cbi-section-descr' }, [
+							_('Selected: '), selCount, ' ', _('port(s)')
+						]),
+						E('div', { 'class': 'cbi-value' }, [
+							E('span', { 'class': 'cbi-value-title', 'id': 'scp-dock-title-native' }, [ _('Untagged / native VLAN') ]),
+							E('div',  { 'class': 'cbi-value-field' }, [
+								E('span', { 'class': 'cbi-select' }, [ selNative ])
+							])
+						]),
+						E('div', { 'class': 'cbi-value' }, [
+							E('span', { 'class': 'cbi-value-title', 'id': 'scp-dock-title-tagged' }, [ _('Tagged VLANs') ]),
+							E('div',  { 'class': 'cbi-value-field' }, [ ddWrap ])
+						]),
+						E('div', { 'class': 'assign-dock-tools' }, [
+							E('button', {
+								'type': 'button',
+								'class': 'cbi-button',
+								'id': 'scp-btn-strip',
+								'title': _('Clear native VLAN and all tagged VLANs on selected ports. Choose Save or Save & Apply to write UCI.'),
+								'click': function(ev) {
+									ev.preventDefault();
+
+									const sel = selectedTiles();
+
+									if (!sel.length) {
+										ui.addNotification(null, E('p', _('Select at least one port first.')));
+										return;
+									}
+
+									for (let i = 0; i < sel.length; i++) {
+										const rec = ctx.ports.filter(function(p) { return p.id === sel[i]; })[0];
+
+										if (!rec)
+											continue;
+
+										rec.native = '';
+										rec.tagged = '';
+										refreshPortTile(rec);
+									}
+
+									selNative.value = '';
+									clearTaggedMenu();
+									previewLine();
+								}
+							}, [ _('Strip all VLAN memberships from selected ports') ]),
+							E('button', {
+								'type': 'button',
+								'class': 'cbi-button',
+								'id': 'scp-btn-clear-sel',
+								'click': function(ev) {
+									ev.preventDefault();
+									document.querySelectorAll('.switchconfig-pc .pc-chip.selected').forEach(function(z) {
+										z.classList.remove('selected');
+									});
+									previewLine();
+								}
+							}, [ _('Clear port selection') ])
+						]),
+						preview
+					]),
+					E('div', { 'class': 'cbi-page-actions' }, [
+						E('button', {
+							'type': 'button',
+							'class': 'cbi-button cbi-button-apply important',
+							'id': 'scp-save-apply',
+							'click': function(ev) {
+								ev.preventDefault();
+								commitToPorts(true);
+							}
+						}, [ _('Save & Apply') ]),
+						E('button', {
+							'type': 'button',
+							'class': 'cbi-button cbi-button-save',
+							'id': 'scp-save',
+							'click': function(ev) {
+								ev.preventDefault();
+								commitToPorts(false);
+							}
+						}, [ _('Save') ]),
+						E('button', {
+							'type': 'button',
+							'class': 'cbi-button cbi-button-reset',
+							'id': 'scp-reset',
+							'click': function(ev) {
+								ev.preventDefault();
+								resetAll();
+							}
+						}, [ _('Reset') ])
+					])
+				])
+			])
+		]);
+
+		updateVlanCatalogueUi();
+
+		window.requestAnimationFrame(function() {
+			for (let i = 0; i < ctx.ports.length; i++) {
+				const p = ctx.ports[i];
+
+				if (ndm[p.id])
+					refreshPortTile(p);
+			}
+		});
+
+		return root;
+	}
+});

--- a/modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json
@@ -46,6 +46,23 @@
 		}
 	},
 
+	"admin/network/switchconfig": {
+		"title": "Switch/VLAN config",
+		"order": 16,
+		"action": {
+			"type": "view",
+			"path": "network/switchconfig"
+		},
+		"depends": {
+			"acl": [ "luci-mod-network-config" ],
+			"uci": {
+				"network": {
+					"@device": { "type": "bridge" }
+				}
+			}
+		}
+	},
+
 	"admin/network/routes": {
 		"title": "Routing",
 		"order": 30,

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -16,7 +16,7 @@
 				"iwinfo": [ "assoclist", "countrylist", "freqlist", "txpowerlist" ],
 				"luci": [ "getSwconfigFeatures", "getSwconfigPortState" ]
 			},
-			"uci": [ "dhcp", "firewall", "network", "wireless", "system" ]
+			"uci": [ "dhcp", "firewall", "luci", "network", "wireless", "system" ]
 		},
 		"write": {
 			"cgi-io": [ "exec" ],
@@ -30,7 +30,7 @@
 				"hostapd.*": [ "del_client" ],
 				"iwinfo": [ "scan" ]
 			},
-			"uci": [ "dhcp", "firewall", "network", "wireless" ]
+			"uci": [ "dhcp", "firewall", "luci", "network", "wireless" ]
 		}
 	},
 


### PR DESCRIPTION
Seeing OpenWrt supporting more and more dedicated switches with more than just a handful of ports, the current interface for configuring and maintaining ports and VLANs becomes cumbersome to use, especially with frequent changes.

Current (personal) pain points are:
 - To reach the current switch/VLAN config page, one has to click through: `Network` -> `Interfaces` -> `Devices` -> `Configure... (the respective switch/bridge)` -> `Bridge VLAN filtering` which - at least for dedicated switches - is not sth. what I feel comfortable having to do every time I want to make a change 
 - While ~5 ports might still fit next to each other, starting with 2 figure numbers, we end up scrolling horizontally. Finding the port to configure on a 24 or 48 port switch will result in plenty of horizontal scrolling, while at the same time you have to memorise which row maps to which VLAN-ID, as those scroll out the moment you scroll right 
 - Every port needs to be configured by its own, no way to bulk-conf them, apply the same VLAN config onto multiple ports (e.g. applying the same tag onto a large number or all ports)
 - Ports and VLAN-IDs are defined by sole numbers. There's no way to annotate them, e.g. a VLAN ID as "iot" or "mgmt", or a port as e.g. "uplink" or "server-mirko".


## Pull request details

### Disclaimer
**Large parts of the code involved in this PR were created/generated with the help of LLMs. It was not properly reviewed and I don't expect anyone to do so with potential AI-slop thrown at.

This PR is merely a starting point for a discussion on how to address some of the pain points and provide a mockup -- or prototype at best -- showing how I can imagine seeing those issues being tackled.
**

### Description
The disclaimer above being stated: This PR provides a functional prototype for how I personally think the/my in the beginning stated pain points could be addressed by the following changes / additions:

 - Adding a dedicated "Switch/VLAN config" entry within the toplevel "Network"-dropdown (you might remember we already had such for swconfig back then, before it got obsoleted by DSA and configuration via vlan aware bridges)
 - Avoiding horizontal scrolling by showing switch ports in multiple rows if not fitting screen width
 - Allowing selection of multiple ports to configure them all the same way at once (includes easily removing all memberships from all selected ports with just one click)
 - Introducing labels for ports and VLANs -- they're optional annotations and don't serve any functional purpose except hinting the user, stored in respective sections within /etc/config/luci 

### Screenshot or video of changes
<img width="1042" height="1358" alt="owrt-luci-swcfg_2" src="https://github.com/user-attachments/assets/a7722c2d-9550-4ff5-a9e0-eac4da27ab3e" />