### PR TITLE
luci-base: disable CSSTIDY by default

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -310,7 +310,7 @@ ifeq ($(PKG_NAME),luci-base)
 
    config LUCI_CSSTIDY
 	bool "Minify CSS files"
-	default y
+	default n
 
    menu "Translations"$(foreach lang,$(LUCI_LANGUAGES),$(if $(LUCI_LANG.$(lang)),
 


### PR DESCRIPTION
## Pull request details

### Description
CSSTIDY 'y' default, relies on an outdated app that causes build errors. Similar to the deprecated 660-fq-codel-buffer patch, this default is also a relic from an era when SOCs had 32-64MB of memory. Modern hardware routinely has 128MB+, making this default minification unnecessary and problematic for current build environments.

- CSSTIDY is based on an old codebase that only supports CSS 2.0 and fails to properly handle features from CSS 2.1+ and CSS3. 
- It actively breaks modern CSS syntax, such as @font-face, flexbox, grid, and other advanced styling features, by misparsing or removing them during minification. 
- This limitation makes it unsuitable for modern themes and web interfaces that rely on current CSS standards. 

- The csstidy package in OpenWRT's build system attempts to fetch sources directly from GitHub during the build, even after running make download to cache dependencies. 
- This causes offline or air-gapped builds to fail, violating the expectation that make download should make the build process self-contained. 
- The issue persists in OpenWRT v23.05.2 and affects reproducible and isolated build environments. 

- CSSTIDY is no longer actively maintained, increasing the risk of unresolved bugs and security issues. 
- Modern, well-maintained alternatives like [clean-css](https://github.com/clean-css/clean-css) and [parcel-css](https://github.com/parcel-bundler/parcel-css) offer superior compression, full CSS3+ support, and active development. 
- Community discussions suggest either removing CSSTIDY from default builds or replacing it entirely with a more robust tool.

### Screenshot or video of changes _(if applicable)_
N/A - Build environment configuration change only.

### Maintainer _(preferred)_
---

## Tested on
**OpenWrt version:** N/A (Build-time configuration change)
**LuCI version:** N/A
**Web browser(s):** N/A

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile. (N/A - modification is in luci.mk core config)