### PR TITLE
luci-app-tailscale: add switch DNSmode, fw set

### DIFF
--- a/applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
+++ b/applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js
@@ -24,7 +24,7 @@ const tailscaleSettingsConf = [
 	[form.Flag, 'nosnat', _('Disable SNAT'), _('Disable Source NAT (SNAT) for traffic to advertised routes. Most users should leave this unchecked.'), { rmempty: false }],
 	[form.Flag, 'shields_up', _('Shields Up'), _('When enabled, blocks all inbound connections from the Tailscale network.'), { rmempty: false }],
 	[form.Flag, 'ssh', _('Enable Tailscale SSH'), _('Allow connecting to this device through the SSH function of Tailscale.'), { rmempty: false }],
-	[form.Flag, 'disable_magic_dns', _('Disable MagicDNS'), _('Use system DNS instead of MagicDNS.'), { rmempty: false }],
+	[form.ListValue, 'dns_mode', _('DNS Mode'), _('Controls how Tailscale DNS is handled.')+'<br>'+_('Disabled: system DNS only.')+'<br>'+_('MagicDNS: Tailscale overrides resolv.conf.')+'<br>'+_('OpenWrt Forward: MagicDNS via dnsmasq forwarding.(Only support ts.net)'), { values: [['disabled', _('Disabled')], ['magicdns', 'MagicDNS'], ['openwrt_forward', _('OpenWrt Forward')]], rmempty: false }],
 	[form.Flag, 'enable_relay', _('Enable Peer Relay'), _('Enable this device as a Peer Relay server. Requires a public IP and an UDP port open on the router.'), { rmempty: false }]
 ];
 
@@ -322,10 +322,18 @@ return view.extend({
 					uci.set('tailscale', 'settings', 'shields_up', ((settings_from_rpc.shields_up || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'runwebclient', ((settings_from_rpc.runwebclient || false) ? '1' : '0'));
 					uci.set('tailscale', 'settings', 'nosnat', ((settings_from_rpc.nosnat || false) ? '1' : '0'));
-					uci.set('tailscale', 'settings', 'disable_magic_dns', ((settings_from_rpc.disable_magic_dns || false) ? '1' : '0'));
+					uci.set('tailscale', 'settings', 'dns_mode', 'disabled');
 
 					uci.set('tailscale', 'settings', 'daemon_reduce_memory', '0');
 					uci.set('tailscale', 'settings', 'daemon_mtu', '');
+					return uci.save();
+				}
+			}).then(function() {
+				// Migrate from old disable_magic_dns to dns_mode if needed
+				if (uci.get('tailscale', 'settings', 'dns_mode') === null) {
+					var oldMagicDns = uci.get('tailscale', 'settings', 'disable_magic_dns');
+					uci.set('tailscale', 'settings', 'dns_mode', oldMagicDns === '1' ? 'disabled' : 'magicdns');
+					uci.unset('tailscale', 'settings', 'disable_magic_dns');
 					return uci.save();
 				}
 			}).then(function() {
@@ -423,17 +431,17 @@ return view.extend({
 		+'<br>'+_('and enables Masquerading and MSS Clamping (MTU fix) to ensure stable connections.');
 		fwBtn.inputstyle = 'action';
 		fwBtn.onclick = function() {
-			const btn = this;
-			btn.disabled = true;
 			return callSetupFirewall().then(function(res) {
-				const msg = res?.message || _('Firewall configuration applied.');
-				ui.addNotification(null, E('p', {}, msg), 'info');
-			}).catch(function(err) {
-				ui.addNotification(null, E('p', {}, _('Failed to configure firewall: %s').format(err?.message || err || 'Unknown error')), 'error');
-			}).finally(function() {
-				btn.disabled = false;
+			const msg = res?.message || _('Firewall configuration applied.');
+			ui.addNotification(null, E('p', {}, msg), 'info');
+		}).catch(function(err) {
+			ui.addNotification(null, E('p', {}, _('Failed to configure firewall: %s').format(err?.message || err || 'Unknown error')), 'error');
+		}).then(function() {
+			return new Promise(function(resolve) {
+				window.setTimeout(resolve, 3000);
 			});
-		};
+		});
+	};
 
 		const helpTitle = s.taboption('general', form.DummyValue, '_help_title');
 		helpTitle.title = _('How to enable Site-to-Site?');
@@ -492,7 +500,7 @@ return view.extend({
 			}
 			// Display a prompt message in the new window
 			const doc = loginWindow.document;
-			doc.body.innerHTML = 
+			doc.body.innerHTML =
 				'<h2>' + _('Tailscale Login') + '</h2>' +
 				'<p>' + _('Requesting Tailscale login URL... Please wait.') + '</p>' +
 				'<p>' + _('This can take up to 30 seconds.') + '</p>';
@@ -511,7 +519,7 @@ return view.extend({
 					loginWindow.location.href = res.url;
 				} else {
 					// If it fails, inform the user and they can close the new tab
-					doc.body.innerHTML = 
+					doc.body.innerHTML =
 						'<h2>' + _('Error') + '</h2>' +
 						'<p>' + _('Failed to get login URL. You may close this tab.') + '</p>';
 					ui.addTimeLimitedNotification(null, [ E('p', _('Failed to get login URL: Invalid response from server.')) ], 7000, 'error');
@@ -526,13 +534,13 @@ return view.extend({
 			const confirmationContent = E([
 				E('p', {}, _('Are you sure you want to log out?')
 					+'<br>'+_('This will disconnect this device from your Tailnet and require you to re-authenticate.')),
-				
+
 				E('div', { 'style': 'text-align: right; margin-top: 1em;' }, [
 					E('button', {
 						'class': 'cbi-button',
 						'click': ui.hideModal
 					}, _('Cancel')),
-					' ', 
+					' ',
 					E('button', {
 						'class': 'cbi-button cbi-button-negative',
 						'click': function() {

--- a/applications/luci-app-tailscale-community/po/es/community.po
+++ b/applications/luci-app-tailscale-community/po/es/community.po
@@ -15,17 +15,17 @@ msgstr ""
 msgid "(Experimental) Reduce Memory Usage"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "1. Select \"Accept Routes\" (to access remote devices)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
 msgid ""
 "2. In \"Advertise Routes\", select your local subnet (to allow remote "
 "devices to access this LAN)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:454
 msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Accept Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
 msgid "Account Settings"
 msgstr ""
 
@@ -41,11 +41,11 @@ msgstr ""
 msgid "Advertise Exit Node"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid "Advertise Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid ""
 "Advertise subnet routes behind this device. Select from the detected subnets "
 "below or enter custom routes (comma-separated)."
@@ -67,33 +67,33 @@ msgstr ""
 msgid "Allow user access to tailscale"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:527
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
 msgid "Are you sure you want to log out?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
 msgid "Auto Configure Firewall"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:534
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:542
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
 msgid "Click to Log out account on this device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:457
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
 msgid "Click to get a login URL for this device."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:167
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:244
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:367
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:375
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:553
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:561
 msgid "Confirm Logout"
 msgstr ""
 
@@ -101,30 +101,34 @@ msgstr ""
 msgid "Connection Info"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
 msgid "Custom Login Server"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid "Custom Login Server Auth Key"
 msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr "Modo DNS"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:21
 msgid "Declare this device as an Exit Node."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:556
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:564
 msgid "Devices List"
-msgstr ""
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
@@ -137,11 +141,16 @@ msgid ""
 "should leave this unchecked."
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Disabled: system DNS only."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr ""
 
@@ -183,7 +192,7 @@ msgid ""
 "performance (set GOGC=10)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:523
 msgid "Error"
 msgstr ""
 
@@ -199,14 +208,14 @@ msgstr ""
 msgid "Error reading cached DERP region map: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:421
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
 msgid ""
 "Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
 "features."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid "Exit Node"
 msgstr ""
 
@@ -215,19 +224,19 @@ msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:438
 msgid "Failed to configure firewall: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:524
 msgid "Failed to get login URL. You may close this tab."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
 msgid "Failed to get login URL: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:517
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
 msgid "Failed to get login URL: Invalid response from server."
 msgstr ""
 
@@ -235,11 +244,11 @@ msgstr ""
 msgid "Firewall Mode"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
 msgid "Firewall configuration applied."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:384
 msgid "General Settings"
 msgstr ""
 
@@ -247,16 +256,16 @@ msgstr ""
 msgid "Hostname"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:439
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
 msgid "How to enable Site-to-Site?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:480
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -266,7 +275,7 @@ msgstr ""
 msgid "Invalid Date"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:430
 msgid ""
 "It automatically creates the tailscale interface, sets up firewall zones for "
 "LAN <-> Tailscale forwarding,"
@@ -284,25 +293,29 @@ msgstr ""
 msgid "Last Seen"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
 msgid "Leave blank for default Tailscale control plane."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Logging out..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:456
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
 msgid "Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:477
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:550
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
 msgid "Logout"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Logout failed: %s"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "MagicDNS: Tailscale overrides resolv.conf."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
@@ -317,7 +330,7 @@ msgstr ""
 msgid "No peer devices found."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:397
 msgid "None"
 msgstr ""
 
@@ -337,19 +350,27 @@ msgstr ""
 msgid "Online"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:463
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr "Reenvío OpenWrt"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward: MagicDNS via dnsmasq forwarding.(Only support ts.net)"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "%s)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:380
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
 msgid "Peer Relay Port"
 msgstr ""
 
@@ -357,9 +378,9 @@ msgstr ""
 msgid "Please use the login button in the settings below to authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Please wait."
 msgstr ""
 
@@ -371,16 +392,16 @@ msgstr ""
 msgid "RX"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
 msgid "Requesting Login URL..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:497
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid ""
 "Select an exit node from the list. If enabled, Allow LAN Access is enabled "
 "implicitly."
@@ -407,7 +428,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:544
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:552
 msgid "Successfully logged out."
 msgstr ""
 
@@ -427,7 +448,7 @@ msgstr ""
 msgid "Tailnet Name"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 #: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
 msgid "Tailscale"
 msgstr ""
@@ -448,11 +469,11 @@ msgstr ""
 msgid "Tailscale IPv6"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
 msgid "Tailscale Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 msgid ""
 "Tailscale is a mesh VPN solution that makes it easy to connect your devices "
 "securely. This configuration page allows you to manage Tailscale settings on "
@@ -463,17 +484,17 @@ msgstr ""
 msgid "Tailscale status error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
 msgid "This can take up to 30 seconds."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:536
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:381
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
 msgid ""
 "UDP port for the Peer Relay service. Open this port on your router firewall/"
 "NAT."
@@ -482,13 +503,9 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Unknown error"
-msgstr ""
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
@@ -504,7 +521,7 @@ msgstr ""
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:455
 msgid ""
 "[Important] Log in to the Tailscale admin console and manually enable "
 "\"Subnet Routes\" for this device."
@@ -514,7 +531,7 @@ msgstr ""
 msgid "ago"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:423
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:431
 msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."

--- a/applications/luci-app-tailscale-community/po/templates/community.pot
+++ b/applications/luci-app-tailscale-community/po/templates/community.pot
@@ -5,17 +5,17 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "(Experimental) Reduce Memory Usage"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "1. Select \"Accept Routes\" (to access remote devices)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
 msgid ""
 "2. In \"Advertise Routes\", select your local subnet (to allow remote "
 "devices to access this LAN)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:454
 msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
 msgstr ""
 
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Accept Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
 msgid "Account Settings"
 msgstr ""
 
@@ -31,11 +31,11 @@ msgstr ""
 msgid "Advertise Exit Node"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid "Advertise Routes"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid ""
 "Advertise subnet routes behind this device. Select from the detected subnets "
 "below or enter custom routes (comma-separated)."
@@ -57,33 +57,33 @@ msgstr ""
 msgid "Allow user access to tailscale"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:527
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
 msgid "Are you sure you want to log out?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
 msgid "Auto Configure Firewall"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:534
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:542
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
 msgid "Click to Log out account on this device."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:457
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
 msgid "Click to get a login URL for this device."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:167
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:244
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:367
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:375
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:553
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:561
 msgid "Confirm Logout"
 msgstr ""
 
@@ -91,30 +91,34 @@ msgstr ""
 msgid "Connection Info"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
 msgid "Custom Login Server"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid "Custom Login Server Auth Key"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:21
 msgid "Declare this device as an Exit Node."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:556
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:564
 msgid "Devices List"
-msgstr ""
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
@@ -127,11 +131,16 @@ msgid ""
 "should leave this unchecked."
 msgstr ""
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Disabled: system DNS only."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr ""
 
@@ -173,7 +182,7 @@ msgid ""
 "performance (set GOGC=10)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:523
 msgid "Error"
 msgstr ""
 
@@ -189,14 +198,14 @@ msgstr ""
 msgid "Error reading cached DERP region map: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:421
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
 msgid ""
 "Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
 "features."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid "Exit Node"
 msgstr ""
 
@@ -205,19 +214,19 @@ msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:438
 msgid "Failed to configure firewall: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:524
 msgid "Failed to get login URL. You may close this tab."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
 msgid "Failed to get login URL: %s"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:517
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
 msgid "Failed to get login URL: Invalid response from server."
 msgstr ""
 
@@ -225,11 +234,11 @@ msgstr ""
 msgid "Firewall Mode"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
 msgid "Firewall configuration applied."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:384
 msgid "General Settings"
 msgstr ""
 
@@ -237,16 +246,16 @@ msgstr ""
 msgid "Hostname"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:439
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
 msgid "How to enable Site-to-Site?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:480
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -256,7 +265,7 @@ msgstr ""
 msgid "Invalid Date"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:430
 msgid ""
 "It automatically creates the tailscale interface, sets up firewall zones for "
 "LAN <-> Tailscale forwarding,"
@@ -274,25 +283,29 @@ msgstr ""
 msgid "Last Seen"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
 msgid "Leave blank for default Tailscale control plane."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Logging out..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:456
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
 msgid "Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:477
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:550
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
 msgid "Logout"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Logout failed: %s"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "MagicDNS: Tailscale overrides resolv.conf."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
@@ -307,7 +320,7 @@ msgstr ""
 msgid "No peer devices found."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:397
 msgid "None"
 msgstr ""
 
@@ -327,19 +340,27 @@ msgstr ""
 msgid "Online"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:463
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward: MagicDNS via dnsmasq forwarding.(Only support ts.net)"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "%s)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:380
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
 msgid "Peer Relay Port"
 msgstr ""
 
@@ -347,9 +368,9 @@ msgstr ""
 msgid "Please use the login button in the settings below to authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Please wait."
 msgstr ""
 
@@ -361,16 +382,16 @@ msgstr ""
 msgid "RX"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
 msgid "Requesting Login URL..."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:497
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid ""
 "Select an exit node from the list. If enabled, Allow LAN Access is enabled "
 "implicitly."
@@ -397,7 +418,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:544
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:552
 msgid "Successfully logged out."
 msgstr ""
 
@@ -417,7 +438,7 @@ msgstr ""
 msgid "Tailnet Name"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 #: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
 msgid "Tailscale"
 msgstr ""
@@ -438,11 +459,11 @@ msgstr ""
 msgid "Tailscale IPv6"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
 msgid "Tailscale Login"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 msgid ""
 "Tailscale is a mesh VPN solution that makes it easy to connect your devices "
 "securely. This configuration page allows you to manage Tailscale settings on "
@@ -453,17 +474,17 @@ msgstr ""
 msgid "Tailscale status error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
 msgid "This can take up to 30 seconds."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:536
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:381
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
 msgid ""
 "UDP port for the Peer Relay service. Open this port on your router firewall/"
 "NAT."
@@ -472,13 +493,9 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Unknown error"
-msgstr ""
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
 msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
@@ -494,7 +511,7 @@ msgstr ""
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:455
 msgid ""
 "[Important] Log in to the Tailscale admin console and manually enable "
 "\"Subnet Routes\" for this device."
@@ -504,7 +521,7 @@ msgstr ""
 msgid "ago"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:423
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:431
 msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."

--- a/applications/luci-app-tailscale-community/po/zh_Hans/community.po
+++ b/applications/luci-app-tailscale-community/po/zh_Hans/community.po
@@ -5,17 +5,17 @@ msgstr "Content-Type: text/plain; charset=UTF-8\n"
 msgid "(Experimental) Reduce Memory Usage"
 msgstr "(实验性) 减少内存使用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "1. Select \"Accept Routes\" (to access remote devices)."
 msgstr "1. 勾选 接受路由 (接受远程设备访问)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
 msgid ""
 "2. In \"Advertise Routes\", select your local subnet (to allow remote "
 "devices to access this LAN)."
 msgstr "2. 在 通告路由 选择本设备的局域网段 (让远程设备能访问你)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:454
 msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
 msgstr "3. 点击 自动配置防火墙 (打通防火墙转发)。"
 
@@ -23,7 +23,7 @@ msgstr "3. 点击 自动配置防火墙 (打通防火墙转发)。"
 msgid "Accept Routes"
 msgstr "接受路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
 msgid "Account Settings"
 msgstr "账户设置"
 
@@ -31,11 +31,11 @@ msgstr "账户设置"
 msgid "Advertise Exit Node"
 msgstr "通告出口节点"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid "Advertise Routes"
 msgstr "通告路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid ""
 "Advertise subnet routes behind this device. Select from the detected subnets "
 "below or enter custom routes (comma-separated)."
@@ -58,33 +58,33 @@ msgstr "允许通过 Tailscale 的 SSH 功能连接到此设备。"
 msgid "Allow user access to tailscale"
 msgstr "允许用户访问 Tailscale"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:527
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
 msgid "Are you sure you want to log out?"
 msgstr "您确定要登出吗？"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
 msgid "Auto Configure Firewall"
 msgstr "自动配置防火墙"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:534
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:542
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
 msgid "Click to Log out account on this device."
 msgstr "点击以登出此设备上的账户。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:457
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
 msgid "Click to get a login URL for this device."
 msgstr "点击获取此设备的登录 URL。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:167
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:244
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:367
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:375
 msgid "Collecting data ..."
 msgstr "正在收集数据..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:553
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:561
 msgid "Confirm Logout"
 msgstr "确认登出"
 
@@ -92,31 +92,35 @@ msgstr "确认登出"
 msgid "Connection Info"
 msgstr "连接信息"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr "无法打开新标签页。请检查您的浏览器或扩展程序是否阻止了弹出窗口。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
 msgid "Custom Login Server"
 msgstr "自定义登录服务器"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid "Custom Login Server Auth Key"
 msgstr "自定义登录服务器认证密钥"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr "DNS 模式"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:21
 msgid "Declare this device as an Exit Node."
 msgstr "将此设备声明为出口节点。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:556
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:564
 msgid "Devices List"
 msgstr "设备列表"
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
-msgstr "禁用 MagicDNS"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
 msgid "Disable SNAT"
@@ -128,11 +132,16 @@ msgid ""
 "should leave this unchecked."
 msgstr "为通告路由的流量禁用源地址转换 (SNAT)。大多数用户应保持此项不勾选。"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
 msgstr "已禁用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Disabled: system DNS only."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr "从 Tailscale 断开连接并使当前节点密钥过期。"
 
@@ -176,7 +185,7 @@ msgid ""
 "performance (set GOGC=10)."
 msgstr "启用此选项可以减少内存使用，但可能会牺牲一些性能 (设置 GOGC=10)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:523
 msgid "Error"
 msgstr "错误"
 
@@ -192,14 +201,14 @@ msgstr "获取 DERP 区域地图时出错: %s"
 msgid "Error reading cached DERP region map: %s"
 msgstr "读取缓存的 DERP 区域地图时出错: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:421
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
 msgid ""
 "Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
 "features."
 msgstr "子网路由（局域网间互通）和出口节点的基本配置。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid "Exit Node"
 msgstr "出口节点"
 
@@ -208,19 +217,19 @@ msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr "在端口 5252 上暴露一个 Web 界面，用于通过 Tailscale 管理此节点。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:438
 msgid "Failed to configure firewall: %s"
 msgstr "获取防火墙设置失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:524
 msgid "Failed to get login URL. You may close this tab."
 msgstr "获取登录 URL 失败。您可以关闭此标签页。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
 msgid "Failed to get login URL: %s"
 msgstr "获取登录 URL 失败: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:517
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
 msgid "Failed to get login URL: Invalid response from server."
 msgstr "获取登录 URL 失败: 服务器响应无效。"
 
@@ -228,11 +237,11 @@ msgstr "获取登录 URL 失败: 服务器响应无效。"
 msgid "Firewall Mode"
 msgstr "防火墙模式"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
 msgid "Firewall configuration applied."
 msgstr "已应用防火墙配置"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:384
 msgid "General Settings"
 msgstr "常规设置"
 
@@ -240,16 +249,16 @@ msgstr "常规设置"
 msgid "Hostname"
 msgstr "主机名"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:439
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
 msgid "How to enable Site-to-Site?"
 msgstr "如何实现站点到站点（即多局域网互通）？"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr "如果显示超时，您可以刷新页面并再次点击登录。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:480
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -261,7 +270,7 @@ msgstr ""
 msgid "Invalid Date"
 msgstr "无效日期"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:430
 msgid ""
 "It automatically creates the tailscale interface, sets up firewall zones for "
 "LAN <-> Tailscale forwarding,"
@@ -279,26 +288,30 @@ msgstr "已登出"
 msgid "Last Seen"
 msgstr "上次在线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
 msgid "Leave blank for default Tailscale control plane."
 msgstr "留空以使用默认的 Tailscale 控制平面。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Logging out..."
 msgstr "正在登出..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:456
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
 msgid "Login"
 msgstr "登录"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:477
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:550
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
 msgid "Logout"
 msgstr "登出"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Logout failed: %s"
 msgstr "登出失败: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "MagicDNS: Tailscale overrides resolv.conf."
+msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
 msgid "N/A"
@@ -312,7 +325,7 @@ msgstr "未运行"
 msgid "No peer devices found."
 msgstr "未找到节点设备。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:397
 msgid "None"
 msgstr "无"
 
@@ -332,19 +345,27 @@ msgstr "离线"
 msgid "Online"
 msgstr "在线"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:463
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr "OpenWrt 转发"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward: MagicDNS via dnsmasq forwarding.(Only support ts.net)"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "%s)."
 msgstr "可选：指定一个自定义控制服务器 URL (例如，一个 Headscale 实例, %s)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
 msgstr "可选：为自定义控制服务器指定一个认证密钥。如果不需要，请留空。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:380
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
 msgid "Peer Relay Port"
 msgstr "DERP端口"
 
@@ -352,9 +373,9 @@ msgstr "DERP端口"
 msgid "Please use the login button in the settings below to authenticate."
 msgstr "请使用下方设置中的登录按钮进行认证。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Please wait."
 msgstr "请稍候。"
 
@@ -366,16 +387,16 @@ msgstr "正在运行"
 msgid "RX"
 msgstr "接收"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
 msgid "Requesting Login URL..."
 msgstr "正在请求登录 URL..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:497
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr "正在请求 Tailscale 登录 URL... 请稍候。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid ""
 "Select an exit node from the list. If enabled, Allow LAN Access is enabled "
 "implicitly."
@@ -402,7 +423,7 @@ msgstr "开启防护 (Shields Up)"
 msgid "Status"
 msgstr "状态"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:544
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:552
 msgid "Successfully logged out."
 msgstr "登出成功。"
 
@@ -422,7 +443,7 @@ msgstr "发送"
 msgid "Tailnet Name"
 msgstr "Tailnet 名称"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 #: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
 msgid "Tailscale"
 msgstr "Tailscale"
@@ -443,11 +464,11 @@ msgstr "Tailscale IPv4"
 msgid "Tailscale IPv6"
 msgstr "Tailscale IPv6"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
 msgid "Tailscale Login"
 msgstr "Tailscale 登录"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 msgid ""
 "Tailscale is a mesh VPN solution that makes it easy to connect your devices "
 "securely. This configuration page allows you to manage Tailscale settings on "
@@ -460,17 +481,17 @@ msgstr ""
 msgid "Tailscale status error"
 msgstr "Tailscale 状态异常"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
 msgid "This can take up to 30 seconds."
 msgstr "此过程最多可能需要 30 秒。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:536
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
 msgstr "这将使此设备从您的 Tailnet 断开连接，并需要您重新进行身份验证。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:381
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
 msgid ""
 "UDP port for the Peer Relay service. Open this port on your router firewall/"
 "NAT."
@@ -479,14 +500,10 @@ msgstr "DERP的UDP端口号。需要在防火墙/NAT规则中开放该端口。"
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Unknown error"
 msgstr "未知错误"
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
-msgstr "使用系统 DNS 而不是 MagicDNS。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"
@@ -501,7 +518,7 @@ msgstr "启用后，将阻止来自 Tailscale 网络的所有入站连接。"
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr "使用出口节点时，允许访问本地局域网。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:455
 msgid ""
 "[Important] Log in to the Tailscale admin console and manually enable "
 "\"Subnet Routes\" for this device."
@@ -511,7 +528,7 @@ msgstr "【重要】 登录 Tailscale 控制平面，在设备设置中手动授
 msgid "ago"
 msgstr "前"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:423
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:431
 msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."

--- a/applications/luci-app-tailscale-community/po/zh_Hant/community.po
+++ b/applications/luci-app-tailscale-community/po/zh_Hant/community.po
@@ -5,17 +5,17 @@ msgstr "Content-Type: text/plain; charset=UTF-8\n"
 msgid "(Experimental) Reduce Memory Usage"
 msgstr "(實驗性) 減少記憶體使用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
 msgid "1. Select \"Accept Routes\" (to access remote devices)."
 msgstr "1. 勾選 接受路由 (接受遠端裝置訪問)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
 msgid ""
 "2. In \"Advertise Routes\", select your local subnet (to allow remote "
 "devices to access this LAN)."
 msgstr "2. 在 通告路由 選擇本裝置的區域網段 (讓遠端裝置能訪問你)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:454
 msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
 msgstr "3. 點選 自動配置防火牆 (打通防火牆轉發)。"
 
@@ -23,7 +23,7 @@ msgstr "3. 點選 自動配置防火牆 (打通防火牆轉發)。"
 msgid "Accept Routes"
 msgstr "接受路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:453
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:461
 msgid "Account Settings"
 msgstr "賬戶設定"
 
@@ -31,11 +31,11 @@ msgstr "賬戶設定"
 msgid "Advertise Exit Node"
 msgstr "通告出口節點"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid "Advertise Routes"
 msgstr "通告路由"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:412
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
 msgid ""
 "Advertise subnet routes behind this device. Select from the detected subnets "
 "below or enter custom routes (comma-separated)."
@@ -58,33 +58,33 @@ msgstr "允許透過 Tailscale 的 SSH 功能連線到此裝置。"
 msgid "Allow user access to tailscale"
 msgstr "允許使用者訪問 Tailscale"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:527
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
 msgid "Are you sure you want to log out?"
 msgstr "您確定要登出嗎？"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:428
 msgid "Auto Configure Firewall"
 msgstr "自動配置防火牆"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:534
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:542
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
 msgid "Click to Log out account on this device."
 msgstr "點選以登出此裝置上的賬戶。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:457
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
 msgid "Click to get a login URL for this device."
 msgstr "點選獲取此裝置的登入 URL。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:167
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:244
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:367
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:375
 msgid "Collecting data ..."
 msgstr "正在收集資料..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:553
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:561
 msgid "Confirm Logout"
 msgstr "確認登出"
 
@@ -92,31 +92,35 @@ msgstr "確認登出"
 msgid "Connection Info"
 msgstr "連線資訊"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:490
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Controls how Tailscale DNS is handled."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
 msgid ""
 "Could not open a new tab. Please check if your browser or an extension "
 "blocked the pop-up."
 msgstr "無法開啟新標籤頁。請檢查您的瀏覽器或擴充套件程式是否阻止了彈出視窗。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:462
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
 msgid "Custom Login Server"
 msgstr "自定義登入伺服器"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:470
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
 msgid "Custom Login Server Auth Key"
 msgstr "自定義登入伺服器認證金鑰"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "DNS Mode"
+msgstr "DNS 模式"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:21
 msgid "Declare this device as an Exit Node."
 msgstr "將此裝置宣告為出口節點。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:556
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:564
 msgid "Devices List"
 msgstr ""
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Disable MagicDNS"
-msgstr "停用 MagicDNS"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
 msgid "Disable SNAT"
@@ -128,11 +132,16 @@ msgid ""
 "should leave this unchecked."
 msgstr "為通告路由的流量停用源地址轉換 (SNAT)。大多數使用者應保持此項不勾選。"
 
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
 msgid "Disabled"
 msgstr "已停用"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Disabled: system DNS only."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:487
 msgid "Disconnect from Tailscale and expire current node key."
 msgstr "從 Tailscale 斷開連線並使當前節點金鑰過期。"
 
@@ -174,7 +183,7 @@ msgid ""
 "performance (set GOGC=10)."
 msgstr "啟用此選項可以減少記憶體使用，但可能會犧牲一些效能 (設定 GOGC=10)。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:523
 msgid "Error"
 msgstr "錯誤"
 
@@ -190,14 +199,14 @@ msgstr "獲取 DERP 區域地圖時出錯: %s"
 msgid "Error reading cached DERP region map: %s"
 msgstr "讀取快取的 DERP 區域地圖時出錯: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:421
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
 msgid ""
 "Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
 "features."
 msgstr "子網路由和出口節點的基本配置。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:287
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid "Exit Node"
 msgstr "出口節點"
 
@@ -206,19 +215,19 @@ msgid ""
 "Expose a web interface on port 5252 for managing this node over Tailscale."
 msgstr "在埠 5252 上暴露一個 Web 介面，用於透過 Tailscale 管理此節點。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:438
 msgid "Failed to configure firewall: %s"
 msgstr "獲取防火牆設定失敗: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:524
 msgid "Failed to get login URL. You may close this tab."
 msgstr "獲取登入 URL 失敗。您可以關閉此標籤頁。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
 msgid "Failed to get login URL: %s"
 msgstr "獲取登入 URL 失敗: %s"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:517
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:525
 msgid "Failed to get login URL: Invalid response from server."
 msgstr "獲取登入 URL 失敗: 伺服器響應無效。"
 
@@ -226,11 +235,11 @@ msgstr "獲取登入 URL 失敗: 伺服器響應無效。"
 msgid "Firewall Mode"
 msgstr "防火牆模式"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:429
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
 msgid "Firewall configuration applied."
 msgstr "已應用防火牆配置"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:384
 msgid "General Settings"
 msgstr "常規設定"
 
@@ -238,16 +247,16 @@ msgstr "常規設定"
 msgid "Hostname"
 msgstr "主機名"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:439
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
 msgid "How to enable Site-to-Site?"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
 msgid ""
 "If the timeout is displayed, you can refresh the page and click Login again."
 msgstr "如果顯示超時，您可以重新整理頁面並再次點選登入。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:480
 msgid ""
 "If you are using custom login server but not providing an Auth Key, will "
 "redirect to the login page without pre-filling the key."
@@ -259,7 +268,7 @@ msgstr ""
 msgid "Invalid Date"
 msgstr "無效日期"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:422
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:430
 msgid ""
 "It automatically creates the tailscale interface, sets up firewall zones for "
 "LAN <-> Tailscale forwarding,"
@@ -279,26 +288,30 @@ msgstr "已登出"
 msgid "Last Seen"
 msgstr "上次線上"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:472
 msgid "Leave blank for default Tailscale control plane."
 msgstr "留空以使用預設的 Tailscale 控制平面。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Logging out..."
 msgstr "正在登出..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:456
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:464
 msgid "Login"
 msgstr "登入"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:477
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:550
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:558
 msgid "Logout"
 msgstr "登出"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Logout failed: %s"
 msgstr "登出失敗: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "MagicDNS: Tailscale overrides resolv.conf."
+msgstr ""
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
 msgid "N/A"
@@ -312,7 +325,7 @@ msgstr "未執行"
 msgid "No peer devices found."
 msgstr "未找到對等裝置。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:397
 msgid "None"
 msgstr ""
 
@@ -332,19 +345,27 @@ msgstr "離線"
 msgid "Online"
 msgstr "線上"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:463
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward"
+msgstr "OpenWrt 轉發"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "OpenWrt Forward: MagicDNS via dnsmasq forwarding.(Only support ts.net)"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
 msgid ""
 "Optional: Specify a custom control server URL (e.g., a Headscale instance, "
 "%s)."
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:471
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:479
 msgid ""
 "Optional: Specify an authentication key for the custom control server. Leave "
 "blank if not required."
 msgstr "可選：為自定義控制伺服器指定一個認證金鑰。如果不需要，請留空。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:380
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
 msgid "Peer Relay Port"
 msgstr ""
 
@@ -352,9 +373,9 @@ msgstr ""
 msgid "Please use the login button in the settings below to authenticate."
 msgstr "請使用下方設定中的登入按鈕進行認證。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:540
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:548
 msgid "Please wait."
 msgstr "請稍候。"
 
@@ -366,16 +387,16 @@ msgstr "正在執行"
 msgid "RX"
 msgstr "接收"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:500
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:508
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:514
 msgid "Requesting Login URL..."
 msgstr "正在請求登入 URL..."
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:497
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
 msgid "Requesting Tailscale login URL... Please wait."
 msgstr "正在請求 Tailscale 登入 URL... 請稍候。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:388
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:396
 msgid ""
 "Select an exit node from the list. If enabled, Allow LAN Access is enabled "
 "implicitly."
@@ -402,7 +423,7 @@ msgstr "開啟防護 (Shields Up)"
 msgid "Status"
 msgstr "狀態"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:544
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:552
 msgid "Successfully logged out."
 msgstr "登出成功。"
 
@@ -422,7 +443,7 @@ msgstr "傳送"
 msgid "Tailnet Name"
 msgstr "Tailnet 名稱"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 #: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
 msgid "Tailscale"
 msgstr "Tailscale"
@@ -443,11 +464,11 @@ msgstr "Tailscale IPv4"
 msgid "Tailscale IPv6"
 msgstr "Tailscale IPv6"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:496
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
 msgid "Tailscale Login"
 msgstr "Tailscale 登入"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:341
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:349
 msgid ""
 "Tailscale is a mesh VPN solution that makes it easy to connect your devices "
 "securely. This configuration page allows you to manage Tailscale settings on "
@@ -460,17 +481,17 @@ msgstr ""
 msgid "Tailscale status error"
 msgstr ""
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:498
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:506
 msgid "This can take up to 30 seconds."
 msgstr "此過程最多可能需要 30 秒。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:536
 msgid ""
 "This will disconnect this device from your Tailnet and require you to re-"
 "authenticate."
 msgstr "這將使此裝置從您的 Tailnet 斷開連線，並需要您重新進行身份驗證。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:381
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:389
 msgid ""
 "UDP port for the Peer Relay service. Open this port on your router firewall/"
 "NAT."
@@ -479,14 +500,10 @@ msgstr ""
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:121
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:148
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:151
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:521
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:547
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:529
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:555
 msgid "Unknown error"
 msgstr "未知錯誤"
-
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
-msgid "Use system DNS instead of MagicDNS."
-msgstr "使用系統 DNS 而不是 MagicDNS。"
 
 #: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
 msgid "Version"
@@ -501,7 +518,7 @@ msgstr "啟用後，將阻止來自 Tailscale 網路的所有入站連線。"
 msgid "When using the exit node, access to the local LAN is allowed."
 msgstr "使用出口節點時，允許訪問本地區域網。"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:447
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:455
 msgid ""
 "[Important] Log in to the Tailscale admin console and manually enable "
 "\"Subnet Routes\" for this device."
@@ -511,7 +528,7 @@ msgstr "【重要】 登入 Tailscale 控制平面，在裝置設定中手動授
 msgid "ago"
 msgstr "前"
 
-#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:423
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:431
 msgid ""
 "and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
 "connections."

--- a/applications/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
+++ b/applications/luci-app-tailscale-community/root/etc/init.d/tailscale-settings
@@ -21,6 +21,51 @@ version_gte() {
 	return $?
 }
 
+# Add/remove DNS forward entry in dnsmasq for MagicDNS via OpenWrt
+setup_tailscale_dns_forward() {
+	if [ ! -x /usr/sbin/tailscale ] && [ ! -x /usr/bin/tailscale ]; then
+		return 0
+	fi
+
+	local entry="/.ts.net/100.100.100.100"
+	local found=0
+
+	# Check if entry already exists in dnsmasq
+	if uci -q show dhcp.@dnsmasq[0].server 2>/dev/null | grep -Fqx "dhcp.@dnsmasq[0].server='$entry'"; then
+		found=1
+	fi
+
+	if [ "$found" = "0" ]; then
+		uci add_list dhcp.@dnsmasq[0].server="$entry"
+		uci commit dhcp
+		/etc/init.d/dnsmasq reload 2>/dev/null || /etc/init.d/dnsmasq restart 2>/dev/null
+		logger -t "$NAME" "Added DNS forward: $entry"
+	fi
+}
+
+remove_tailscale_dns_forward() {
+	local entry="/.ts.net/100.100.100.100"
+	local idx=0
+	local removed=0
+	while true; do
+		local val
+		val=$(uci -q get dhcp.@dnsmasq[0].server."${idx}" 2>/dev/null)
+		[ -z "$val" ] && break
+		if [ "$val" = "$entry" ]; then
+			uci -q del_list dhcp.@dnsmasq[0].server="$entry"
+			removed=1
+			break
+		fi
+		idx=$((idx + 1))
+	done
+
+	if [ "$removed" = "1" ]; then
+		uci commit dhcp
+		/etc/init.d/dnsmasq reload 2>/dev/null || /etc/init.d/dnsmasq restart 2>/dev/null
+		logger -t "$NAME" "Removed Tailscale DNS forward entry: $entry"
+	fi
+}
+
 apply_settings() {
 	local ts_bin
 	if [ -x /usr/sbin/tailscale ]; then
@@ -35,7 +80,7 @@ apply_settings() {
 	config_load tailscale
 
 	local accept_routes advertise_exit_node exit_node exit_node_allow_lan_access
-	local ssh disable_magic_dns shields_up runwebclient nosnat hostname
+	local ssh shields_up runwebclient nosnat hostname
 	local enable_relay relay_server_port
 
 	config_get accept_routes              settings accept_routes              '0'
@@ -43,7 +88,7 @@ apply_settings() {
 	config_get exit_node                  settings exit_node                  ''
 	config_get exit_node_allow_lan_access settings exit_node_allow_lan_access '0'
 	config_get ssh                        settings ssh                        '0'
-	config_get disable_magic_dns          settings disable_magic_dns          '0'
+	config_get dns_mode                   settings dns_mode                   'disabled'
 	config_get shields_up                 settings shields_up                 '0'
 	config_get runwebclient               settings runwebclient               '0'
 	config_get nosnat                     settings nosnat                     '0'
@@ -89,10 +134,22 @@ apply_settings() {
 		&& set -- "$@" --ssh=true \
 		|| set -- "$@" --ssh=false
 
-	# --accept-dns (inverse of disable_magic_dns)
-	[ "$disable_magic_dns" = "1" ] \
-		&& set -- "$@" --accept-dns=false \
-		|| set -- "$@" --accept-dns=true
+	# --accept-dns based on dns_mode
+	case "$dns_mode" in
+		magicdns)
+			set -- "$@" --accept-dns=true
+			remove_tailscale_dns_forward
+			;;
+		openwrt_forward)
+			set -- "$@" --accept-dns=false
+			setup_tailscale_dns_forward
+			;;
+		*)
+			# disabled (default)
+			set -- "$@" --accept-dns=false
+			remove_tailscale_dns_forward
+			;;
+	esac
 
 	# --shields-up
 	[ "$shields_up" = "1" ] \

--- a/applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json
+++ b/applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json
@@ -1,5 +1,5 @@
 {
-	"admin/services/tailscale": {
+	"admin/vpn/tailscale": {
 		"title": "Tailscale",
 		"order": 90,
 		"action": {

--- a/applications/luci-app-tailscale-community/root/usr/share/rpcd/ucode/tailscale.uc
+++ b/applications/luci-app-tailscale-community/root/usr/share/rpcd/ucode/tailscale.uc
@@ -123,7 +123,7 @@ methods.get_settings = {
 					settings.ssh = status_data?.RunSSH || false;
 					settings.runwebclient = status_data?.RunWebClient || false;
 					settings.nosnat = status_data?.NoSNAT || false;
-					settings.disable_magic_dns = !status_data?.CorpDNS || false;
+					settings.dns_mode = uci.get('tailscale', 'settings', 'dns_mode') || 'disabled';
 					settings.fw_mode = split(uci.get('tailscale', 'settings', 'fw_mode'),' ')[0] || 'nftables';
 				}
 				}
@@ -254,21 +254,18 @@ methods.setup_firewall = {
 			}
 
 			// 2. config Firewall Zone
-			let fw_all = uci.get_all('firewall');
 			let ts_zone_section = null;
 			let fwd_lan_to_ts = false;
 			let fwd_ts_to_lan = false;
 
-			for (let sec_key in fw_all) {
-				let s = fw_all[sec_key];
-				if (s['.type'] == 'zone' && s['name'] == 'tailscale') {
-					ts_zone_section = sec_key;
-				}
-				if (s['.type'] == 'forwarding') {
-					if (s.src == 'lan' && s.dest == 'tailscale') fwd_lan_to_ts = true;
-					if (s.src == 'tailscale' && s.dest == 'lan') fwd_ts_to_lan = true;
-				}
-			}
+			uci.foreach('firewall', 'zone', function(s) {
+				if (s['name'] == 'tailscale')
+				ts_zone_section = s['.name'];
+				});
+				uci.foreach('firewall', 'forwarding', function(s) {
+					if (s['src'] == 'lan' && s['dest'] == 'tailscale') fwd_lan_to_ts = true;
+					if (s['src'] == 'tailscale' && s['dest'] == 'lan') fwd_ts_to_lan = true;
+				});
 
 			if (ts_zone_section == null) {
 				let zid = uci.add('firewall', 'zone');
@@ -293,7 +290,7 @@ methods.setup_firewall = {
 
 				// check if 'tailscale' is already in the list
 				for (let n in net_list) {
-					if (net_list[n] == 'tailscale') {
+					if (n == 'tailscale') {
 						has_ts_net = true;
 						break;
 					}
@@ -321,29 +318,16 @@ methods.setup_firewall = {
 				changed_firewall = true;
 			}
 
-			// Exit node requires WAN <-> tailscale forwarding
-			let fwd_wan_to_ts = false;
+			// Exit node requires WAN <- tailscale forwarding
 			let fwd_ts_to_wan = false;
-
-			for (let sec_key in fw_all) {
-				let s = fw_all[sec_key];
-				if (s['.type'] == 'forwarding') {
-					if (s.src == 'wan' && s.dest == 'tailscale') fwd_wan_to_ts = true;
-					if (s.src == 'tailscale' && s.dest == 'wan') fwd_ts_to_wan = true;
-				}
-			}
+			uci.foreach('firewall', 'forwarding', function(s) {
+				if (s['src'] == 'tailscale' && s['dest'] == 'wan') fwd_ts_to_wan = true;
+			});
 
 			if (!fwd_ts_to_wan) {
 				let fid = uci.add('firewall', 'forwarding');
 				uci.set('firewall', fid, 'src', 'tailscale');
 				uci.set('firewall', fid, 'dest', 'wan');
-				changed_firewall = true;
-			}
-
-			if (!fwd_wan_to_ts) {
-				let fid = uci.add('firewall', 'forwarding');
-				uci.set('firewall', fid, 'src', 'wan');
-				uci.set('firewall', fid, 'dest', 'tailscale');
 				changed_firewall = true;
 			}
 


### PR DESCRIPTION
## Pull request details

### Descriptionadd
**switch DNSMode, default DISABLE
add fw now donot duplicate
fw remove WAN-> TAILSCALE FORWARD CHAIN**

I do not think switch DNSMode to Openwrt Forward is a great ideal, because many users who use headscale (I help others to test) may have customized other domain names instead of the default ts.net.

However, since some users requested this option, it was added anyway.

when OPENWRT FORWARD is set, the health monitoring show

> Tailscale Health Check: Linux DNS config not ideal. /etc/resolv.conf overwritten

Is a normal behavior, disabling this warning may be too complicated, and will hide the necessary error prompt in some cases.




### Screenshot or video of changes _(if applicable)_

<img width="1250" height="565" alt="Image" src="https://github.com/user-attachments/assets/59087968-6b0b-4c0c-9f47-85218b1748b4" />

<img width="1239" height="475" alt="Image" src="https://github.com/user-attachments/assets/471302de-d781-427b-a11a-f42d332b00da" />


---

## Tested on
Powered by [LuCI openwrt-24.10 branch (25.267.23331~f2e50e2)](https://github.com/openwrt/luci) / [ImmortalWrt 24.10.3 (r33451-5531f6bc76a3)](https://immortalwrt.org/)

Edge 148

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [x] _(Optional)_ Includes what Issue it closes https://github.com/openwrt/luci/issues/8641
