### PR TITLE
luci-app-attendedsysupgrade: filemode should be octal

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -459,7 +459,7 @@ return view.extend({
 				let form_data = new FormData();
 				form_data.append('sessionid', rpc.getSessionID());
 				form_data.append('filename', '/tmp/firmware.bin');
-				form_data.append('filemode', 600);
+				form_data.append('filemode', 0o600);
 				form_data.append('filedata', response.blob());
 
 				ui.showModal(_('Uploading...'), [


### PR DESCRIPTION
Fix decimal "600" file mode that should have octal prefix.

Link: #8650

Tested on x86/64 main snapshot.