### PR TITLE
luci-app-sfp-info: add SFP/QSFP transceiver diagnostics dashboard

### DIFF
--- a/applications/luci-app-sfp-info/Makefile
+++ b/applications/luci-app-sfp-info/Makefile
@@ -1,0 +1,16 @@
+# Copyright (C) 2026 OpenWrt.org
+# This is free software, licensed under the Apache License, Version 2.0.
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=SFP/QSFP Transceiver Diagnostics
+LUCI_DEPENDS:=+luci-base +ethtool-full  # requires ethtool >= 7.0 for --json support
+LUCI_PKGARCH:=all
+
+PKG_LICENSE:=Apache-2.0
+PKG_VERSION:=1.0
+PKG_MAINTAINER:=Meng Zhuo <mengzhuo@iscas.ac.cn>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-sfp-info/README.md
+++ b/applications/luci-app-sfp-info/README.md
@@ -1,0 +1,25 @@
+# luci-app-sfp-info
+
+Visual dashboard for SFP/QSFP optical transceiver diagnostics via `ethtool --json -m`.
+
+## Features
+
+- Auto-detection of all SFP/SFP+/QSFP+/QSFP28 modules on network interfaces
+- Real-time display of temperature, voltage, bias current, TX/RX power
+- Alarm and warning status with inline labels
+- Auto-refresh every 10 seconds
+- Supports SFF-8472 (SFP), SFF-8636 (QSFP), and CMIS (QSFP-DD/OSFP)
+
+## Dependencies
+
+- `luci-base`
+- `ethtool-full` (>= 7.0 for JSON output support)
+
+## RPC API
+
+The backend provides one ubus method under `luci.sfp-info`:
+
+**list** -- Returns full diagnostics for all detected SFP interfaces:
+```
+ubus call luci.sfp-info list
+```

--- a/applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js
+++ b/applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js
@@ -1,0 +1,206 @@
+'use strict';
+'require view';
+'require rpc';
+'require poll';
+
+var callList = rpc.declare({
+	object: 'luci.sfp-info',
+	method: 'list',
+	expect: { 'result': [] }
+});
+
+function mwToDbm(mw) {
+	if (mw == null || mw <= 0)
+		return null;
+
+	return 10 * Math.log10(mw);
+}
+
+function fmtDate(code) {
+	if (!code)
+		return '-';
+
+	var m = code.match(/^(\d{2})(\d{2})(\d{2})/);
+
+	if (!m)
+		return code;
+
+	return '20' + m[1] + '-' + m[2] + '-' + m[3];
+}
+
+function fmtVal(val, unit, dec) {
+	if (val == null)
+		return '-';
+
+	return val.toFixed(dec || 1) + ' ' + unit;
+}
+
+function rangeTip(lo, hi, unit, dec) {
+	if (lo == null && hi == null)
+		return '';
+
+	dec = dec || 1;
+	var l = lo != null ? lo.toFixed(dec) : '?';
+	var h = hi != null ? hi.toFixed(dec) : '?';
+
+	return _('Range') + ': ' + l + ' - ' + h + ' ' + unit;
+}
+
+return view.extend({
+	load: function() {
+		return callList();
+	},
+
+	render: function(data) {
+		var modules = Array.isArray(data) ?
+			data :
+			((data && data.result) ? data.result : []);
+
+		var tbl = E('table', { 'class': 'table cbi-section-table' }, [
+			E('tr', { 'class': 'tr cbi-section-table-titles' }, [
+				E('th', { 'class': 'th' }, _('Interface')),
+				E('th', { 'class': 'th' }, _('Vendor')),
+				E('th', { 'class': 'th' }, _('Type')),
+				E('th', { 'class': 'th' }, _('Part Number')),
+				E('th', { 'class': 'th' }, _('Date Code')),
+				E('th', { 'class': 'th' }, _('Temperature')),
+				E('th', { 'class': 'th' }, _('Voltage')),
+				E('th', { 'class': 'th' }, _('Bias Current')),
+				E('th', { 'class': 'th' }, _('TX Power')),
+				E('th', { 'class': 'th' }, _('RX Power')),
+				E('th', { 'class': 'th' }, _('Status')),
+			])
+		]);
+
+		this._populateTable(tbl, modules);
+
+		var view = E('div', {}, [
+			E('h2', {}, _('SFP / QSFP Transceiver Information')),
+			E('div', { 'class': 'cbi-section' }, [ tbl ])
+		]);
+
+		var self = this;
+		poll.add(function() {
+			return callList().then(function(res) {
+				var mods = Array.isArray(res) ?
+					res :
+					((res && res.result) ? res.result : []);
+				self._populateTable(tbl, mods);
+			});
+		}, 10);
+
+		return view;
+	},
+
+	_populateTable: function(tbl, modules) {
+		/* remove old data rows, keep header */
+		var rows = tbl.querySelectorAll('tr:not(.cbi-section-table-titles)');
+		rows.forEach(function(r) {
+			r.remove();
+		});
+
+		if (!modules.length) {
+			tbl.appendChild(E('tr', { 'class': 'tr placeholder' }, [
+				E('td', { 'class': 'td', 'colspan': '11' },
+					E('em', {},
+						_('No SFP/QSFP modules detected.')))
+			]));
+			return;
+		}
+
+		for (var i = 0; i < modules.length; i++) {
+			var row = this._renderRow(modules[i]);
+			row.classList.add('cbi-rowstyle-' + ((i % 2) ? 2 : 1));
+			tbl.appendChild(row);
+		}
+	},
+
+	_renderRow: function(mod) {
+		var d = mod.diagnostics || {};
+		var thr = mod.thresholds || {};
+
+		var type = (mod.identifier || '-');
+		if (mod.connector)
+			type += ' ' + mod.connector;
+		if (mod.transceiver_type && mod.transceiver_type.length)
+			type += ' \u00b7 ' + mod.transceiver_type.join(', ');
+
+		var statusText = statusLabel(mod.alarms, mod.warnings);
+
+		var tempTitle  = rangeTip(
+			thr.temp_low_c, thr.temp_high_c, '\u00b0C');
+		var voltTitle  = rangeTip(
+			thr.voltage_low_v, thr.voltage_high_v, 'V');
+		var biasTitle  = rangeTip(
+			thr.tx_bias_low_ma, thr.tx_bias_high_ma, 'mA');
+		var txTitle    = rangeTip(
+			mwToDbm(thr.tx_power_low_mw),
+			mwToDbm(thr.tx_power_high_mw),
+			'dBm', 2);
+		var rxTitle    = rangeTip(
+			mwToDbm(thr.rx_power_low_mw),
+			mwToDbm(thr.rx_power_high_mw),
+			'dBm', 2);
+
+		return E('tr', { 'class': 'tr' }, [
+			E('td', { 'class': 'td' }, mod.iface),
+			E('td', { 'class': 'td' }, mod.vendor_name || '-'),
+			E('td', { 'class': 'td' }, type),
+			E('td', { 'class': 'td' }, mod.vendor_pn || '-'),
+			E('td', { 'class': 'td' }, fmtDate(mod.date_code)),
+			E('td', { 'class': 'td', 'title': tempTitle },
+				fmtVal(d.temperature_c, '\u00b0C', 1)),
+			E('td', { 'class': 'td', 'title': voltTitle },
+				fmtVal(d.voltage_v, 'V', 3)),
+			E('td', { 'class': 'td', 'title': biasTitle },
+				fmtVal(d.bias_current_ma, 'mA', 1)),
+			E('td', { 'class': 'td', 'title': txTitle },
+				fmtVal(d.tx_power_dbm, 'dBm', 2)),
+			E('td', { 'class': 'td', 'title': rxTitle },
+				fmtVal(d.rx_power_dbm, 'dBm', 2)),
+			E('td', { 'class': 'td' }, statusText),
+		]);
+	},
+
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null
+});
+
+function statusLabel(alarms, warnings) {
+	var items = [];
+
+	var L = {
+		'temp_high':     _('Temperature high'),
+		'temp_low':      _('Temperature low'),
+		'voltage_high':  _('Voltage high'),
+		'voltage_low':   _('Voltage low'),
+		'tx_bias_high':  _('TX bias high'),
+		'tx_bias_low':   _('TX bias low'),
+		'tx_power_high': _('TX power high'),
+		'tx_power_low':  _('TX power low'),
+		'rx_power_high': _('RX power high'),
+		'rx_power_low':  _('RX power low')
+	};
+
+	if (alarms) {
+		for (var k in alarms) {
+			if (alarms[k])
+				items.push(E('span', { 'class': 'label notice' },
+					L[k] || k.replace(/_/g, ' ')));
+		}
+	}
+
+	if (!items.length && warnings) {
+		for (var w in warnings) {
+			if (warnings[w])
+				items.push(E('span', { 'class': 'label warning' },
+					L[w] || w.replace(/_/g, ' ')));
+		}
+	}
+
+	if (items.length)
+		return E('div', {}, items);
+
+	return E('span', { 'class': 'label success' }, _('Normal'));
+}

--- a/applications/luci-app-sfp-info/po/templates/sfp-info.pot
+++ b/applications/luci-app-sfp-info/po/templates/sfp-info.pot
@@ -1,0 +1,118 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:202
+msgid "Alarm"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:69
+msgid "Bias Current"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:66
+msgid "Date Code"
+msgstr ""
+
+#: applications/luci-app-sfp-info/root/usr/share/rpcd/acl.d/luci-app-sfp-info.json:3
+msgid "Grant ubus access to SFP Info"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:62
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:106
+msgid "No SFP/QSFP modules detected."
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:214
+msgid "Normal"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:65
+msgid "Part Number"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:181
+msgid "RX power high"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:182
+msgid "RX power low"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:71
+msgid "RX Power"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:47
+msgid "Range"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:79
+msgid "SFP / QSFP Transceiver Information"
+msgstr ""
+
+#: applications/luci-app-sfp-info/root/usr/share/luci/menu.d/luci-app-sfp-info.json:3
+msgid "SFP Info"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:72
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:177
+msgid "TX bias high"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:178
+msgid "TX bias low"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:70
+msgid "TX Power"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:179
+msgid "TX power high"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:180
+msgid "TX power low"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:173
+msgid "Temperature high"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:174
+msgid "Temperature low"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:67
+msgid "Temperature"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:64
+msgid "Type"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:63
+msgid "Vendor"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:175
+msgid "Voltage high"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:176
+msgid "Voltage low"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:68
+msgid "Voltage"
+msgstr ""
+
+#: applications/luci-app-sfp-info/htdocs/luci-static/resources/view/sfp-info/main.js:208
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-sfp-info/po/zh_Hans/sfp-info.po
+++ b/applications/luci-app-sfp-info/po/zh_Hans/sfp-info.po
@@ -1,0 +1,101 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-05-22 19:27+0800\n"
+"Last-Translator: Meng Zhuo <mengzhuo@iscas.ac.cn>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationssfp-info/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate\n"
+
+msgid "Alarm"
+msgstr "告警"
+
+msgid "Bias Current"
+msgstr "偏置电流"
+
+msgid "Date Code"
+msgstr "生产日期"
+
+msgid "Grant ubus access to SFP Info"
+msgstr "授予 ubus 访问 SFP 收发器信息的权限"
+
+msgid "Interface"
+msgstr "接口"
+
+msgid "No SFP/QSFP modules detected."
+msgstr "未检测到 SFP/QSFP 收发器。"
+
+msgid "Normal"
+msgstr "正常"
+
+msgid "Part Number"
+msgstr "型号"
+
+msgid "RX power high"
+msgstr "接收功率过高"
+
+msgid "RX power low"
+msgstr "接收功率过低"
+
+msgid "RX Power"
+msgstr "接收功率"
+
+msgid "Range"
+msgstr "范围"
+
+msgid "SFP / QSFP Transceiver Information"
+msgstr "SFP / QSFP 收发器信息"
+
+msgid "SFP Info"
+msgstr "SFP 收发器信息"
+
+msgid "Status"
+msgstr "状态"
+
+msgid "TX bias high"
+msgstr "偏置电流过高"
+
+msgid "TX bias low"
+msgstr "偏置电流过低"
+
+msgid "TX Power"
+msgstr "发送功率"
+
+msgid "TX power high"
+msgstr "发送功率过高"
+
+msgid "TX power low"
+msgstr "发送功率过低"
+
+msgid "Temperature high"
+msgstr "温度过高"
+
+msgid "Temperature low"
+msgstr "温度过低"
+
+msgid "Temperature"
+msgstr "温度"
+
+msgid "Type"
+msgstr "类型"
+
+msgid "Vendor"
+msgstr "厂商"
+
+msgid "Voltage high"
+msgstr "电压过高"
+
+msgid "Voltage low"
+msgstr "电压过低"
+
+msgid "Voltage"
+msgstr "电压"
+
+msgid "Warning"
+msgstr "警告"

--- a/applications/luci-app-sfp-info/po/zh_Hant/sfp-info.po
+++ b/applications/luci-app-sfp-info/po/zh_Hant/sfp-info.po
@@ -1,0 +1,101 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-05-22 19:27+0800\n"
+"Last-Translator: Meng Zhuo <mengzhuo@iscas.ac.cn>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationssfp-info/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate\n"
+
+msgid "Alarm"
+msgstr "警報"
+
+msgid "Bias Current"
+msgstr "偏壓電流"
+
+msgid "Date Code"
+msgstr "生產日期"
+
+msgid "Grant ubus access to SFP Info"
+msgstr "授予 ubus 存取 SFP 收發器資訊的權限"
+
+msgid "Interface"
+msgstr "介面"
+
+msgid "No SFP/QSFP modules detected."
+msgstr "未檢測到 SFP/QSFP 收發器。"
+
+msgid "Normal"
+msgstr "正常"
+
+msgid "Part Number"
+msgstr "型號"
+
+msgid "RX power high"
+msgstr "接收功率過高"
+
+msgid "RX power low"
+msgstr "接收功率過低"
+
+msgid "RX Power"
+msgstr "接收功率"
+
+msgid "Range"
+msgstr "範圍"
+
+msgid "SFP / QSFP Transceiver Information"
+msgstr "SFP / QSFP 收發器資訊"
+
+msgid "SFP Info"
+msgstr "SFP 收發器資訊"
+
+msgid "Status"
+msgstr "狀態"
+
+msgid "TX bias high"
+msgstr "偏壓電流過高"
+
+msgid "TX bias low"
+msgstr "偏壓電流過低"
+
+msgid "TX Power"
+msgstr "發送功率"
+
+msgid "TX power high"
+msgstr "發送功率過高"
+
+msgid "TX power low"
+msgstr "發送功率過低"
+
+msgid "Temperature high"
+msgstr "溫度過高"
+
+msgid "Temperature low"
+msgstr "溫度過低"
+
+msgid "Temperature"
+msgstr "溫度"
+
+msgid "Type"
+msgstr "類型"
+
+msgid "Vendor"
+msgstr "廠商"
+
+msgid "Voltage high"
+msgstr "電壓過高"
+
+msgid "Voltage low"
+msgstr "電壓過低"
+
+msgid "Voltage"
+msgstr "電壓"
+
+msgid "Warning"
+msgstr "警告"

--- a/applications/luci-app-sfp-info/root/usr/share/luci/menu.d/luci-app-sfp-info.json
+++ b/applications/luci-app-sfp-info/root/usr/share/luci/menu.d/luci-app-sfp-info.json
@@ -1,0 +1,13 @@
+{
+	"admin/status/sfp-info": {
+		"title": "SFP Info",
+		"order": 50,
+		"action": {
+			"type": "view",
+			"path": "sfp-info/main"
+		},
+		"depends": {
+			"acl": ["luci-app-sfp-info"]
+		}
+	}
+}

--- a/applications/luci-app-sfp-info/root/usr/share/rpcd/acl.d/luci-app-sfp-info.json
+++ b/applications/luci-app-sfp-info/root/usr/share/rpcd/acl.d/luci-app-sfp-info.json
@@ -1,0 +1,10 @@
+{
+	"luci-app-sfp-info": {
+		"description": "Grant ubus access to SFP Info",
+		"read": {
+			"ubus": {
+				"luci.sfp-info": ["list"]
+			}
+		}
+	}
+}

--- a/applications/luci-app-sfp-info/root/usr/share/rpcd/ucode/sfp-info.uc
+++ b/applications/luci-app-sfp-info/root/usr/share/rpcd/ucode/sfp-info.uc
@@ -1,0 +1,286 @@
+#!/usr/bin/env ucode
+'use strict';
+
+import { lsdir, popen, stat } from 'fs';
+import { log } from 'math';
+
+function run_json(cmd) {
+	let proc = popen(cmd, 'r');
+
+	if (!proc)
+		return null;
+
+	let out = proc.read('all');
+
+	proc.close();
+
+	if (!out)
+		return null;
+
+	try {
+		return json(trim(out));
+	} catch (e) {
+		return null;
+	}
+}
+
+function shellquote(s) {
+	return `'${replace(s, "'", "'\\''")}'`;
+}
+
+function mw_to_dbm(mw) {
+	if (mw == null || mw <= 0)
+		return null;
+
+	return 10 * log(mw) / log(10);
+}
+
+function parse_ethtool_json(eth_data, iface) {
+	/* ethtool --json -m outputs a JSON array with one element */
+	let data = null;
+
+	if (type(eth_data) == 'array' && length(eth_data) > 0)
+		data = eth_data[0];
+	else if (type(eth_data) == 'object')
+		data = eth_data;
+	else
+		return null;
+
+	/* must have an identifier to be a valid transceiver */
+	let identifier = data.identifier_description || null;
+
+	if (!identifier)
+		return null;
+
+	/* connector */
+	let connector = data.connector_description || null;
+
+	/* wavelength */
+	let wavelength = data.laser_wavelength != null ?
+		+data.laser_wavelength : null;
+
+	/* vendor OUI -- ethtool JSON always [byte0, byte1, byte2] */
+	let vendor_oui = type(data.vendor_oui) == 'array' ?
+		sprintf('%02x:%02x:%02x',
+			data.vendor_oui[0],
+			data.vendor_oui[1],
+			data.vendor_oui[2]) : null;
+
+	/* transceiver types -- ethtool may output a single string */
+	let transceiver_types = [];
+
+	if (data.transceiver_type)
+		push(transceiver_types, data.transceiver_type);
+
+	/* detect multi-channel (QSFP/CMIS) by array bias current */
+	let bias = data.laser_tx_bias_current;
+	let is_multi_ch = type(bias) == 'array';
+	let ch_count = is_multi_ch ? min(length(bias), 4) : 1;
+
+	let diag = {};
+
+	diag.temperature_c = data.module_temperature_measurement != null ?
+		+data.module_temperature_measurement : null;
+	diag.voltage_v = data.module_voltage_measurement != null ?
+		+data.module_voltage_measurement : null;
+
+	if (is_multi_ch) {
+		for (let ch = 0; ch < ch_count; ch++) {
+			let ci = ch + 1;
+
+			/* bias current per channel */
+			diag[`bias_current_ma_ch${ci}`] =
+				bias[ch] != null ? +bias[ch] : null;
+
+			/* TX power per channel */
+			let tx_arr = data.transmit_avg_optical_power;
+			let tx_mw = (type(tx_arr) == 'array' &&
+				tx_arr[ch] != null) ? +tx_arr[ch] : null;
+
+			diag[`tx_power_mw_ch${ci}`] = tx_mw;
+			diag[`tx_power_dbm_ch${ci}`] = mw_to_dbm(tx_mw);
+
+			/* RX power per channel -- QSFP: rx_power.values array */
+			let rx_obj = data.rx_power;
+			let rx_arr = (type(rx_obj) == 'object' &&
+				type(rx_obj.values) == 'array') ?
+				rx_obj.values : null;
+
+			let rx_mw = (rx_arr != null && rx_arr[ch] != null) ?
+				+rx_arr[ch] : null;
+
+			diag[`rx_power_mw_ch${ci}`] = rx_mw;
+			diag[`rx_power_dbm_ch${ci}`] = mw_to_dbm(rx_mw);
+		}
+
+		/* plain keys from channel 1 for table view */
+		diag.bias_current_ma = diag.bias_current_ma_ch1;
+		diag.tx_power_mw     = diag.tx_power_mw_ch1;
+		diag.tx_power_dbm    = diag.tx_power_dbm_ch1;
+		diag.rx_power_mw     = diag.rx_power_mw_ch1;
+		diag.rx_power_dbm    = diag.rx_power_dbm_ch1;
+	} else {
+		/* SFP: single-channel values */
+		diag.bias_current_ma = bias != null ? +bias : null;
+
+		let tx_val = data.transmit_avg_optical_power;
+
+		diag.tx_power_mw  = tx_val != null ? +tx_val : null;
+		diag.tx_power_dbm = mw_to_dbm(tx_val != null ? +tx_val : null);
+
+		/* SFP: rx_power is { value, type } */
+		let rx_obj = data.rx_power;
+		let rx_val = (type(rx_obj) == 'object') ? rx_obj.value : null;
+
+		diag.rx_power_mw  = rx_val != null ? +rx_val : null;
+		diag.rx_power_dbm = mw_to_dbm(rx_val != null ? +rx_val : null);
+	}
+
+	/*
+	 * Alarm / warning flags.
+	 * Ethtool JSON keys are display-names lowercased with underscores.
+	 * We map them to the short keys the frontend expects.
+	 * For QSFP, channel-level flags are arrays -- check if any channel is true.
+	 */
+	const alarm_map = {
+		'laser_bias_current_high_alarm':  'tx_bias_high',
+		'laser_output_power_high_alarm': 'tx_power_high',
+		'laser_tx_power_high_alarm':     'tx_power_high',
+		'laser_bias_current_low_alarm':   'tx_bias_low',
+		'laser_output_power_low_alarm':  'tx_power_low',
+		'laser_tx_power_low_alarm':      'tx_power_low',
+		'module_temperature_high_alarm':  'temp_high',
+		'module_temperature_low_alarm':   'temp_low',
+		'module_voltage_high_alarm':      'voltage_high',
+		'module_voltage_low_alarm':       'voltage_low',
+		'laser_rx_power_high_alarm':      'rx_power_high',
+		'laser_rx_power_low_alarm':       'rx_power_low',
+	};
+
+	const warning_map = {
+		'laser_bias_current_high_warning':  'tx_bias_high',
+		'laser_output_power_high_warning': 'tx_power_high',
+		'laser_tx_power_high_warning':     'tx_power_high',
+		'laser_bias_current_low_warning':   'tx_bias_low',
+		'laser_output_power_low_warning':  'tx_power_low',
+		'laser_tx_power_low_warning':      'tx_power_low',
+		'module_temperature_high_warning':  'temp_high',
+		'module_temperature_low_warning':   'temp_low',
+		'module_voltage_high_warning':      'voltage_high',
+		'module_voltage_low_warning':       'voltage_low',
+		'laser_rx_power_high_warning':      'rx_power_high',
+		'laser_rx_power_low_warning':       'rx_power_low',
+	};
+
+	function map_flags(src, map) {
+		let out = {};
+
+		for (let json_key, out_key in map) {
+			let val = src[json_key];
+
+			if (val == null)
+				continue;
+
+			/* arrays: any channel set -> true (QSFP channel-level) */
+			if (type(val) == 'array') {
+				let has = false;
+
+				for (let v in val) {
+					if (v) {
+						has = true;
+						break;
+					}
+				}
+
+				out[out_key] = has;
+			} else {
+				out[out_key] = !!val;
+			}
+		}
+
+		return out;
+	}
+
+	let alarms   = map_flags(data, alarm_map);
+	let warnings = map_flags(data, warning_map);
+
+	/*
+	 * Thresholds.
+	 * Ethtool JSON nests thresholds as sub-objects:
+	 * { module_temperature: { high_alarm_threshold: ... }, ... }
+	 */
+	function get_thr(obj, key) {
+		if (type(obj) != 'object')
+			return null;
+
+		return obj[key] != null ? +obj[key] : null;
+	}
+
+	let thresholds = {};
+	const thr_map = {
+		'module_temperature': { h: 'temp_high_c',       l: 'temp_low_c'       },
+		'module_voltage':     { h: 'voltage_high_v',     l: 'voltage_low_v'    },
+		'laser_bias_current': { h: 'tx_bias_high_ma',    l: 'tx_bias_low_ma'   },
+		'laser_output_power': { h: 'tx_power_high_mw',   l: 'tx_power_low_mw'  },
+		'laser_rx_power':     { h: 'rx_power_high_mw',   l: 'rx_power_low_mw'  },
+	};
+
+	for (let src_key, out_keys in thr_map) {
+		let obj = data[src_key];
+
+		if (type(obj) == 'object') {
+			thresholds[out_keys.h] = get_thr(obj, 'high_alarm_threshold');
+			thresholds[out_keys.l] = get_thr(obj, 'low_alarm_threshold');
+		}
+	}
+
+	return {
+		iface, present: true,
+		identifier, connector, wavelength,
+		vendor_name:  data.vendor_name || null,
+		vendor_oui,
+		vendor_pn:    data.vendor_pn  || null,
+		vendor_rev:   data.vendor_rev || null,
+		vendor_sn:    data.vendor_sn  || null,
+		date_code:    data.date_code  || null,
+		transceiver_type: transceiver_types,
+		diagnostics:  diag,
+		alarms, warnings, thresholds,
+	};
+}
+
+function rpc_list() {
+	let result = [];
+	let names  = lsdir('/sys/class/net/');
+
+	if (!names)
+		return { result };
+
+	for (let name in names) {
+		/* skip virtual interfaces: only physical NICs
+		 * have a /sys/class/net/<name>/device symlink */
+		if (!stat('/sys/class/net/' + name + '/device'))
+			continue;
+
+		let out = run_json(
+			'/usr/sbin/ethtool --json -m ' +
+			shellquote(name) +
+			' 2>/dev/null');
+
+		if (out) {
+			try {
+				let parsed = parse_ethtool_json(out, name);
+				if (parsed)
+					push(result, parsed);
+			} catch (e) {}
+		}
+	}
+
+	return { result };
+}
+
+const methods = {
+	list: { call: () => rpc_list() },
+};
+
+return { 'luci.sfp-info': methods };


### PR DESCRIPTION
Add a new LuCI application for visualizing SFP/QSFP optical transceiver diagnostics via ethtool -m. The dashboard auto-detects all modules on network interfaces and displays temperature, voltage, bias current, TX/RX power, alarm/warning status, module type, connector, date code and vendor information.

Supports SFF-8472 (SFP/SFP+), SFF-8636 (QSFP+/QSFP28) and CMIS (QSFP-DD/OSFP) standards.

Includes Simplified Chinese (zh_Hans) and Traditional Chinese (zh_Hant) translations.

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
