### PR TITLE
Alternative view for configuring switch ports and VLANs

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/bridgevlan.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/bridgevlan.js
@@ -1,0 +1,494 @@
+/* Helper module for the bridge-vlan UCI model.
+ *
+ * Provides the read side (find/parse/enumerate bridge-vlan sections and their
+ * port specs) and the write side (anti-stacking port-list writer plus an
+ * out-of-band store for user-defined port/VLAN labels in /etc/config/luci).
+ *
+ * Used by the Switch/VLAN view (view/network/switch-vlan.js); kept separate
+ * from the view so the UCI/port-spec primitives are reusable. */
+
+'use strict';
+'require uci';
+'require network';
+'require baseclass';
+
+const MIN_VLAN_ID = 1;
+const MAX_VLAN_ID = 4094;
+
+const LUCI_LABEL_SECTION_TYPE = 'switchvlan';
+const LUCI_PORT_LABELS_NAME = 'port_labels';
+const LUCI_VLAN_LABELS_NAME = 'vlan_labels';
+
+/* netifd defaults a bridge-vlan's "local" flag to true when the option is
+ * absent (see config_init_vlan_entry() in netifd's config.c), so an unset
+ * value must be read as local, not the other way around. Parse the UCI value
+ * as a proper boolean and treat absence as true. */
+function parseLocal(value) {
+	if (value == null || value === '')
+		return true;
+
+	switch (String(value).toLowerCase()) {
+	case '0':
+	case 'false':
+	case 'no':
+	case 'off':
+	case 'disabled':
+		return false;
+	default:
+		return true;
+	}
+}
+
+/* =============================================================================
+ * Port spec parsing & formatting
+ * ============================================================================= */
+
+function parsePortSpec(spec) {
+	const m = String(spec).match(/^([^:]+)(?::([ut*]*))?$/);
+
+	if (!m)
+		return null;
+
+	const flags = m[2] || '';
+
+	return {
+		port: m[1],
+		tagged: /t/.test(flags),
+		untagged: /u/.test(flags) || flags === '',
+		pvid: /\x2a/.test(flags) || flags === ''
+	};
+}
+
+function formatPortSpec(port, role) {
+	if (role === 'untagged' || role === 'native')
+		return port;
+
+	if (role === 'tagged')
+		return '%s:t'.format(port);
+
+	return null;
+}
+
+/* =============================================================================
+ * Bridge selection & enumeration
+ * ============================================================================= */
+
+function getBridgeDeviceName(deviceSection) {
+	if (!deviceSection)
+		return null;
+
+	return deviceSection.name || deviceSection['.name'] || null;
+}
+
+/* uci.get is mandatory here: the .ports field on a uci.sections() callback
+ * argument is a snapshot and goes stale after uci.set/unset on this option. */
+function getVlanSectionPorts(sectionId) {
+	return L.toArray(uci.get('network', sectionId, 'ports'));
+}
+
+function isVlanFilteringEnabled(deviceSection) {
+	if (!deviceSection)
+		return false;
+
+	if (deviceSection.type !== 'bridge')
+		return false;
+
+	if (deviceSection.vlan_filtering === '1')
+		return true;
+
+	const devname = getBridgeDeviceName(deviceSection);
+	let has_vlans = false;
+
+	uci.sections('network', 'bridge-vlan', function(bvs) {
+		if (bvs.device == devname)
+			has_vlans = true;
+	});
+
+	return has_vlans;
+}
+
+/* A bridge qualifies only when every member resolves to a physical
+ * ethernet/DSA port. Bridges spanning wifi APs, tunnels, wireguard, VLAN
+ * sub-interfaces or nested bridges are excluded on purpose — they're legal
+ * vlan-aware bridges but the T/U-on-physical-ports UI doesn't apply. */
+function findActiveBridge() {
+	let match = null;
+
+	uci.sections('network', 'device', s => {
+		if (match || !isVlanFilteringEnabled(s))
+			return;
+
+		const ports = collectBridgePorts(s);
+
+		if (!ports.length)
+			return;
+
+		const allSwitchworthy = ports.every(p => {
+			const t = network.instantiateDevice(p).getType();
+			return t === 'switch' || t === 'ethernet';
+		});
+
+		if (allSwitchworthy)
+			match = s;
+	});
+
+	return match;
+}
+
+function collectBridgePorts(deviceSection) {
+	const seen = {};
+	const devname = getBridgeDeviceName(deviceSection);
+	const section_id = deviceSection ? deviceSection['.name'] : null;
+
+	if (!deviceSection)
+		return [];
+
+	L.toArray(uci.get('network', section_id, 'ports')).forEach(function(port) {
+		seen[port] = true;
+	});
+
+	if (devname) {
+		const br = network.instantiateDevice(devname);
+		const brports = (br && typeof br.getPorts === 'function') ? br.getPorts() : null;
+
+		if (brports) {
+			brports.forEach(function(portdev) {
+				const name = portdev ? portdev.getName() : null;
+
+				if (name)
+					seen[name] = true;
+			});
+		}
+
+		uci.sections('network', 'bridge-vlan', function(bvs) {
+			if (bvs.device != devname)
+				return;
+
+			getVlanSectionPorts(bvs['.name']).forEach(function(spec) {
+				const m = String(spec).match(/^([^:]+)(?::[ut*]+)?$/);
+
+				if (m)
+					seen[m[1]] = true;
+			});
+		});
+	}
+
+	return Object.keys(seen).sort(L.naturalCompare);
+}
+
+function collectBridgeVlans(deviceSection) {
+	const out = [];
+
+	if (!deviceSection)
+		return out;
+
+	uci.sections('network', 'bridge-vlan', function(bvs) {
+		if (bvs.device != getBridgeDeviceName(deviceSection))
+			return;
+
+		const vid = +bvs.vlan;
+
+		if (!(vid >= MIN_VLAN_ID && vid <= MAX_VLAN_ID))
+			return;
+
+		out.push({
+			section_id: bvs['.name'],
+			vlan: vid,
+			local: parseLocal(bvs.local),
+			ports: getVlanSectionPorts(bvs['.name']).slice()
+		});
+	});
+
+	out.sort(function(a, b) { return a.vlan - b.vlan; });
+
+	return out;
+}
+
+/* =============================================================================
+ * VLAN configuration validation
+ * ============================================================================= */
+
+function checkUnsupportedConfig(deviceSection) {
+	const issues = [];
+
+	if (!deviceSection)
+		return issues;
+
+	const portUntagged = {};
+
+	uci.sections('network', 'bridge-vlan', function(bvs) {
+		if (bvs.device != getBridgeDeviceName(deviceSection))
+			return;
+
+		const vid = +bvs.vlan;
+
+		if (!(vid >= MIN_VLAN_ID && vid <= MAX_VLAN_ID)) {
+			issues.push(_('VLAN ID %s is outside the valid range %d–%d.').format(
+				bvs.vlan, MIN_VLAN_ID, MAX_VLAN_ID));
+			return;
+		}
+
+		getVlanSectionPorts(bvs['.name']).forEach(function(spec) {
+			const parsed = parsePortSpec(spec);
+
+			if (!parsed) {
+				issues.push(_('Port specification "%s" on VLAN %d cannot be parsed.').format(spec, vid));
+				return;
+			}
+
+			/* Order matters: a spec carrying both the tagged and PVID flags
+			 * (e.g. "lan1:t*") is reported as the PVID-with-tagged-egress
+			 * case, not the tagged-and-untagged one. */
+			if (parsed.tagged && parsed.pvid)
+				issues.push(_('Port "%s" has the primary VLAN flag together with tagged egress on VLAN %d (PVID ≠ untagged VLAN).').format(parsed.port, vid));
+			else if (parsed.tagged && parsed.untagged)
+				issues.push(_('Port "%s" is both tagged and untagged on VLAN %d.').format(parsed.port, vid));
+			else if (parsed.pvid && !parsed.tagged && !parsed.untagged)
+				issues.push(_('Port "%s" is the primary VLAN on VLAN %d but has no untagged egress (PVID ≠ untagged VLAN).').format(parsed.port, vid));
+
+			if (parsed.untagged) {
+				if (portUntagged[parsed.port] != null && portUntagged[parsed.port] !== vid) {
+					issues.push(_('Port "%s" is configured as untagged on more than one VLAN (%d and %d).').format(
+						parsed.port, portUntagged[parsed.port], vid));
+				}
+
+				portUntagged[parsed.port] = vid;
+			}
+		});
+	});
+
+	return issues;
+}
+
+/* =============================================================================
+ * Per-port state derivation (native + tagged VLANs for each member)
+ * ============================================================================= */
+
+function buildPortState(deviceSection, ports) {
+	const state = {};
+
+	ports.forEach(function(name) {
+		state[name] = { name: name, native: null, tagged: [] };
+	});
+
+	if (!deviceSection)
+		return state;
+
+	uci.sections('network', 'bridge-vlan', function(bvs) {
+		if (bvs.device != getBridgeDeviceName(deviceSection))
+			return;
+
+		const vid = +bvs.vlan;
+
+		getVlanSectionPorts(bvs['.name']).forEach(function(spec) {
+			const parsed = parsePortSpec(spec);
+
+			if (!parsed || !state[parsed.port])
+				return;
+
+			if (parsed.untagged)
+				state[parsed.port].native = vid;
+			else if (parsed.tagged)
+				state[parsed.port].tagged.push(vid);
+		});
+	});
+
+	for (let name in state)
+		state[name].tagged.sort(function(a, b) { return a - b; });
+
+	return state;
+}
+
+/* =============================================================================
+ * Port/VLAN label store (out-of-band, in /etc/config/luci)
+ * ============================================================================= */
+
+function labelOptionKey(name) {
+	return String(name).replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+function ensureLabelSections() {
+	let port_sid = null, vlan_sid = null;
+
+	uci.sections('luci', LUCI_LABEL_SECTION_TYPE, function(s) {
+		if (s['.name'] === LUCI_PORT_LABELS_NAME)
+			port_sid = s['.name'];
+		else if (s['.name'] === LUCI_VLAN_LABELS_NAME)
+			vlan_sid = s['.name'];
+	});
+
+	if (!port_sid)
+		port_sid = uci.add('luci', LUCI_LABEL_SECTION_TYPE, LUCI_PORT_LABELS_NAME);
+
+	if (!vlan_sid)
+		vlan_sid = uci.add('luci', LUCI_LABEL_SECTION_TYPE, LUCI_VLAN_LABELS_NAME);
+
+	return { port: port_sid, vlan: vlan_sid };
+}
+
+function readPortLabel(portName) {
+	const value = uci.get('luci', LUCI_PORT_LABELS_NAME, labelOptionKey(portName));
+	return value != null ? String(value) : '';
+}
+
+function readVlanLabel(vlanId) {
+	const value = uci.get('luci', LUCI_VLAN_LABELS_NAME, labelOptionKey(vlanId));
+	return value != null ? String(value) : '';
+}
+
+function writePortLabel(portName, label) {
+	ensureLabelSections();
+
+	const key = labelOptionKey(portName);
+
+	if (label == null || label === '')
+		uci.unset('luci', LUCI_PORT_LABELS_NAME, key);
+	else
+		uci.set('luci', LUCI_PORT_LABELS_NAME, key, label);
+}
+
+function writeVlanLabel(vlanId, label) {
+	ensureLabelSections();
+
+	const key = labelOptionKey(vlanId);
+
+	if (label == null || label === '')
+		uci.unset('luci', LUCI_VLAN_LABELS_NAME, key);
+	else
+		uci.set('luci', LUCI_VLAN_LABELS_NAME, key, label);
+}
+
+/* =============================================================================
+ * Bridge-vlan ports writer (anti-stacking; bypasses LuCI's missing
+ * "undo pending change" API by poking uci.state directly)
+ * ============================================================================= */
+
+function vlanPortsEqual(a, b) {
+	const norm = list => L.toArray(list).slice().sort(L.naturalCompare);
+	const sa = norm(a);
+	const sb = norm(b);
+	return sa.length === sb.length && sa.every((v, i) => v === sb[i]);
+}
+
+function getBaseVlanPorts(section_id) {
+	if (uci.state.creates.network?.[section_id])
+		return L.toArray(uci.state.creates.network[section_id].ports);
+	return L.toArray(uci.state.values.network?.[section_id]?.ports);
+}
+
+function clearPendingVlanPorts(section_id) {
+	const c = uci.state.changes.network;
+	const d = uci.state.deletes.network;
+
+	if (c?.[section_id]) {
+		delete c[section_id].ports;
+		if (!Object.keys(c[section_id]).length)
+			delete c[section_id];
+	}
+
+	if (c && !Object.keys(c).length)
+		delete uci.state.changes.network;
+
+	if (d?.[section_id] && d[section_id] !== true) {
+		delete d[section_id].ports;
+		if (!Object.keys(d[section_id]).length)
+			delete d[section_id];
+	}
+
+	if (d && !Object.keys(d).length)
+		delete uci.state.deletes.network;
+}
+
+/* Anti-stacking writer for bridge-vlan ports. Two non-obvious behaviours:
+ *  1. If the new list equals the loaded baseline, the local pending change
+ *     is *cleared* (poking uci.state directly via clearPendingVlanPorts —
+ *     LuCI's uci module has no public "undo a pending change" API). Without
+ *     this, toggling T then T leaves a phantom entry in "Unsaved Changes".
+ *  2. An empty list calls uci.unset, not uci.set([]); OpenWrt UCI rejects
+ *     empty list values on set. */
+function setBridgeVlanPorts(section_id, ports) {
+	const normalized = L.toArray(ports).slice().sort(L.naturalCompare);
+	const base = getBaseVlanPorts(section_id);
+
+	if (vlanPortsEqual(normalized, base)) {
+		if (uci.state.creates.network?.[section_id]) {
+			if (base.length)
+				uci.set('network', section_id, 'ports', base.slice().sort(L.naturalCompare));
+			else
+				uci.unset('network', section_id, 'ports');
+		}
+		else {
+			clearPendingVlanPorts(section_id);
+		}
+		return;
+	}
+
+	if (normalized.length)
+		uci.set('network', section_id, 'ports', normalized);
+	else
+		uci.unset('network', section_id, 'ports');
+}
+
+/* =============================================================================
+ * Label maintenance
+ * ============================================================================= */
+
+function pruneOrphanLabels(validPorts, validVlans) {
+	const portKeys = {}, vlanKeys = {};
+
+	validPorts.forEach(function(p) { portKeys[labelOptionKey(p)] = true; });
+	validVlans.forEach(function(v) { vlanKeys[labelOptionKey(v)] = true; });
+
+	const toRemove = [];
+
+	uci.sections('luci', LUCI_LABEL_SECTION_TYPE, function(s) {
+		const isPortSection = (s['.name'] === LUCI_PORT_LABELS_NAME);
+		const isVlanSection = (s['.name'] === LUCI_VLAN_LABELS_NAME);
+
+		if (!isPortSection && !isVlanSection)
+			return;
+
+		const keys = isPortSection ? portKeys : vlanKeys;
+
+		for (let opt in s) {
+			if (opt.charAt(0) === '.')
+				continue;
+
+			if (!keys[opt])
+				toRemove.push({ section: s['.name'], option: opt });
+		}
+	});
+
+	toRemove.forEach(function(entry) {
+		uci.unset('luci', entry.section, entry.option);
+	});
+
+	return toRemove.length;
+}
+
+return baseclass.extend({
+	MIN_VLAN_ID: MIN_VLAN_ID,
+	MAX_VLAN_ID: MAX_VLAN_ID,
+	LUCI_LABEL_SECTION_TYPE: LUCI_LABEL_SECTION_TYPE,
+	LUCI_PORT_LABELS_NAME: LUCI_PORT_LABELS_NAME,
+	LUCI_VLAN_LABELS_NAME: LUCI_VLAN_LABELS_NAME,
+
+	parsePortSpec: parsePortSpec,
+	formatPortSpec: formatPortSpec,
+	parseLocal: parseLocal,
+	isVlanFilteringEnabled: isVlanFilteringEnabled,
+	findActiveBridge: findActiveBridge,
+	collectBridgePorts: collectBridgePorts,
+	collectBridgeVlans: collectBridgeVlans,
+	checkUnsupportedConfig: checkUnsupportedConfig,
+	buildPortState: buildPortState,
+	labelOptionKey: labelOptionKey,
+	ensureLabelSections: ensureLabelSections,
+	readPortLabel: readPortLabel,
+	readVlanLabel: readVlanLabel,
+	writePortLabel: writePortLabel,
+	writeVlanLabel: writeVlanLabel,
+	pruneOrphanLabels: pruneOrphanLabels,
+	vlanPortsEqual: vlanPortsEqual,
+	setBridgeVlanPorts: setBridgeVlanPorts
+});

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch-vlan.css
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch-vlan.css
@@ -1,0 +1,583 @@
+/* Switch/VLAN configuration view */
+
+/* Conflict notifications via ui.addNotification (flex layout; theme zeros ul padding) */
+#maincontent > .alert-message .svc-vlan-conflict {
+	min-width: 0;
+	width: 100%;
+}
+
+#maincontent > .alert-message .svc-vlan-conflict > p {
+	margin: 0 0 0.35em;
+}
+
+#maincontent > .alert-message .svc-vlan-conflict-ports {
+	margin: 0.35em 0 0;
+	padding: 0;
+}
+
+#maincontent > .alert-message .svc-vlan-conflict-port {
+	margin: 0.15em 0 0;
+	padding: 0;
+}
+
+#maincontent > .alert-message .svc-vlan-conflict-port::before {
+	content: '•\00a0';
+}
+
+#maincontent > .alert-message .svc-vlan-conflict ul {
+	margin: 0.35em 0 0;
+	padding-left: 1.35em;
+	list-style-position: inside;
+}
+
+#switch-vlan-view {
+	--svc-port-selected-bg: #e8f4fc;
+	--svc-port-selected-border: #3c7aa8;
+	--svc-port-selected-ring: rgba(60, 141, 188, 0.28);
+	/* Teal + amber-orange: distinguishable from grey port text */
+	--svc-vlan-untagged: #0d9488;
+	--svc-vlan-tagged: #d97706;
+	--svc-vlan-untagged-bg: rgba(13, 148, 136, 0.12);
+	--svc-vlan-tagged-bg: rgba(217, 119, 6, 0.14);
+	--svc-vlan-untagged-stripe: rgba(13, 148, 136, 0.2);
+	--svc-vlan-tagged-stripe: rgba(217, 119, 6, 0.2);
+}
+
+:root[data-darkmode="true"] #switch-vlan-view {
+	--svc-port-selected-bg: rgba(126, 184, 232, 0.22);
+	--svc-port-selected-border: #b3d4f0;
+	--svc-port-selected-ring: rgba(126, 184, 232, 0.45);
+	--svc-vlan-untagged: #2dd4bf;
+	--svc-vlan-tagged: #fbbf24;
+	--svc-vlan-untagged-bg: rgba(45, 212, 191, 0.18);
+	--svc-vlan-tagged-bg: rgba(251, 191, 36, 0.2);
+	--svc-vlan-untagged-stripe: rgba(45, 212, 191, 0.32);
+	--svc-vlan-tagged-stripe: rgba(251, 191, 36, 0.36);
+}
+
+#switch-vlan-view .svc-block {
+	margin: 1em 0;
+}
+
+.svc-block-header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5em;
+	margin-bottom: 0.5em;
+}
+
+.svc-block-header h3 {
+	margin: 0;
+	font-size: 1.1em;
+}
+
+.svc-port-header-actions {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.4em;
+}
+
+#switch-vlan-view .cbi-section-descr {
+	margin-bottom: 1em;
+}
+
+.svc-empty {
+	margin: 0.5em 0;
+	color: #888;
+	font-style: italic;
+}
+
+/* Port tiles */
+.svc-ports {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(11em, 1fr));
+	gap: 0.5em;
+}
+
+.svc-port-tile {
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	padding: 0.5em 0.6em;
+	background: var(--background-color-medium, #fafafa);
+	color: var(--text-color-high, #000);
+	cursor: pointer;
+	user-select: none;
+	display: flex;
+	flex-direction: column;
+	gap: 0.35em;
+	transition: background 0.05s linear, border-color 0.05s linear, box-shadow 0.05s linear;
+	min-width: 0;
+}
+
+.svc-port-tile:hover {
+	border-color: #888;
+	background: var(--background-color-high, #f3f3f3);
+}
+
+.svc-port-tile.selected {
+	background: var(--svc-port-selected-bg);
+	border-width: 3px;
+	border-color: var(--svc-port-selected-border);
+	box-shadow: 0 0 0 2px var(--svc-port-selected-ring);
+}
+
+.svc-port-tile.selected:hover {
+	background: #dff0fb;
+	border-color: #336b95;
+}
+
+:root[data-darkmode="true"] #switch-vlan-view .svc-port-tile.selected:hover {
+	background: rgba(126, 184, 232, 0.3);
+}
+
+.svc-port-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.4em;
+}
+
+.svc-port-name {
+	font-family: monospace;
+	font-weight: bold;
+	font-size: 1.05em;
+}
+
+.svc-port-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3em;
+	font-size: 0.92em;
+	color: inherit;
+	white-space: nowrap;
+}
+
+.svc-port-dot {
+	display: inline-block;
+	width: 0.7em;
+	height: 0.7em;
+	border-radius: 50%;
+	background: #aaa;
+	flex: 0 0 auto;
+}
+
+.svc-port-link[data-state="up"] .svc-port-dot   { background: #1aaf5d; }
+.svc-port-link[data-state="down"] .svc-port-dot { background: #b0b0b0; }
+
+.svc-port-label {
+	width: 100%;
+	box-sizing: border-box;
+	font-size: 0.92em;
+	color: inherit;
+	padding: 2px 4px;
+	border: 1px solid #ddd;
+	border-radius: 2px;
+	background: var(--background-color-high, #fff);
+}
+
+.svc-port-label:focus {
+	border-color: #3c8dbc;
+	outline: none;
+}
+
+.svc-port-vlans {
+	display: flex;
+	flex-direction: column;
+	gap: 0.1em;
+	font-size: 0.9em;
+	min-height: 2.2em;
+}
+
+.svc-port-vlan {
+	font-family: monospace;
+	font-weight: bold;
+	color: inherit;
+	overflow-wrap: anywhere;
+}
+
+.svc-port-vlan:empty {
+	min-height: 1.1em;
+}
+
+.svc-port-tag-prefix {
+	margin-right: 0.25em;
+}
+
+#switch-vlan-view .svc-port-vlan.native .svc-port-tag-prefix {
+	font-weight: bold;
+	color: var(--svc-vlan-untagged);
+}
+
+#switch-vlan-view .svc-port-vlan.tagged .svc-port-tag-prefix {
+	font-weight: bold;
+	color: var(--svc-vlan-tagged);
+}
+
+/* Highlight ports when hovering a VLAN row (teal = untagged, amber = tagged) */
+.svc-port-tile.highlight-untagged {
+        border-color: var(--svc-vlan-untagged);
+        background:
+                repeating-linear-gradient(
+                        90deg,
+                        var(--svc-vlan-untagged-stripe) 0 24px,
+                        var(--svc-vlan-untagged-bg) 24px 48px
+                );
+}
+
+.svc-port-tile.highlight-tagged {
+        border-color: var(--svc-vlan-tagged);
+        background:
+                repeating-linear-gradient(
+                        180deg,
+                        var(--svc-vlan-tagged-stripe) 0 24px,
+                        var(--svc-vlan-tagged-bg) 24px 48px
+                );
+}
+
+/* VLAN list — table layout keeps column widths and dividers aligned */
+.svc-vlans {
+	display: table;
+	width: 100%;
+	border-collapse: separate;
+	border-spacing: 0 0.3em;
+	table-layout: auto;
+}
+
+.svc-vlan-header,
+.svc-vlan-row {
+	display: table-row;
+}
+
+.svc-vlan-header > .svc-vlan-cell,
+.svc-vlan-row > .svc-vlan-cell {
+	display: table-cell;
+	vertical-align: middle;
+	padding: 0.4em 0.5em;
+	box-sizing: border-box;
+}
+
+.svc-vlan-header > .svc-vlan-cell {
+	color: var(--text-color-low, #666);
+	font-size: 0.9em;
+	font-weight: normal;
+	white-space: nowrap;
+	padding-bottom: 0.35em;
+	border-bottom: 1px solid var(--border-color-low, #ddd);
+}
+
+.svc-vlan-header > .svc-vlan-cell:not(.svc-vlan-cell-id),
+.svc-vlan-row > .svc-vlan-cell:not(.svc-vlan-cell-id) {
+	text-align: center;
+}
+
+.svc-vlan-cell-id {
+	width: 6em;
+	white-space: nowrap;
+	padding-left: 0.6em;
+	padding-right: 0.5em;
+	text-align: right;
+}
+
+/* No width — extra space goes here (auto layout + narrow 1% siblings) */
+.svc-vlan-cell-label {
+	min-width: 10em;
+}
+
+.svc-vlan-cell-label,
+.svc-vlan-cell-local,
+.svc-vlan-cell-select,
+.svc-vlan-cell-assign,
+.svc-vlan-cell-action {
+	padding-left: 0.65em;
+	border-left: 1px solid var(--border-color-low, #ccc);
+}
+
+.svc-vlan-cell-local {
+	width: 1%;
+	white-space: nowrap;
+}
+
+.svc-vlan-cell-select,
+.svc-vlan-cell-assign,
+.svc-vlan-cell-action {
+	width: 1%;
+	white-space: nowrap;
+}
+
+.svc-vlan-cell-action {
+	padding-right: 0.75em;
+}
+
+.svc-vlan-row > .svc-vlan-cell-id {
+	border: 1px solid #ddd;
+	border-right: none;
+	border-radius: 4px 0 0 4px;
+	background: #fafafa;
+}
+
+.svc-vlan-row > .svc-vlan-cell-label,
+.svc-vlan-row > .svc-vlan-cell-local,
+.svc-vlan-row > .svc-vlan-cell-select,
+.svc-vlan-row > .svc-vlan-cell-assign {
+	border-top: 1px solid #ddd;
+	border-bottom: 1px solid #ddd;
+	background: #fafafa;
+}
+
+.svc-vlan-row > .svc-vlan-cell-action {
+	border: 1px solid #ddd;
+	border-left: 1px solid var(--border-color-low, #ccc);
+	border-radius: 0 4px 4px 0;
+	background: #fafafa;
+}
+
+.svc-vlan-row:hover > .svc-vlan-cell {
+	background: #f3f3f3;
+	border-color: #bbb;
+}
+
+.svc-vlan-row.svc-vlan-add-row > .svc-vlan-cell {
+	background: #f7faff;
+}
+
+/* Dashed outline on the outside of the add row only — not between columns */
+.svc-vlan-row.svc-vlan-add-row > .svc-vlan-cell-id {
+	border-left-style: dashed;
+	border-top-style: dashed;
+	border-bottom-style: dashed;
+}
+
+.svc-vlan-row.svc-vlan-add-row > .svc-vlan-cell-action {
+	border-right-style: dashed;
+	border-top-style: dashed;
+	border-bottom-style: dashed;
+}
+
+.svc-vlan-row > .svc-vlan-cell-empty {
+	border-left: none;
+	padding-left: 0;
+}
+
+.svc-vlan-row.flash {
+	animation: svc-flash 0.8s ease-out;
+}
+
+@keyframes svc-flash {
+	0%   { background: #fff5b1; }
+	100% { background: #fafafa; }
+}
+
+.svc-vlan-id {
+	font-family: monospace;
+	font-weight: bold;
+}
+
+.svc-vlan-id-input {
+	width: 100%;
+	max-width: 100%;
+	min-width: 0;
+	box-sizing: border-box;
+	padding: 2px 4px;
+	font-family: monospace;
+}
+
+.svc-vlan-label {
+	width: 100%;
+	box-sizing: border-box;
+	padding: 2px 4px;
+	border: 1px solid #ddd;
+	border-radius: 2px;
+	background: var(--background-color-high, #fff);
+}
+
+.svc-vlan-label:focus,
+.svc-vlan-id-input:focus {
+	border-color: #3c8dbc;
+	outline: none;
+}
+
+.svc-vlan-select-group,
+.svc-vlan-assign-group {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.3em;
+	white-space: nowrap;
+}
+
+.svc-vlan-cell-local > .cbi-checkbox {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.svc-vlan-select-group .cbi-button,
+.svc-vlan-assign-group .cbi-button {
+	min-width: 3.25em;
+}
+
+.svc-vlan-btn-tagged,
+.svc-vlan-btn-untagged,
+.svc-vlan-btn-remove,
+.svc-vlan-btn-add,
+.svc-vlan-assign-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0 8px !important;
+	font-size: 13px !important;
+	line-height: 2em !important;
+	min-height: 2em;
+	white-space: nowrap;
+	cursor: pointer;
+	user-select: none;
+}
+
+.svc-vlan-assign-btn.svc-vlan-assign-disabled {
+	opacity: 0.55;
+	cursor: default;
+}
+
+/* T = tagged (amber), U = untagged (teal) — select + assign buttons */
+#switch-vlan-view .svc-vlan-btn-tagged:not(:disabled),
+#switch-vlan-view .svc-vlan-btn-assign-tagged:not(.svc-vlan-assign-disabled) {
+	border-color: var(--svc-vlan-tagged);
+	background-color: var(--svc-vlan-tagged-bg);
+}
+
+#switch-vlan-view .svc-vlan-btn-untagged:not(:disabled),
+#switch-vlan-view .svc-vlan-btn-assign-untagged:not(.svc-vlan-assign-disabled) {
+	border-color: var(--svc-vlan-untagged);
+	background-color: var(--svc-vlan-untagged-bg);
+}
+
+#switch-vlan-view .svc-vlan-btn-tagged .svc-vlan-btn-prefix,
+#switch-vlan-view .svc-vlan-btn-assign-tagged .svc-vlan-btn-prefix {
+	color: var(--svc-vlan-tagged);
+}
+
+#switch-vlan-view .svc-vlan-btn-untagged .svc-vlan-btn-prefix,
+#switch-vlan-view .svc-vlan-btn-assign-untagged .svc-vlan-btn-prefix {
+	color: var(--svc-vlan-untagged);
+}
+
+#switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-checked,
+#switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-checked {
+	color: #fff;
+}
+
+#switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-checked .svc-vlan-btn-prefix,
+#switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-checked .svc-vlan-btn-prefix {
+	color: #fff;
+}
+
+#switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-checked {
+	background: linear-gradient(#b45309, var(--svc-vlan-tagged));
+	border-color: #b45309;
+}
+
+#switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-checked {
+	background: linear-gradient(#0f766e, var(--svc-vlan-untagged));
+	border-color: #0f766e;
+}
+
+#switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-mixed {
+	background: linear-gradient(
+		135deg,
+		var(--svc-vlan-tagged) 45%,
+		transparent 45%,
+		transparent 55%,
+		var(--svc-vlan-tagged-bg) 55%
+	);
+	border-color: var(--svc-vlan-tagged);
+}
+
+#switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-mixed {
+	background: linear-gradient(
+		135deg,
+		var(--svc-vlan-untagged) 45%,
+		transparent 45%,
+		transparent 55%,
+		var(--svc-vlan-untagged-bg) 55%
+	);
+	border-color: var(--svc-vlan-untagged);
+}
+
+:root[data-darkmode="true"] #switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-checked,
+:root[data-darkmode="true"] #switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-checked {
+	color: #1a1a1a;
+}
+
+:root[data-darkmode="true"] #switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-checked .svc-vlan-btn-prefix,
+:root[data-darkmode="true"] #switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-checked .svc-vlan-btn-prefix {
+	color: #1a1a1a;
+}
+
+:root[data-darkmode="true"] #switch-vlan-view .svc-vlan-btn-assign-tagged.svc-vlan-assign-checked {
+	background: linear-gradient(#f59e0b, var(--svc-vlan-tagged));
+	border-color: var(--svc-vlan-tagged);
+}
+
+:root[data-darkmode="true"] #switch-vlan-view .svc-vlan-btn-assign-untagged.svc-vlan-assign-checked {
+	background: linear-gradient(#14b8a6, var(--svc-vlan-untagged));
+	border-color: var(--svc-vlan-untagged);
+}
+
+.svc-vlan-btn-prefix {
+	font-family: monospace;
+	font-weight: bold;
+}
+
+@media (max-width: 720px) {
+	.svc-vlans,
+	.svc-vlan-header,
+	.svc-vlan-row,
+	.svc-vlan-header > .svc-vlan-cell,
+	.svc-vlan-row > .svc-vlan-cell {
+		display: block;
+		width: 100%;
+	}
+
+	.svc-vlan-header > .svc-vlan-cell {
+		border-bottom: none;
+		padding: 0.15em 0;
+	}
+
+	.svc-vlan-row > .svc-vlan-cell {
+		border: none !important;
+		border-radius: 0 !important;
+		background: transparent !important;
+		padding: 0.25em 0;
+	}
+
+	.svc-vlan-row {
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		background: #fafafa;
+		padding: 0.4em 0.6em;
+		margin-bottom: 0.3em;
+	}
+
+	.svc-vlan-row.svc-vlan-add-row {
+		border-style: dashed;
+		background: #f7faff;
+	}
+
+	.svc-vlan-row > .svc-vlan-cell-label,
+	.svc-vlan-row > .svc-vlan-cell-local,
+	.svc-vlan-row > .svc-vlan-cell-select,
+	.svc-vlan-row > .svc-vlan-cell-assign,
+	.svc-vlan-row > .svc-vlan-cell-action {
+		border-left: none;
+		padding-left: 0;
+	}
+
+	.svc-vlan-row > .svc-vlan-cell-empty {
+		display: none;
+	}
+}

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch-vlan.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch-vlan.js
@@ -1,0 +1,1091 @@
+/* Switch/VLAN configuration view.
+ *
+ * Operates on a single vlan-aware bridge identified by bvtool.findActiveBridge
+ * (every member must be a physical ethernet/DSA port). Renders two blocks:
+ * a Ports section (clickable port tiles whose selection drives the rest of the
+ * view) and a VLANs section (one row per bridge-vlan with tri-state T/U
+ * buttons that assign/remove tagged/untagged membership across the current
+ * port selection).
+ *
+ * UCI mutations go through bvtool.setBridgeVlanPorts (anti-stacking) and are
+ * auto-stashed to the rpcd session after every user action so the global
+ * "Unsaved Changes" indicator updates live. */
+
+'use strict';
+'require view';
+'require ui';
+'require uci';
+'require poll';
+'require network';
+'require tools.bridgevlan as bvtool';
+
+
+/* =============================================================================
+ * Module-level helpers
+ * ============================================================================= */
+
+/* Parse a bridge-vlan section's `ports` option into { portName -> parsedSpec }. */
+function loadPortMap(section_id) {
+	const portMap = {};
+	L.toArray(uci.get('network', section_id, 'ports')).forEach(spec => {
+		const p = bvtool.parsePortSpec(spec);
+		if (p)
+			portMap[p.port] = p;
+	});
+	return portMap;
+}
+
+/* Serialise a portMap back into a sorted array of `name` / `name:t` specs. */
+function portMapToSpecs(portMap) {
+	return Object.keys(portMap).sort(L.naturalCompare).map(name =>
+		portMap[name].tagged ? name + ':t' : name
+	);
+}
+
+/* Full-page replacement when the bridge VLAN config can't be modelled here. */
+function renderUnsupportedBlocker(bridgeName, issues) {
+	return E('div', { 'class': 'cbi-section' }, [
+		E('h2', _('Switch / VLAN Configuration')),
+		E('div', { 'class': 'alert-message error' }, [
+			E('h4', _('Unsupported VLAN configuration')),
+			E('p', [
+				_('The bridge device "%s" has a VLAN configuration that this view cannot represent. ').format(bridgeName || '?'),
+				_('Most commonly this means that a port has its primary VLAN (PVID) set to a different VLAN than its untagged egress VLAN — a combination that is allowed by 802.1Q but very rarely intentional.')
+			]),
+			E('ul', issues.map(msg => E('li', msg))),
+			E('p', [
+				_('Please review the configuration via the legacy '),
+				E('a', { 'href': L.url('admin/network/network') }, _('Bridge VLAN filtering dialog')),
+				_(' and either correct the unusual configuration or remove the offending VLAN assignments before returning here.')
+			])
+		])
+	]);
+}
+
+/* Full-page replacement when no eligible bridge is configured. */
+function renderNoBridgeBlocker() {
+	return E('div', { 'class': 'cbi-section' }, [
+		E('h2', _('Switch / VLAN Configuration')),
+		E('div', { 'class': 'alert-message warning' }, [
+			E('h4', _('No managed switch found')),
+			E('p', _('No bridge eligible for switch-style configuration was found. This view requires a bridge with VLAN filtering enabled (explicitly or implicitly via bridge-vlan sections) whose member ports are all physical ethernet or DSA switch ports. Bridges containing wireless, tunnel, VLAN sub-interfaces or other virtual members are intentionally excluded.')),
+			E('p', [
+				_('You can enable VLAN filtering on a bridge from the '),
+				E('a', { 'href': L.url('admin/network/network') }, _('Interfaces → Devices')),
+				_(' page.')
+			])
+		])
+	]);
+}
+
+
+return view.extend({
+	bridge: null,
+	ports: [],
+	vlans: [],
+	portLabels: {},
+	vlanLabels: {},
+	selection: null,
+
+
+	/* =========================================================================
+	 * Lifecycle: load, render, full refresh
+	 * ========================================================================= */
+
+	load() {
+		return Promise.all([
+			uci.load('network'),
+			uci.load('luci'),
+			network.getDevices()
+		]);
+	},
+
+	loadState() {
+		this.ports = bvtool.collectBridgePorts(this.bridge);
+		this.vlans = bvtool.collectBridgeVlans(this.bridge);
+
+		this.portLabels = {};
+		this.ports.forEach(p => { this.portLabels[p] = bvtool.readPortLabel(p); });
+
+		this.vlanLabels = {};
+		this.vlans.forEach(v => { this.vlanLabels[v.vlan] = bvtool.readVlanLabel(v.vlan); });
+	},
+
+	render() {
+		this.bridge = bvtool.findActiveBridge();
+
+		if (!this.bridge)
+			return renderNoBridgeBlocker();
+
+		const issues = bvtool.checkUnsupportedConfig(this.bridge);
+
+		if (issues.length)
+			return renderUnsupportedBlocker(this.bridge.name, issues);
+
+		this.loadState();
+
+		bvtool.pruneOrphanLabels(this.ports, this.vlans.map(v => v.vlan));
+
+		if (this.selection == null)
+			this.selection = new Set();
+
+		this.portsBlock = this.renderPortsSection();
+		this.vlansBlock = this.renderVlansSection();
+
+		const root = E('div', { 'class': 'cbi-section', 'id': 'switch-vlan-view' }, [
+			E('link', { 'rel': 'stylesheet', 'href': L.resource('view/network/switch-vlan.css') }),
+			E('h2', _('Switch / VLAN Configuration')),
+			E('div', { 'class': 'cbi-section-descr' }, [
+				_('Configure VLANs and per-port VLAN membership on bridge device '),
+				E('code', this.bridge.name),
+				_('. Select ports, then use T and U on each VLAN row to assign or remove tagged or untagged (native) membership (empty, partial, or full for the current selection). Optional labels for ports and VLANs are stored in the LuCI configuration and are for human reference only.')
+			]),
+			this.portsBlock,
+			this.vlansBlock
+		]);
+
+		this.root = root;
+
+		poll.add(() => this.refreshLinkStatus(), 5);
+
+		Promise.resolve().then(() => this.refreshLinkStatus());
+
+		Promise.resolve().then(() => this.onSelectionChange());
+
+		return root;
+	},
+
+	refreshAll() {
+		this.loadState();
+
+		const newPorts = this.renderPortsSection();
+		const newVlans = this.renderVlansSection();
+
+		if (this.portsBlock && this.portsBlock.parentNode)
+			this.portsBlock.parentNode.replaceChild(newPorts, this.portsBlock);
+
+		if (this.vlansBlock && this.vlansBlock.parentNode)
+			this.vlansBlock.parentNode.replaceChild(newVlans, this.vlansBlock);
+
+		this.portsBlock = newPorts;
+		this.vlansBlock = newVlans;
+
+		for (let name of this.selection)
+			if (this.ports.indexOf(name) === -1)
+				this.selection.delete(name);
+
+		this.refreshLinkStatus();
+		this.onSelectionChange();
+	},
+
+	refreshLinkStatus() {
+		if (!this.root || !this.bridge)
+			return Promise.resolve();
+
+		return network.getDevices().then(devices => {
+			const byName = {};
+			devices.forEach(d => { byName[d.getName()] = d; });
+
+			this.ports.forEach(name => {
+				const dev = byName[name] || network.instantiateDevice(name);
+				const tile = this.root.querySelector('.svc-port-tile[data-port="%s"]'.format(name));
+				if (!tile)
+					return;
+
+				const linkEl = tile.querySelector('.svc-port-link');
+				const speedEl = tile.querySelector('.svc-port-speed');
+				if (!linkEl || !speedEl)
+					return;
+
+				const carrier = dev ? dev.getCarrier() : false;
+				const speed = dev ? dev.getSpeed() : null;
+				const duplex = dev ? dev.getDuplex() : null;
+
+				let state = 'down';
+				let speedText = _('no link');
+
+				if (carrier && speed && speed > 0) {
+					state = 'up';
+					speedText = '%d%s'.format(speed, duplex == 'full' ? 'FD' : (duplex == 'half' ? 'HD' : ''));
+				}
+				else if (carrier) {
+					state = 'up';
+					speedText = _('up');
+				}
+
+				linkEl.setAttribute('data-state', state);
+				speedEl.textContent = speedText;
+			});
+		});
+	},
+
+
+	/* =========================================================================
+	 * Ports section: rendering, tile clicks, selection state
+	 * ========================================================================= */
+
+	renderPortsSection() {
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+
+		const content = this.ports.length
+			? E('div', { 'class': 'svc-ports' }, this.ports.map(name => this.renderPortTile(name, portState[name])))
+			: E('p', { 'class': 'svc-empty' }, _('No ports are configured on this bridge.'));
+
+		const clearBtn = E('button', {
+			'class': 'cbi-button cbi-button-neutral svc-port-btn-clear',
+			'type': 'button',
+			'click': () => this.handleClearSelection()
+		}, _('Clear selection'));
+
+		const selectAllBtn = E('button', {
+			'class': 'cbi-button cbi-button-neutral svc-port-btn-select-all',
+			'type': 'button',
+			'click': () => this.handleSelectAll()
+		}, _('Select all ports'));
+
+		this.clearSelectionBtn = clearBtn;
+		this.selectAllBtn = selectAllBtn;
+
+		return E('div', { 'class': 'svc-block' }, [
+			E('div', { 'class': 'svc-block-header' }, [
+				E('h3', _('Ports')),
+				E('span', { 'class': 'svc-port-header-actions' }, [ clearBtn, selectAllBtn ])
+			]),
+			content
+		]);
+	},
+
+	renderPortTile(name, state) {
+		const selected = this.selection.has(name);
+		const labelValue = this.portLabels[name] || '';
+
+		const labelInput = E('input', {
+			'type': 'text',
+			'class': 'svc-port-label',
+			'placeholder': _('label'),
+			'value': labelValue,
+			'maxlength': 32,
+			'spellcheck': 'false'
+		});
+
+		labelInput.addEventListener('click', ev => ev.stopPropagation());
+		labelInput.addEventListener('mousedown', ev => ev.stopPropagation());
+		labelInput.addEventListener('blur', ev => this.handlePortLabelChange(name, ev));
+
+		const nativeNode = E('span', { 'class': 'svc-port-vlan native' },
+			state.native != null ? [ E('span', { 'class': 'svc-port-tag-prefix' }, 'U:'), '%d'.format(state.native) ] : '');
+
+		const taggedNode = E('span', { 'class': 'svc-port-vlan tagged' },
+			state.tagged.length ? [
+				E('span', { 'class': 'svc-port-tag-prefix' }, 'T:'),
+				state.tagged.map(v => '%d'.format(v)).join(', ')
+			] : '');
+
+		const tile = E('div', {
+			'class': 'svc-port-tile' + (selected ? ' selected' : ''),
+			'data-port': name,
+			'role': 'button',
+			'tabindex': '0'
+		}, [
+			E('div', { 'class': 'svc-port-header' }, [
+				E('span', { 'class': 'svc-port-name' }, name),
+				E('span', { 'class': 'svc-port-link', 'data-state': 'unknown' }, [
+					E('span', { 'class': 'svc-port-dot' }),
+					E('span', { 'class': 'svc-port-speed' }, '—')
+				])
+			]),
+			labelInput,
+			E('div', { 'class': 'svc-port-vlans' }, [ nativeNode, taggedNode ])
+		]);
+
+		tile.addEventListener('click', ev => this.handlePortClick(name, ev));
+		tile.addEventListener('keydown', ev => {
+			if (ev.key === ' ' || ev.key === 'Enter') {
+				ev.preventDefault();
+				this.handlePortClick(name, ev);
+			}
+		});
+
+		return tile;
+	},
+
+	handlePortClick(name, ev) {
+		if (ev && ev.target && ev.target.classList.contains('svc-port-label'))
+			return;
+
+		if (this.selection.has(name))
+			this.selection.delete(name);
+		else
+			this.selection.add(name);
+
+		const tile = this.root.querySelector('.svc-port-tile[data-port="%s"]'.format(name));
+		if (tile)
+			tile.classList.toggle('selected', this.selection.has(name));
+
+		this.onSelectionChange();
+	},
+
+	handlePortLabelChange(name, ev) {
+		const value = (ev.target.value || '').trim();
+
+		if (value === (this.portLabels[name] || ''))
+			return;
+
+		this.portLabels[name] = value;
+		bvtool.writePortLabel(name, value);
+		this.stashNetworkChanges();
+	},
+
+	handleClearSelection() {
+		this.selection.clear();
+		this.refreshPortSelectionDom();
+		this.onSelectionChange();
+	},
+
+	handleSelectAll() {
+		this.ports.forEach(name => this.selection.add(name));
+		this.refreshPortSelectionDom();
+		this.onSelectionChange();
+	},
+
+	refreshPortSelectionDom() {
+		if (!this.root)
+			return;
+
+		const tiles = this.root.querySelectorAll('.svc-port-tile');
+
+		tiles.forEach(tile => {
+			const name = tile.getAttribute('data-port');
+			tile.classList.toggle('selected', this.selection.has(name));
+		});
+	},
+
+	onSelectionChange() {
+		this.refreshSelectionUi();
+	},
+
+	refreshSelectionUi() {
+		const hasSelection = this.selection.size > 0;
+		const allSelected = this.ports.length > 0 && this.selection.size === this.ports.length;
+
+		this.clearSelectionBtn?.toggleAttribute('disabled', !hasSelection);
+		this.selectAllBtn?.toggleAttribute('disabled', allSelected);
+
+		if (!this.root)
+			return;
+
+		this.refreshVlanRowStates();
+	},
+
+	requireSelection() {
+		if (this.selection.size > 0)
+			return true;
+
+		ui.addNotification(null, E('p', _('Select one or more ports first.')), 'warning');
+		return false;
+	},
+
+
+	/* =========================================================================
+	 * VLANs section: rendering, tri-state buttons, per-row interactions
+	 * ========================================================================= */
+
+	renderVlansSection() {
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+		const counts = {};
+
+		this.vlans.forEach(v => {
+			counts[v.vlan] = { tagged: 0, untagged: 0 };
+		});
+
+		this.ports.forEach(name => {
+			const st = portState[name];
+			if (st.native != null && counts[st.native])
+				counts[st.native].untagged++;
+			st.tagged.forEach(vid => {
+				if (counts[vid])
+					counts[vid].tagged++;
+			});
+		});
+
+		const rows = [
+			this.renderVlanHeader(),
+			...this.vlans.map(v => this.renderVlanRow(v, counts[v.vlan])),
+			this.renderVlanAddRow()
+		];
+
+		const container = E('div', { 'class': 'svc-vlans' }, rows);
+
+		return E('div', { 'class': 'svc-block' }, [
+			E('div', { 'class': 'svc-block-header' }, [
+				E('h3', _('VLANs'))
+			]),
+			container
+		]);
+	},
+
+	renderVlanHeader() {
+		return E('div', { 'class': 'svc-vlan-header' }, [
+			E('span', { 'class': 'svc-vlan-cell svc-vlan-cell-id' }, _('VLAN ID')),
+			E('span', { 'class': 'svc-vlan-cell svc-vlan-cell-label' }, _('Label')),
+			E('span', { 'class': 'svc-vlan-cell svc-vlan-cell-local' }, _('Local')),
+			E('span', { 'class': 'svc-vlan-cell svc-vlan-cell-select' }, _('Select ports')),
+			E('span', { 'class': 'svc-vlan-cell svc-vlan-cell-assign' }, _('Assign membership')),
+			E('span', { 'class': 'svc-vlan-cell svc-vlan-cell-action' })
+		]);
+	},
+
+	renderVlanRow(v, count) {
+		const labelInput = E('input', {
+			'type': 'text',
+			'class': 'svc-vlan-label',
+			'placeholder': _('label'),
+			'value': this.vlanLabels[v.vlan] || '',
+			'maxlength': 32,
+			'spellcheck': 'false'
+		});
+
+		labelInput.addEventListener('blur', ev => this.handleVlanLabelChange(v.vlan, ev));
+
+		const localCb = E('input', {
+			'type': 'checkbox',
+			'checked': v.local ? '' : null
+		});
+
+		localCb.addEventListener('change', ev => this.handleVlanLocalChange(v.vlan, ev));
+
+		const localLabel = E('label', {
+			'class': 'cbi-checkbox',
+			'title': _('Mark VLAN as locally terminated on the bridge')
+		}, [ localCb ]);
+
+		const taggedBtn = E('button', {
+			'class': 'cbi-button cbi-button-neutral svc-vlan-btn-tagged',
+			'disabled': count.tagged ? null : '',
+			'title': _('Select all ports having VLAN %d assigned as tagged (%d)').format(v.vlan, count.tagged)
+		}, [ E('span', { 'class': 'svc-vlan-btn-prefix' }, 'T') ]);
+
+		taggedBtn.addEventListener('click', ev => this.handleSelectByRole(v.vlan, 'tagged', ev));
+
+		const untaggedBtn = E('button', {
+			'class': 'cbi-button cbi-button-neutral svc-vlan-btn-untagged',
+			'disabled': count.untagged ? null : '',
+			'title': _('Select all ports having VLAN %d assigned as untagged / native (%d)').format(v.vlan, count.untagged)
+		}, [ E('span', { 'class': 'svc-vlan-btn-prefix' }, 'U') ]);
+
+		untaggedBtn.addEventListener('click', ev => this.handleSelectByRole(v.vlan, 'untagged', ev));
+
+		const assignTaggedToggle = this.createAssignToggle(v.vlan, 'tagged', 'T');
+		const assignUntaggedToggle = this.createAssignToggle(v.vlan, 'untagged', 'U');
+
+		const removeBtn = E('button', {
+			'class': 'cbi-button cbi-button-remove svc-vlan-btn-remove',
+			'title': _('Remove VLAN %d').format(v.vlan)
+		}, _('Remove'));
+
+		removeBtn.addEventListener('click', () => this.handleVlanRemove(v));
+
+		const row = E('div', {
+			'class': 'svc-vlan-row',
+			'data-vlan': '%d'.format(v.vlan)
+		}, [
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-id' }, [
+				E('span', { 'class': 'svc-vlan-id' }, '%d'.format(v.vlan))
+			]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-label' }, [ labelInput ]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-local' }, [ localLabel ]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-select' }, [
+				E('span', { 'class': 'svc-vlan-select-group' }, [ taggedBtn, untaggedBtn ])
+			]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-assign' }, [
+				E('span', { 'class': 'svc-vlan-assign-group' }, [ assignTaggedToggle, assignUntaggedToggle ])
+			]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-action' }, [ removeBtn ])
+		]);
+
+		row.addEventListener('mouseenter', () => this.handleVlanHover(v.vlan, true));
+		row.addEventListener('mouseleave', () => this.handleVlanHover(v.vlan, false));
+		row.addEventListener('focusin', () => this.handleVlanHover(v.vlan, true));
+		row.addEventListener('focusout', () => this.handleVlanHover(v.vlan, false));
+
+		return row;
+	},
+
+	renderVlanAddRow() {
+		const vidInput = E('input', {
+			'type': 'number',
+			'class': 'svc-vlan-id-input',
+			'placeholder': _('VLAN'),
+			'min': '%d'.format(bvtool.MIN_VLAN_ID),
+			'max': '%d'.format(bvtool.MAX_VLAN_ID),
+			'step': '1'
+		});
+
+		const labelInput = E('input', {
+			'type': 'text',
+			'class': 'svc-vlan-label',
+			'placeholder': _('label (optional)'),
+			'maxlength': 32,
+			'spellcheck': 'false'
+		});
+
+		const localCb = E('input', {
+			'type': 'checkbox',
+			'checked': ''
+		});
+
+		const addBtn = E('button', {
+			'class': 'cbi-button cbi-button-add svc-vlan-btn-add'
+		}, _('Add'));
+
+		const localLabel = E('label', {
+			'class': 'cbi-checkbox',
+			'title': _('Mark VLAN as locally terminated on the bridge')
+		}, [ localCb ]);
+
+		const row = E('div', { 'class': 'svc-vlan-row svc-vlan-add-row' }, [
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-id' }, [ vidInput ]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-label' }, [ labelInput ]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-local' }, [ localLabel ]),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-select svc-vlan-cell-empty' }),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-assign svc-vlan-cell-empty' }),
+			E('div', { 'class': 'svc-vlan-cell svc-vlan-cell-action' }, [ addBtn ])
+		]);
+
+		const submit = () => this.handleVlanAdd(vidInput, labelInput, localCb);
+		const submitOnEnter = ev => {
+			if (ev.key === 'Enter') {
+				ev.preventDefault();
+				submit();
+			}
+		};
+
+		addBtn.addEventListener('click', submit);
+		vidInput.addEventListener('keydown', submitOnEnter);
+		labelInput.addEventListener('keydown', submitOnEnter);
+
+		return row;
+	},
+
+	createAssignToggle(vid, role, prefix) {
+		const btn = E('button', {
+			'type': 'button',
+			'class': 'cbi-button cbi-button-neutral svc-vlan-assign-btn svc-vlan-btn-assign-%s'.format(role),
+			'click': ev => this.handleAssignToggleClick(vid, role, ev)
+		}, [
+			E('span', { 'class': 'svc-vlan-btn-prefix' }, prefix)
+		]);
+
+		const roleState = this.computeAssignRoleState(vid);
+		this.refreshAssignButton(btn, vid, role, roleState[role], !this.selection.size);
+
+		return btn;
+	},
+
+	refreshVlanRowStates() {
+		if (!this.root)
+			return;
+
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+		const counts = {};
+
+		this.vlans.forEach(v => counts[v.vlan] = { tagged: 0, untagged: 0 });
+		this.ports.forEach(name => {
+			const st = portState[name];
+			if (st.native != null && counts[st.native])
+				counts[st.native].untagged++;
+			st.tagged.forEach(vid => {
+				if (counts[vid]) counts[vid].tagged++;
+			});
+		});
+
+		const noSelection = !this.selection.size;
+
+		this.root.querySelectorAll('.svc-vlan-row[data-vlan]').forEach(row => {
+			const vid = +row.getAttribute('data-vlan');
+			const count = counts[vid];
+			if (!count)
+				return;
+
+			this.refreshSelectButton(row.querySelector('.svc-vlan-select-group .svc-vlan-btn-tagged'),
+				vid, 'tagged', count.tagged);
+			this.refreshSelectButton(row.querySelector('.svc-vlan-select-group .svc-vlan-btn-untagged'),
+				vid, 'untagged', count.untagged);
+
+			const roleState = this.computeAssignRoleState(vid, portState);
+			this.refreshAssignButton(row.querySelector('.svc-vlan-btn-assign-tagged'),
+				vid, 'tagged', roleState.tagged, noSelection);
+			this.refreshAssignButton(row.querySelector('.svc-vlan-btn-assign-untagged'),
+				vid, 'untagged', roleState.untagged, noSelection);
+		});
+	},
+
+	refreshSelectButton(btn, vid, role, n) {
+		if (!btn)
+			return;
+		btn.toggleAttribute('disabled', !n);
+		btn.title = role === 'tagged'
+			? _('Select all ports having VLAN %d assigned as tagged (%d)').format(vid, n)
+			: _('Select all ports having VLAN %d assigned as untagged / native (%d)').format(vid, n);
+	},
+
+	refreshAssignButton(btn, vid, role, state, noSelection) {
+		if (!btn)
+			return;
+		btn.classList.toggle('svc-vlan-assign-checked', !noSelection && state === 'checked');
+		btn.classList.toggle('svc-vlan-assign-mixed', !noSelection && state === 'mixed');
+		btn.classList.toggle('svc-vlan-assign-disabled', noSelection);
+
+		if (noSelection) {
+			btn.title = _('Select one or more ports first');
+			return;
+		}
+
+		if (role === 'tagged')
+			btn.title = state === 'unchecked'
+				? _('Assign VLAN %d as tagged on selected ports').format(vid)
+				: state === 'mixed'
+					? _('Remove VLAN %d as tagged from selected ports that have it').format(vid)
+					: _('Remove VLAN %d as tagged from all selected ports').format(vid);
+		else
+			btn.title = state === 'unchecked'
+				? _('Assign VLAN %d as untagged (native) on selected ports').format(vid)
+				: state === 'mixed'
+					? _('Remove VLAN %d as untagged (native) from selected ports that have it').format(vid)
+					: _('Remove VLAN %d as untagged (native) from all selected ports').format(vid);
+	},
+
+	computeAssignRoleState(vid, portState) {
+		const total = this.selection.size;
+		if (!total)
+			return { tagged: 'unchecked', untagged: 'unchecked' };
+
+		portState ??= bvtool.buildPortState(this.bridge, this.ports);
+		let taggedN = 0, untaggedN = 0;
+
+		this.selection.forEach(name => {
+			const st = portState[name];
+			if (!st)
+				return;
+			if (st.tagged.some(t => +t === +vid)) taggedN++;
+			if (+st.native === +vid) untaggedN++;
+		});
+
+		const tri = n => n === 0 ? 'unchecked' : n === total ? 'checked' : 'mixed';
+		return { tagged: tri(taggedN), untagged: tri(untaggedN) };
+	},
+
+	handleVlanHover(vid, enter) {
+		if (!this.root)
+			return;
+
+		if (!enter) {
+			this.root.querySelectorAll('.svc-port-tile.highlight-tagged, .svc-port-tile.highlight-untagged')
+				.forEach(t => t.classList.remove('highlight-tagged', 'highlight-untagged'));
+			return;
+		}
+
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+
+		this.ports.forEach(name => {
+			const tile = this.root.querySelector('.svc-port-tile[data-port="%s"]'.format(name));
+			if (!tile)
+				return;
+
+			const st = portState[name];
+			if (st.native === vid)
+				tile.classList.add('highlight-untagged');
+			else if (st.tagged.indexOf(vid) !== -1)
+				tile.classList.add('highlight-tagged');
+		});
+	},
+
+	handleSelectByRole(vid, role, ev) {
+		if (ev) {
+			ev.preventDefault();
+			ev.stopPropagation();
+		}
+
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+
+		this.selection.clear();
+
+		this.ports.forEach(name => {
+			const st = portState[name];
+			if (role === 'untagged' && +st.native === +vid)
+				this.selection.add(name);
+			else if (role === 'tagged' && st.tagged.some(t => +t === +vid))
+				this.selection.add(name);
+		});
+
+		this.refreshPortSelectionDom();
+		this.onSelectionChange();
+	},
+
+	handleVlanLocalChange(vid, ev) {
+		const section = this.findVlanSection(vid);
+		if (!section)
+			return;
+
+		const checked = !!ev.target.checked;
+
+		/* netifd treats an absent "local" option as local=true, so unchecking
+		 * must write '0' explicitly rather than unsetting the option. */
+		uci.set('network', section.section_id, 'local', checked ? '1' : '0');
+
+		for (let v of this.vlans) {
+			if (+v.vlan === +vid) {
+				v.local = checked;
+				break;
+			}
+		}
+
+		this.stashNetworkChanges();
+	},
+
+	handleVlanLabelChange(vid, ev) {
+		const value = (ev.target.value || '').trim();
+
+		if (value === (this.vlanLabels[vid] || ''))
+			return;
+
+		this.vlanLabels[vid] = value;
+		bvtool.writeVlanLabel(vid, value);
+		this.stashNetworkChanges();
+	},
+
+	handleVlanAdd(vidInput, labelInput, localCb) {
+		const raw = (vidInput.value || '').trim();
+		const vid = parseInt(raw, 10);
+
+		if (!raw || !(vid >= bvtool.MIN_VLAN_ID && vid <= bvtool.MAX_VLAN_ID)) {
+			ui.addNotification(null, E('p', _('Please enter a VLAN ID between %d and %d.').format(bvtool.MIN_VLAN_ID, bvtool.MAX_VLAN_ID)), 'warning');
+			vidInput.focus();
+			return;
+		}
+
+		if (this.vlans.some(v => v.vlan === vid)) {
+			ui.addNotification(null, E('p', _('VLAN %d is already configured.').format(vid)), 'warning');
+			vidInput.focus();
+			return;
+		}
+
+		const section_id = uci.add('network', 'bridge-vlan');
+		uci.set('network', section_id, 'device', this.bridge.name);
+		uci.set('network', section_id, 'vlan', '%d'.format(vid));
+
+		uci.set('network', section_id, 'local', localCb.checked ? '1' : '0');
+
+		const labelValue = (labelInput.value || '').trim();
+		if (labelValue)
+			bvtool.writeVlanLabel(vid, labelValue);
+
+		this.refreshAll();
+		this.stashNetworkChanges();
+
+		const newRow = this.root.querySelector('.svc-vlan-row[data-vlan="%d"]'.format(vid));
+		if (newRow)
+			newRow.classList.add('flash');
+	},
+
+	handleVlanRemove(v) {
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+		const affected = this.ports.filter(name =>
+			portState[name].native === v.vlan ||
+			portState[name].tagged.indexOf(v.vlan) !== -1);
+
+		const portList = affected.length ? affected.join(', ') : _('none');
+		const labelText = this.vlanLabels[v.vlan] ? ' (%s)'.format(this.vlanLabels[v.vlan]) : '';
+
+		ui.showModal(_('Remove VLAN %d?').format(v.vlan), [
+			E('p', _('You are about to remove VLAN %d%s. This will also remove the VLAN from every port that currently has it assigned (tagged or untagged).').format(v.vlan, labelText)),
+			E('p', [ E('strong', _('Affected ports: ')), portList ]),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'btn',
+					'click': ui.hideModal
+				}, _('Cancel')),
+				' ',
+				E('button', {
+					'class': 'btn cbi-button-negative important',
+					'click': ui.createHandlerFn(this, function() {
+						this.doVlanRemove(v);
+						ui.hideModal();
+					})
+				}, _('Remove'))
+			])
+		]);
+	},
+
+	doVlanRemove(v) {
+		const section = this.findVlanSection(v.vlan);
+		if (!section)
+			return;
+
+		uci.remove('network', section.section_id);
+
+		bvtool.writeVlanLabel(v.vlan, '');
+
+		this.refreshAll();
+		this.stashNetworkChanges();
+	},
+
+
+	/* =========================================================================
+	 * VLAN membership mutations: T/U click pipeline
+	 * ========================================================================= */
+
+	handleAssignToggleClick(vid, role, ev) {
+		ev.preventDefault();
+		ev.stopPropagation();
+
+		if (ev.currentTarget.classList.contains('svc-vlan-assign-disabled'))
+			return;
+
+		if (!this.requireSelection()) {
+			this.refreshVlanRowStates();
+			return;
+		}
+
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+		const state = this.computeAssignRoleState(vid, portState)[role];
+
+		if (state === 'unchecked') {
+			const conflicts = this.findAssignConflicts(vid, role, portState);
+			if (conflicts.length) {
+				this.showTaggedConflict(conflicts);
+				this.refreshVlanRowStates();
+				return;
+			}
+			if (role === 'tagged')
+				this.applyTaggedChangeToSelection(vid, true);
+			else
+				this.applyUntaggedVlanToSelection(vid);
+		}
+		else if (role === 'tagged') {
+			this.applyTaggedChangeToSelection(vid, false);
+		}
+		else {
+			this.applyRemoveUntaggedFromSelection(vid);
+		}
+
+		this.refreshAll();
+		/* Auto-stash so the global "Unsaved Changes" counter updates immediately,
+		 * matching every other action in this view. Trade-off: if the user toggles,
+		 * the autosave reaches the server's pending state, and then toggles back,
+		 * bvtool.setBridgeVlanPorts clears the *local* pending change but cannot
+		 * undo the already-saved server entry — the counter then shows a phantom
+		 * change that nets to no-op on Apply. Cosmetic only. */
+		this.stashNetworkChanges();
+	},
+
+	findAssignConflicts(vid, role, portState) {
+		const conflicts = [];
+		this.selection.forEach(name => {
+			const st = portState[name];
+			const conflicts_with = role === 'tagged'
+				? +st.native === +vid
+				: st.tagged.some(t => +t === +vid);
+			if (conflicts_with)
+				conflicts.push({ port: name, vlan: vid });
+		});
+		return conflicts;
+	},
+
+	showTaggedConflict(conflicts) {
+		const lines = conflicts.slice(0, 6).map(c =>
+			_('Port "%s" already has VLAN %d as its native (untagged) VLAN.').format(c.port, c.vlan));
+
+		if (conflicts.length > 6)
+			lines.push(_('… and %d more.').format(conflicts.length - 6));
+
+		ui.addNotification(null, E('div', { 'class': 'svc-vlan-conflict' }, [
+			E('p', _('The requested change conflicts with the existing native VLAN assignment of one or more selected ports. No change was made; a port cannot have the same VLAN as both native and tagged.')),
+			E('div', { 'class': 'svc-vlan-conflict-ports' }, lines.map(l =>
+				E('p', { 'class': 'svc-vlan-conflict-port' }, l)))
+		]), 'warning');
+	},
+
+	/* Re-scan via uci.sections() rather than reading this.vlans: the cache is
+	 * only refreshed by loadState() and can be stale between a user edit and
+	 * the next refreshAll/syncStateAfterUciSave, so rapid Add-VLAN-then-assign
+	 * sequences would otherwise miss the new section_id. */
+	findVlanSection(vid) {
+		const devname = this.bridge ? this.bridge.name : null;
+		let section_id = null;
+		let local = true;
+
+		if (!devname)
+			return null;
+
+		uci.sections('network', 'bridge-vlan', s => {
+			if (s.device != devname || +s.vlan !== +vid)
+				return;
+
+			section_id = s['.name'];
+			local = bvtool.parseLocal(s.local);
+		});
+
+		if (!section_id)
+			return null;
+
+		return { vlan: +vid, section_id, local };
+	},
+
+	applyTaggedChangeToSelection(vid, check) {
+		const section = this.findVlanSection(vid);
+		if (!section)
+			return;
+
+		const portMap = loadPortMap(section.section_id);
+		let changed = false;
+
+		this.selection.forEach(name => {
+			const existing = portMap[name];
+			if (check) {
+				if (!existing || (!existing.tagged && existing.untagged)) {
+					portMap[name] = { port: name, tagged: true, untagged: false, pvid: false };
+					changed = true;
+				}
+			}
+			else if (existing && existing.tagged) {
+				if (existing.untagged)
+					portMap[name] = { port: name, tagged: false, untagged: true, pvid: true };
+				else
+					delete portMap[name];
+				changed = true;
+			}
+		});
+
+		if (changed)
+			bvtool.setBridgeVlanPorts(section.section_id, portMapToSpecs(portMap));
+	},
+
+	applyUntaggedVlanToSelection(vid) {
+		const portState = bvtool.buildPortState(this.bridge, this.ports);
+		const oldNatives = new Set();
+
+		this.selection.forEach(name => {
+			if (portState[name].native != null && portState[name].native !== vid)
+				oldNatives.add(portState[name].native);
+		});
+
+		oldNatives.forEach(oldVid => {
+			const section = this.findVlanSection(oldVid);
+			if (!section)
+				return;
+
+			const ports = L.toArray(uci.get('network', section.section_id, 'ports'));
+			const filtered = ports.filter(spec => {
+				const p = bvtool.parsePortSpec(spec);
+				return !p || !this.selection.has(p.port) || (p.tagged && !p.untagged);
+			});
+
+			if (filtered.length !== ports.length)
+				bvtool.setBridgeVlanPorts(section.section_id, filtered);
+		});
+
+		const section = this.findVlanSection(vid);
+		if (!section) {
+			ui.addNotification(null, E('p', _('VLAN %d does not exist.').format(vid)), 'warning');
+			return;
+		}
+
+		const portMap = loadPortMap(section.section_id);
+		let changed = false;
+
+		this.selection.forEach(name => {
+			if (!portMap[name] || !portMap[name].untagged) {
+				portMap[name] = { port: name, tagged: false, untagged: true, pvid: true };
+				changed = true;
+			}
+		});
+
+		if (changed)
+			bvtool.setBridgeVlanPorts(section.section_id, portMapToSpecs(portMap));
+	},
+
+	applyRemoveUntaggedFromSelection(vid) {
+		const section = this.findVlanSection(vid);
+		if (!section)
+			return;
+
+		const portMap = loadPortMap(section.section_id);
+		let changed = false;
+
+		this.selection.forEach(name => {
+			const existing = portMap[name];
+			if (!existing || !existing.untagged)
+				return;
+
+			if (existing.tagged)
+				portMap[name] = { port: name, tagged: true, untagged: false, pvid: false };
+			else
+				delete portMap[name];
+			changed = true;
+		});
+
+		if (changed)
+			bvtool.setBridgeVlanPorts(section.section_id, portMapToSpecs(portMap));
+	},
+
+
+	/* =========================================================================
+	 * Stash, save, apply, reset
+	 * ========================================================================= */
+
+	hasPendingLocalChanges() {
+		for (const conf of [ 'network', 'luci' ]) {
+			if (uci.state.creates[conf] && Object.keys(uci.state.creates[conf]).length)
+				return true;
+			if (uci.state.changes[conf] && Object.keys(uci.state.changes[conf]).length)
+				return true;
+			if (uci.state.deletes[conf] && Object.keys(uci.state.deletes[conf]).length)
+				return true;
+		}
+
+		return false;
+	},
+
+	/* Serialised via _stashChain: concurrent uci.save() RPCs race on the rpcd
+	 * session state, so each stash must wait for the previous one to settle. */
+	async stashNetworkChanges() {
+		this._stashChain = (this._stashChain ?? Promise.resolve()).then(async () => {
+			try {
+				const doSave = this.hasPendingLocalChanges();
+				if (doSave)
+					await uci.save();
+				ui.changes.renderChangeIndicator(await uci.changes());
+				if (doSave)
+					this.syncStateAfterUciSave();
+			}
+			catch (err) {
+				ui.addNotification(null, E('p', _('Failed to save configuration: %s').format(err.message)), 'danger');
+			}
+		});
+
+		return this._stashChain;
+	},
+
+	syncStateAfterUciSave() {
+		this.loadState();
+		this.refreshVlanRowStates();
+	},
+
+	handleSave(ev) {
+		return this.stashNetworkChanges().then(() => {
+			ui.addNotification(null, E('p', _('Changes have been staged. Use "Save & Apply" or the "Unsaved Changes" indicator to apply them.')), 'info');
+		});
+	},
+
+	handleSaveApply(ev, mode) {
+		return this.stashNetworkChanges().then(() => {
+			ui.changes.apply(mode == '0');
+		});
+	},
+
+	handleReset(ev) {
+		ui.changes.revert();
+	},
+
+});

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch-vlan.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch-vlan.js
@@ -152,7 +152,33 @@ return view.extend({
 
 		Promise.resolve().then(() => this.onSelectionChange());
 
+		Promise.resolve().then(() => this.showExperimentalDisclaimer());
+
 		return root;
+	},
+
+	showExperimentalDisclaimer() {
+		ui.showModal(_('Experimental view'), [
+			E('p', _('The Switch / VLAN configuration view is new and still considered experimental. Bugs in this view may result in network misconfiguration that can leave your device unreachable over the network.')),
+			E('p', _('Before making changes, make sure you have an alternative way to access the device (e.g. a serial or out-of-band connection) and review every change in "Unsaved Changes" before applying.')),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'btn',
+					'click': function() {
+						ui.hideModal();
+						if (window.history.length > 1)
+							window.history.back();
+						else
+							window.location.href = L.url('admin/network/network');
+					}
+				}, _('Cancel')),
+				' ',
+				E('button', {
+					'class': 'btn cbi-button-action important',
+					'click': ui.hideModal
+				}, _('I understand, continue'))
+			])
+		]);
 	},
 
 	refreshAll() {

--- a/modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json
@@ -46,6 +46,24 @@
 		}
 	},
 
+	"admin/network/switch-vlan": {
+		"title": "Switch/VLAN config",
+		"order": 12,
+		"action": {
+			"type": "view",
+			"path": "network/switch-vlan"
+		},
+		"depends": {
+			"acl": [ "luci-mod-network-config" ],
+			"uci": [
+				{ "network": { "@device": { "type": "bridge", "name": "switch", "vlan_filtering": "1" } } },
+				{ "network": { "@device": { "type": "bridge", "name": "switch" }, "@bridge-vlan": { "device": "switch" } } },
+				{ "network": { "@device": { "type": "bridge", "vlan_filtering": "1" } } },
+				{ "network": { "@bridge-vlan": true } }
+			]
+		}
+	},
+
 	"admin/network/routes": {
 		"title": "Routing",
 		"order": 30,

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -16,7 +16,7 @@
 				"iwinfo": [ "assoclist", "countrylist", "freqlist", "txpowerlist" ],
 				"luci": [ "getSwconfigFeatures", "getSwconfigPortState" ]
 			},
-			"uci": [ "dhcp", "firewall", "network", "wireless", "system" ]
+			"uci": [ "dhcp", "firewall", "luci", "network", "wireless", "system" ]
 		},
 		"write": {
 			"cgi-io": [ "exec" ],
@@ -30,7 +30,7 @@
 				"hostapd.*": [ "del_client" ],
 				"iwinfo": [ "scan" ]
 			},
-			"uci": [ "dhcp", "firewall", "network", "wireless" ]
+			"uci": [ "dhcp", "firewall", "luci", "network", "wireless" ]
 		}
 	},
 


### PR DESCRIPTION
Seeing OpenWrt supporting more and more dedicated switches with more than just a handful of physical ports, the current interface for configuring and maintaining ports and VLANs becomes cumbersome to use, especially with frequent changes.

## Pull request details

### Description
Register a new "Switch/VLAN config" entry in the Network top-level
menu and add the view at view/network/switch-vlan.js.

The menu entry is only visible when the network configuration
contains either a bridge device with vlan_filtering explicitly
enabled or at least one bridge-vlan section (mirroring the implicit
enable behaviour of the existing Bridge VLAN filtering dialog).

A warning about this yet being an experimental view which might
eat all your traffic is shown upon accessing this view.

### Disclaimer
**Large parts of the code involved in this PR were created/generated with the help of LLMs. Given my (lack of) JavaScript skills, me having reviewed the code to the best of my abilities might not be enough.**

### Current (personal) pain points are:
 - To reach the current switch/VLAN config page, one has to click
   through: Network -> Interfaces -> Devices -> Configure... (the
   respective switch/bridge) -> Bridge VLAN filtering which - at
   least for dedicated switches - is not sth. I feel comfortable
   having to do every time I want to make a basic change.

 - While ~5 ports might still fit next to each other, starting with
   2 figure numbers (at the latest), we end up scrolling
   horizontally. Finding a higher port to configure on a 24 or 48
   port switch inevitably results in plenty of horizontal scrolling,
   while at the same time you have to memorise which row maps to
   which VLAN-ID, as those scroll out the moment you start
   scrolling.

 - Every port needs to be configured by its own, no way to bulk-conf
   them, to apply the same VLAN config onto multiple ports (e.g.
   applying the same tag onto a large number or all ports).

 - Ports and VLAN-IDs are defined by sole numbers. There's no way to
   annotate them, e.g. a VLAN ID as "iot" or "mgmt", or a port as
   e.g. "uplink" or "server-mirko".

### How this PR tries to address above stated issues
**The disclaimer above being stated:** This PR provides a functional and isolated component (no changes to other parts of code) for how I personally think the/my in the beginning stated pain points could be addressed by the following changes / additions:
 - Add a dedicated "Switch/VLAN config" entry within the top-level
   "Network" dropdown (you might remember we already had such for
   swconfig back then, before it got obsoleted by DSA and conf via
   vlan aware bridges).

 - Avoid horizontal scrolling by showing switch ports in multiple
   rows if not fitting screen width.

 - Allow selection of multiple ports to configure them all the same
   way at once.

 - Introduce labels for ports and VLANs; they're optional annotations
   and don't serve any functional purpose except hinting the user,
   hence stored in respective sections within /etc/config/luci.

 - Visualising which VLANs are assigned to which ports by colour-
   coding the ports when hovering over configured VLANs.

### Discussion points
 - There's another pull request regarding port labels:
   https://github.com/openwrt/luci/pull/8579 -- however we want
   port and VLAN labels. Not sure how to combine those efforts.

 - Shall we only allow this view for dedicated switch devices?
   We don't have a device class "switch" or alike yet, but could
   easily depend on the "realtek" target, as it's the only supported
   platform currently.

 - Identifying the physical switch: apart from the possibility of
   there being more than one switch, how to identify an appropriate
   one:
    - Go for the bridge named "switch" by sole naming convention.
    - Filter for vlan-aware bridges (which itself is not well
      defined unfortunately), and filter for ony eth/sfp ports, so
      we don't include e.g. wifi ifaces), -- as does the "Bridge
      VLAN filtering" view -- and choose the first one from the list.
    - Filter for physical ports as the "Port status" view does
      (Overview -> Status) and choose the bridge all of them are
      members of; would call luci.getBuiltinEthernetPorts() and
      hence need further ACL permissions.

 - Stashing / saving changes: when and how to stash changes.
   Narrowed down, there are 2 obvious options:
    - uci.save() on every click and change - logging all the
      changes for review when clicking on "Unsaved changes" in the
      top-right corner.
      Due to the uci structure fo configuring VLANs being a bit un-
      fortunate, back-and-forth changes can't be easily tracked but
      stack up.
    - Stash changes inside luci only until being "Saved", which
      then saves them all at once. That works well for models
      where the underlying view has the "Save & Apply" / "Save" /
      "Reset" button-triple, but not really for a full-page view.

 - Should the "local"-flag be en- or disabled by default?

 - We currently do not support configurations of ingress != egress
   VLAN (or in other terms: PVID / primary VLAN != untagged VLAN)

### Screenshot or video of changes

Short screencast showing base features:
https://github.com/user-attachments/assets/94e09cff-3565-4707-82a9-de8971a8f126

Screenshot:
<img width="1840" height="2710" alt="openwrt-luci-switch-vlan-config" src="https://github.com/user-attachments/assets/fba78de3-4c9a-4645-a4ed-83b721e87132" />