### PR TITLE
luci-base: fix order of clone bug

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
@@ -225,6 +225,7 @@ return view.extend({
 		o = s.option(form.Flag, 'enabled', _('Enable'));
 		o.modalonly = false;
 		o.default = o.enabled;
+		o.rmempty = false;
 		o.editable = true;
 		o.tooltip = function(section_id) {
 			const weekdays = uci.get('firewall', section_id, 'weekdays');

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -1309,6 +1309,12 @@ const CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstra
 		const sids = this.cfgsections();
 
 		for (let i = 0, sid = sids[0]; (sid = sids[i]) != null; i++) {
+			/*
+			 * do not remove elements that are not rendered yet
+			 */
+			if (!this.map.findElement('data-section-id', sid))
+				continue;
+
 			for (let j = 0, o = this.children[0]; (o = this.children[j]) != null; j++) {
 				let isActive = o.isActive(sid);
 				const isSatisfied = o.checkDepends(sid);
@@ -2155,7 +2161,11 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 				}
 			}
 			else if (this.forcewrite || !isEqual(cval, fval)) {
-				return Promise.resolve(this.write(section_id, fval));
+				/*
+				 * do not remove elements that are not rendered yet
+				 */
+				if (this.map.findElement('data-field', this.cbid(section_id)) != null)
+					return Promise.resolve(this.write(section_id, fval));
 			}
 		}
 		else if (!this.retain) {

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2761,7 +2761,7 @@ const CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection
 	 * @param {string} name
 	 * @returns {null}
 	 */
-	handleClone(section_id, put_next, name) {
+	handleClone(section_id, put_next, ev, name) {
 		let config_name = this.uciconfig || this.map.config;
 
 		this.map.data.clone(config_name, this.sectiontype, section_id, put_next, name);


### PR DESCRIPTION
## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
If a rule was manipulated via cli, the rule was appended to the end if cloned.
Somehow the reason appears to be that `name` was incorrectly assigned, because name was the event Object this way.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** LuCI openwrt-25.12<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Firefox<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [x] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#8613).

