### PR TITLE
luci-app-https-dns-proxy: fix get_providers() invalid JSON in directory fallback

### DIFF
--- a/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
+++ b/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
@@ -11,8 +11,8 @@
 # ubus -S call luci.https-dns-proxy getProviders '{"name": "https-dns-proxy" }'
 
 readonly packageName="https-dns-proxy"
-readonly providersDir="/usr/share/${packageName}/providers"
-readonly providersJson="/usr/share/${packageName}/providers.json"
+readonly providersDir="${_LUCI_PROVIDERS_DIR:-/usr/share/${packageName}/providers}"
+readonly providersJson="${_LUCI_PROVIDERS_JSON:-/usr/share/${packageName}/providers.json}"
 
 . "${IPKG_INSTROOT}/lib/functions.sh"
 . "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"
@@ -103,15 +103,17 @@ get_platform_support() {
 }
 
 get_providers() {
-	local f
+	local f first=1
 	echo '{"https-dns-proxy":'
 	if [ -s "$providersJson" ]; then
 		cat "$providersJson"
 	else
 		echo '['
-		for f in "$providersDir"/*; do
+		for f in "$providersDir"/*.json; do
+			[ -f "$f" ] || continue
+			[ "$first" = "1" ] || printf ','
+			first=0
 			cat "$f"
-			echo ','
 		done
 		echo ']'
 	fi

--- a/applications/luci-app-https-dns-proxy/tests/run_tests.sh
+++ b/applications/luci-app-https-dns-proxy/tests/run_tests.sh
@@ -459,6 +459,88 @@ else
 fi
 
 ###############################################################################
+#                     04: getProviders JSON output                            #
+###############################################################################
+
+printf "\n##\n## 04: getProviders JSON output\n##\n\n"
+
+if [ -f "$RPC_SCRIPT" ] && [ -d "$PROVIDERS_DIR" ]; then
+	_tmp_stubs="$(mktemp -d)"
+	_tmp_empty="$(mktemp -d)"
+	mkdir -p "$_tmp_stubs/lib" "$_tmp_stubs/usr/share/libubox"
+
+	cat > "$_tmp_stubs/lib/functions.sh" << 'STUB'
+#!/bin/sh
+STUB
+
+	cat > "$_tmp_stubs/usr/share/libubox/jshn.sh" << 'STUB'
+#!/bin/sh
+json_init() { :; }
+json_load() { :; }
+json_get_var() { :; }
+json_cleanup() { :; }
+STUB
+
+	# ── directory fallback returns valid JSON ──
+	n_tests=$((n_tests + 1))
+	_fallback_out="$(
+		IPKG_INSTROOT="$_tmp_stubs" \
+		_LUCI_PROVIDERS_DIR="$PROVIDERS_DIR" \
+		_LUCI_PROVIDERS_JSON="/nonexistent/providers.json" \
+		bash "$RPC_SCRIPT" call getProviders <<< '{"name":"https-dns-proxy"}' 2>/dev/null
+	)"
+	if echo "$_fallback_out" | python3 -m json.tool >/dev/null 2>&1; then
+		pass "getProviders dir-fallback returns valid JSON"
+	else
+		fail "getProviders dir-fallback returns invalid JSON (trailing comma bug?)" \
+		     "$(echo "$_fallback_out" | tail -3)"
+	fi
+
+	# ── directory fallback includes all providers ──
+	n_tests=$((n_tests + 1))
+	_expected_count="$(find "$PROVIDERS_DIR" -maxdepth 1 -name '*.json' | wc -l | tr -d ' ')"
+	_actual_count="$(echo "$_fallback_out" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(len(d.get('https-dns-proxy',[])))
+except Exception:
+    print(0)
+" 2>/dev/null)"
+	if [ "$_actual_count" = "$_expected_count" ]; then
+		pass "getProviders dir-fallback: all $_expected_count providers present"
+	else
+		fail "getProviders dir-fallback: expected $_expected_count providers, got ${_actual_count:-0}"
+	fi
+
+	# ── empty providers directory returns valid empty array ──
+	n_tests=$((n_tests + 1))
+	_empty_out="$(
+		IPKG_INSTROOT="$_tmp_stubs" \
+		_LUCI_PROVIDERS_DIR="$_tmp_empty" \
+		_LUCI_PROVIDERS_JSON="/nonexistent/providers.json" \
+		bash "$RPC_SCRIPT" call getProviders <<< '{"name":"https-dns-proxy"}' 2>/dev/null
+	)"
+	_empty_count="$(echo "$_empty_out" | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(len(d.get('https-dns-proxy',[])))
+except Exception:
+    print(-1)
+" 2>/dev/null)"
+	if [ "$_empty_count" = "0" ]; then
+		pass "getProviders empty dir-fallback: valid empty array"
+	else
+		fail "getProviders empty dir-fallback: expected 0 providers, got ${_empty_count:-invalid JSON}"
+	fi
+
+	rm -rf "$_tmp_stubs" "$_tmp_empty"
+else
+	echo "  SKIP: RPC script or providers directory not found"
+fi
+
+###############################################################################
 #                         SHELL SCRIPT SYNTAX                                 #
 ###############################################################################
 


### PR DESCRIPTION
Fixes #8647

## Summary

- `get_providers()` emitted a trailing comma after every provider file in the directory-scan fallback, producing JSON rejected by strict parsers and silently breaking the provider list in the UI
- An empty `$providersDir` caused `cat` to fail on a literal glob string while still emitting `,`, producing `[,]`

## Patch

**`root/usr/libexec/rpcd/luci.https-dns-proxy`**

- Flip comma placement: emit separator *before* each item after the first (not after every item)
- Add `[ -f "$f" ] || continue` guard and narrow glob to `*.json` so an empty/absent directory yields a valid empty array instead of broken output
- Allow `_LUCI_PROVIDERS_DIR` / `_LUCI_PROVIDERS_JSON` env-var overrides (default unchanged) to make the fallback path exercisable in the test harness without touching live system paths

**`tests/run_tests.sh`**

New section 04 — three tests:
1. Directory fallback output is valid JSON (python3 json parser accepts it)
2. All 45 providers are present in the output (count check)
3. Empty providers directory yields a valid empty array

## Test run results

```
## 04: getProviders JSON output

  PASS: getProviders dir-fallback returns valid JSON
  PASS: getProviders dir-fallback: all 45 providers present
  PASS: getProviders empty dir-fallback: valid empty array

Ran 335 tests, 335 passed, 0 failed
```

(was 332 tests before this patch; all pre-existing tests still pass)

Signed-off-by: unglazed7010 <thatblueghoul@gmail.com>