### PR TITLE
luci-base: fix path() backwards compatibility

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -2836,9 +2836,16 @@
 		 * Return the joined URL path.
 		 */
 		path(prefix = '', ...parts) {
+			/**
+			 * Backwards-compat: accept a single array argument,
+			 * pre-rest-params calling convention used by require()/compileClass
+			*/
+			if (parts.length === 1 && Array.isArray(parts[0]))
+				parts = parts[0];
+
 			const url = [ prefix ];
 
-			for (let i = 0; i < parts.length; i++){				
+			for (let i = 0; i < parts.length; i++){
 				const part = parts[i];
 				if (Array.isArray(part))
 					url.push(this.path('', part));


### PR DESCRIPTION

Commit a818ac8 changed LuCI.url.path() from accepting an array as second argument to using rest parameters. This silently broke all callers passing an array (notably require()/compileClass when loading class files from dot-separated names), which caused 404 errors during DOM setup and made LuCI unusable after login.

Restore backwards compatibility by detecting and unpacking a single array argument while keeping support for the new rest-parameter calling convention.

Closes: #8666

Signed-off-by: Dirk Brenken <dev@brenken.org>