### PR TITLE
luci-mod-network: Add option to control auto-negotiation and phy speed and duplex

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js
@@ -140,6 +140,14 @@ function updatePlaceholders(opt, section_id) {
 	}
 }
 
+function formatLinkSpeed(link) {
+	let unit = ['Mbps', 'Gbps', 'Tbps', 'Pbps', 'Ebps', 'Zbps'];
+	let unit_index = 0;
+	while (link >= 1000 && unit_index < unit.length-1)
+		link /= 1000, unit_index++;
+	return '%f%s'.format(link, unit[unit_index]);
+}
+
 var cbiFlagTristate = form.ListValue.extend({
 	__init__(/* ... */) {
 		this.super('__init__', arguments);
@@ -428,7 +436,16 @@ return baseclass.extend({
 		return s.taboption(tabName, optionClass, optionName, optionTitle, optionDescription);
 	},
 
-	addDeviceOptions(s, dev, isNew, rtTables, hasPSE) {
+/**
+ *
+ * @param {any} s
+ * @param {any} dev
+ * @param {boolean} isNew
+ * @param {any} rtTables
+ * @param {boolean} hasPSE
+ * @param {{speed: number, duplex: "full"|"half", base: string}[]} phyLinkSpeeds
+ */
+	addDeviceOptions(s, dev, isNew, rtTables, hasPSE, phyLinkSpeeds) {
 		const parent_dev = dev ? dev.getParent() : null;
 		const devname = dev ? dev.getName() : null;
 		let o, ss;
@@ -806,7 +823,7 @@ return baseclass.extend({
 		o.description = _('Specify the number of peer notifications to be issued after a failover event.');
 		o.placeholder = '1';
 		o.datatype = 'range(0, 255)';
-		o.depends('type', 'bonding');		
+		o.depends('type', 'bonding');
 
 		o = this.replaceOption(s, 'devadvanced', form.ListValue, 'primary_reselect', _('Primary port reselection policy'));
 		o.default = '';
@@ -886,7 +903,7 @@ return baseclass.extend({
 			}
 		};
 		o.depends('type', 'bonding');
-		
+
 		o = this.replaceOption(s, 'devadvanced', form.Value, 'monitor_interval', _('Monitor Interval'));
 		o.description = _('Specifies the link monitoring frequency in milliseconds');
 		o.placeholder = '100';
@@ -1124,6 +1141,47 @@ return baseclass.extend({
 		o.rmempty = true;
 		o.datatype = 'macaddr';
 		o.depends('type', 'veth');
+
+		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'autoneg', _('Auto negotiation'),
+			_('Disable to manually control the duplex and link speed of the network device.'));
+		o.value('', _('automatic (enabled)'));
+		o.value('1', _('Enable'));
+		o.value('0', _('Disable'));
+		o.default = '';
+		o.rmempty = true;
+
+		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'duplex', _('Duplex'));
+		o.default = '';
+		o.rmempty = true;
+		o.depends('autoneg', '0');
+		o.value('', _('automatic'));
+		o.value('1', _('Full duplex'));
+		o.value('0', _('Half duplex'));
+
+		let devicePhySpeeds = phyLinkSpeeds
+			.reduce((a, b) => a.includes(b.speed) ? a : a.concat(b.speed), []);
+		o = this.replaceOption(s, 'devgeneral', form.Value, 'speed', _('Speed'),
+			_('Use a speed compatible with your device, forcing a higher speed will result in the system setting a lower value, but one that is compatible with the network interface'));
+		o.datatype = "string";
+		o.rmempty = true;
+		o.depends('autoneg', '0');
+		o.value('', _('automatic'));
+		for (let link of devicePhySpeeds)
+			o.value('%d'.format(link), formatLinkSpeed(link));
+
+		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'rxpause', _('Controls the receive (RX) flow control'));
+		o.rmempty = true;
+		o.default = '';
+		o.value('', _('Default'));
+		o.value('1', _('Enable'));
+		o.value('0', _('Disable'));
+
+		o = this.replaceOption(s, 'devgeneral', form.ListValue, 'txpause', _('Controls the transmission (TX) flow control'));
+		o.rmempty = true;
+		o.default = '';
+		o.value('', _('Default'));
+		o.value('1', _('Enable'));
+		o.value('0', _('Disable'));
 
 		o = this.replaceOption(s, 'devgeneral', form.Value, 'txqueuelen', _('TX queue length'));
 		o.placeholder = dev ? dev._devstate('qlen') : '';

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -19,6 +19,28 @@ const callNetworkDeviceStatus = rpc.declare({
 	expect: { '': {} }
 });
 
+const speedBaseParse = /^(\d+)base(\w+)-(H|F)$/;
+const phyLinkSpeeds = [
+	"10baseT-F", "10baseT-H",
+	"100baseT-F", "100baseT-H",
+	"1000baseT-F",
+	"2500baseT-F",
+	"5000baseT-F",
+	"10000baseT-F",
+	"14000baseT-F",
+	"20000baseT-F",
+	"25000baseT-F",
+	"40000baseT-F",
+	"50000baseT-F",
+	"56000baseT-F",
+	"80000baseT-F",
+	"100000baseT-F",
+	"200000baseT-F",
+	"400000baseT-F",
+	"800000baseT-F",
+	"1600000baseT-F"
+];
+
 var isReadonlyView = !L.hasViewPermission() || null;
 
 function count_changes(section_id) {
@@ -975,7 +997,7 @@ return view.extend({
 						return;
 					}
 
-					so = ss.taboption('ipv6-ra', form.Value, 'ra_pref64', _('NAT64 prefix'), _('Announce NAT64 prefix in <abbr title="Router Advertisement">RA</abbr> messages.') +  ' ' + 
+					so = ss.taboption('ipv6-ra', form.Value, 'ra_pref64', _('NAT64 prefix'), _('Announce NAT64 prefix in <abbr title="Router Advertisement">RA</abbr> messages.') +  ' ' +
 						_('See %s and %s.').format('<a href="%s" target="_blank">RFC6146</a>', '<a href="%s" target="_blank">RFC8781</a>').format('https://www.rfc-editor.org/rfc/rfc6146', 'https://www.rfc-editor.org/rfc/rfc8781'));
 					so.optional = true;
 					so.datatype = 'cidr6';
@@ -997,7 +1019,7 @@ return view.extend({
 					so.depends('ra', 'server');
 					so.depends({ ra: 'hybrid', master: '0' });
 
-					so = ss.taboption('ipv6-ra', form.Value, 'ra_reachabletime', _('<abbr title="Router Advertisement">RA</abbr> Reachability Timer'), 
+					so = ss.taboption('ipv6-ra', form.Value, 'ra_reachabletime', _('<abbr title="Router Advertisement">RA</abbr> Reachability Timer'),
 						_('Units: milliseconds. 0 means unspecified.') + ' ' +
 						_('Dictates how long a node assumes a neighbor is reachable after a reachability confirmation; published in <abbr title="Router Advertisement">RA</abbr> messages.'));
 					so.optional = true;
@@ -1006,7 +1028,7 @@ return view.extend({
 					so.depends('ra', 'server');
 					so.depends({ ra: 'hybrid', master: '0' });
 
-					so = ss.taboption('ipv6-ra', form.Value, 'ra_retranstime', _('<abbr title="Router Advertisement">RA</abbr> Retransmission Timer'), 
+					so = ss.taboption('ipv6-ra', form.Value, 'ra_retranstime', _('<abbr title="Router Advertisement">RA</abbr> Retransmission Timer'),
 						_('Units: milliseconds. 0 means unspecified.') + ' ' +
 						_('Controls retransmitted Neighbor Solicitation messages; published in <abbr title="Router Advertisement">RA</abbr> messages.'));
 					so.optional = true;
@@ -1587,15 +1609,43 @@ return view.extend({
 			const isNew = (uci.get('network', s.section, 'name') == null);
 			const dev = getDevice(s.section);
 			const devName = dev ? dev.getName() : null;
+			const parseLinks = (data) => data.reduce((a, b) => {
+				const data = speedBaseParse.exec(b);
+				if (data && data.length == 4) {
+					const [_, speed, base, duplex] = data;
+					const newSpeed = {
+						speed: Number(speed),
+						base: base.toUpperCase(),
+						duplex: duplex.toLowerCase() == "h" ? "half" : "full",
+					}
+					if (!a.some(previusSpeed => previusSpeed.speed == newSpeed.speed &&
+						previusSpeed.duplex == newSpeed.duplex &&
+						previusSpeed.base == newSpeed.base))
+						return a.concat(newSpeed)
+				}
+				return a;
+			}, []).sort(({ speed: p }, { speed: n }) => p > n ? 1 : -1);
 
 			/* Query PSE status from netifd to determine if device has PSE capability */
 			if (devName) {
-				return L.resolveDefault(callNetworkDeviceStatus(devName), {}).then((status) => {
-					const hasPSE = (status.pse != null);
-					nettools.addDeviceOptions(s, dev, isNew, rtTables, hasPSE);
+				return L.resolveDefault(callNetworkDeviceStatus(devName), {}).then(({
+					pse,
+					"link-advertising": linkAdvertising,
+					"link-partner-advertising": linkPartnerAdvertising,
+					"link-supported": linkSupported
+				}) => {
+					const hasPSE = (pse != null);
+					let phy_links = ([
+						...(linkAdvertising || []),
+						...(linkPartnerAdvertising || []),
+						...(linkSupported || [])
+					]);
+					if (!phy_links || phy_links.length === 0)
+						phy_links = phyLinkSpeeds;
+					nettools.addDeviceOptions(s, dev, isNew, rtTables, hasPSE, parseLinks(phy_links));
 				});
 			} else {
-				nettools.addDeviceOptions(s, dev, isNew, rtTables, false);
+				nettools.addDeviceOptions(s, dev, isNew, rtTables, false, parseLinks(phyLinkSpeeds));
 				return Promise.resolve();
 			}
 		};


### PR DESCRIPTION
## Pull request details

### Description
Add some settings that were missing from the device configuration have been added to control auto-negotiation, PHY speed, duplex, and rx/tx pause.

A binding has also been added to luci.c to retrieve the supported PHY speeds, if no value is returned, 10Mbps, 100Mbps, 1Gbps, 2.5Gbps, 5Gbps, 10Gbps, and 25Gbps are set as available values for use.

### Screenshot or video of changes

<img width="1359" height="619" alt="mikrotik lan_cgi-bin_luci_admin_network_network (1)" src="https://github.com/user-attachments/assets/cabd92b5-d8cc-4910-bfac-a7ad047fb0b2" />

[Gravação da tela 2026_05_26 14-47-40.webm](https://github.com/user-attachments/assets/e58aa58f-8227-46ba-92e7-0a359354277e)

---

## Tested on

**Device:** MikroTik RouterBOARD 760iGS (hEX S)
**OpenWrt version:** 25.12.4 (r32933-4ccb782af7)
**LuCI version:** Master (26.146.62900~8bc2621)
**Web browser(s):** Chrome 148.0.7778.178, Firefox 151.0.1

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
