### PR TITLE
luci-base: remove unnecessary constraint

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2161,11 +2161,7 @@ const CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 				}
 			}
 			else if (this.forcewrite || !isEqual(cval, fval)) {
-				/*
-				 * do not remove elements that are not rendered yet
-				 */
-				if (this.map.findElement('data-field', this.cbid(section_id)) != null)
-					return Promise.resolve(this.write(section_id, fval));
+				return Promise.resolve(this.write(section_id, fval));
 			}
 		}
 		else if (!this.retain) {


### PR DESCRIPTION
## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
This constraint didn't interfere with the clone bug(#8613) and is therefore removed.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12 <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** luci openwrt-25.12<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Firefox<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
